### PR TITLE
Initial dotSettings file & annotations.

### DIFF
--- a/src/NetMQ.sln.DotSettings
+++ b/src/NetMQ.sln.DotSettings
@@ -1,0 +1,12 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAssignment/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCast/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantDefaultFieldInitializer/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantExplicitArrayCreation/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantIfElseBlock/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantThisQualifier/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEvident/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002ELocal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="m_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String>
+	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String></wpf:ResourceDictionary>

--- a/src/NetMQ/JetBrains.Annotations.cs
+++ b/src/NetMQ/JetBrains.Annotations.cs
@@ -1,0 +1,454 @@
+﻿/*
+ * Copyright 2007-2012 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+// ReSharper disable CheckNamespace
+namespace JetBrains.Annotations
+{
+    /// <summary>
+    /// Indicates that marked element should be localized or not.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)]
+    internal sealed class LocalizationRequiredAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalizationRequiredAttribute"/> class with
+        /// <see cref="Required"/> set to <see langword="true"/>.
+        /// </summary>
+        public LocalizationRequiredAttribute()
+            : this(true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalizationRequiredAttribute"/> class.
+        /// </summary>
+        /// <param name="required"><c>true</c> if a element should be localized; otherwise, <c>false</c>.</param>
+        public LocalizationRequiredAttribute(bool required)
+        {
+            Required = required;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether a element should be localized.
+        /// <value><c>true</c> if a element should be localized; otherwise, <c>false</c>.</value>
+        /// </summary>
+        [UsedImplicitly]
+        public bool Required { get; private set; }
+
+        /// <summary>
+        /// Returns whether the value of the given object is equal to the current <see cref="LocalizationRequiredAttribute"/>.
+        /// </summary>
+        /// <param name="obj">The object to test the value equality of. </param>
+        /// <returns>
+        /// <c>true</c> if the value of the given object is equal to that of the current; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            var attribute = obj as LocalizationRequiredAttribute;
+            return attribute != null && attribute.Required == Required;
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A hash code for the current <see cref="LocalizationRequiredAttribute"/>.</returns>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+
+    /// <summary>
+    /// Indicates that marked method builds string by format pattern and (optional) arguments. 
+    /// Parameter, which contains format string, should be given in constructor.
+    /// The format string should be in <see cref="string.Format(IFormatProvider,string,object[])"/> -like form
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    internal sealed class StringFormatMethodAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes new instance of StringFormatMethodAttribute
+        /// </summary>
+        /// <param name="formatParameterName">Specifies which parameter of an annotated method should be treated as format-string</param>
+        public StringFormatMethodAttribute(string formatParameterName)
+        {
+            FormatParameterName = formatParameterName;
+        }
+
+        /// <summary>
+        /// Gets format parameter name
+        /// </summary>
+        [UsedImplicitly]
+        public string FormatParameterName { get; private set; }
+    }
+
+    /// <summary>
+    /// Indicates that the function argument should be string literal and match one of the parameters of the caller function.
+    /// For example, <see cref="ArgumentNullException"/> has such parameter.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    internal sealed class InvokerParameterNameAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that the function is used to notify class type property value is changed.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    internal sealed class NotifyPropertyChangedInvocatorAttribute : Attribute
+    {
+        public NotifyPropertyChangedInvocatorAttribute() { }
+        public NotifyPropertyChangedInvocatorAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        [UsedImplicitly]
+        public string ParameterName { get; private set; }
+    }
+
+    /// <summary>
+    /// Indicates that the value of marked element could be <c>null</c> sometimes, so the check for <c>null</c> is necessary before its usage
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Delegate | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    internal sealed class CanBeNullAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that the value of marked element could never be <c>null</c>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Delegate | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    internal sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>
+    /// Describes dependency between method input and output
+    /// </summary>
+    /// <syntax>
+    /// <p>Function definition table syntax:</p>
+    /// <list>
+    /// <item>FDT      ::= FDTRow [;FDTRow]*</item>
+    /// <item>FDTRow   ::= Input =&gt; Output | Output &lt;= Input</item>
+    /// <item>Input    ::= ParameterName: Value [, Input]*</item>
+    /// <item>Output   ::= [ParameterName: Value]* {halt|stop|void|nothing|Value}</item>
+    /// <item>Value    ::= true | false | null | notnull | canbenull</item>
+    /// </list>
+    /// If method has single input parameter, it's name could be omitted. <br/>
+    /// Using "halt" (or "void"/"nothing", which is the same) for method output means that methos doesn't return normally. <br/>
+    /// "canbenull" annotation is only applicable for output parameters. <br/>
+    /// You can use multiple [ContractAnnotation] for each FDT row, or use single attribute with rows separated by semicolon. <br/>
+    /// </syntax>
+    /// <examples>
+    /// <list>
+    /// <item>[ContractAnnotation("=> halt")] public void TerminationMethod()</item>
+    /// <item>[ContractAnnotation("halt &lt;= condition: false")] public void Assert(bool condition, string text) // Regular Assertion method</item>
+    /// <item>[ContractAnnotation("s:null => true")] public bool IsNullOrEmpty(string s) // String.IsNullOrEmpty</item>
+    /// <item>[ContractAnnotation("null => null; notnull => notnull")] public object Transform(object data) // Method which returns null if parameter is null, and not null if parameter is not null</item>
+    /// <item>[ContractAnnotation("s:null=>false; =>true,result:notnull; =>false, result:null")] public bool TryParse(string s, out Person result)</item>
+    /// </list>
+    /// </examples>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    internal sealed class ContractAnnotationAttribute : Attribute
+    {
+        public ContractAnnotationAttribute([NotNull] string fdt)
+            : this(fdt, false)
+        {
+        }
+
+        public ContractAnnotationAttribute([NotNull] string fdt, bool forceFullStates)
+        {
+            FDT = fdt;
+            ForceFullStates = forceFullStates;
+        }
+
+        public string FDT { get; private set; }
+        public bool ForceFullStates { get; private set; }
+    }
+
+    /// <summary>
+    /// Indicates that the value of marked type (or its derivatives) cannot be compared using '==' or '!=' operators.
+    /// There is only exception to compare with <c>null</c>, it is permitted
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = true)]
+    internal sealed class CannotApplyEqualityOperatorAttribute : Attribute { }
+
+    /// <summary>
+    /// When applied to target attribute, specifies a requirement for any type which is marked with 
+    /// target attribute to implement or inherit specific type or types
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// [BaseTypeRequired(typeof(IComponent)] // Specify requirement
+    /// public class ComponentAttribute : Attribute 
+    /// {}
+    /// 
+    /// [Component] // ComponentAttribute requires implementing IComponent interface
+    /// public class MyComponent : IComponent
+    /// {}
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    [BaseTypeRequired(typeof(Attribute))]
+    internal sealed class BaseTypeRequiredAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes new instance of BaseTypeRequiredAttribute
+        /// </summary>
+        /// <param name="baseType">Specifies which types are required</param>
+        public BaseTypeRequiredAttribute(Type baseType)
+        {
+            BaseTypes = new[] { baseType };
+        }
+
+        /// <summary>
+        /// Gets enumerations of specified base types
+        /// </summary>
+        public Type[] BaseTypes { get; private set; }
+    }
+
+    /// <summary>
+    /// Indicates that the marked symbol is used implicitly (e.g. via reflection, in external library),
+    /// so this symbol will not be marked as unused (as well as by other usage inspections)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)]
+    internal sealed class UsedImplicitlyAttribute : Attribute
+    {
+        [UsedImplicitly]
+        public UsedImplicitlyAttribute()
+            : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default) { }
+
+        [UsedImplicitly]
+        public UsedImplicitlyAttribute(ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+        {
+            UseKindFlags = useKindFlags;
+            TargetFlags = targetFlags;
+        }
+
+        [UsedImplicitly]
+        public UsedImplicitlyAttribute(ImplicitUseKindFlags useKindFlags)
+            : this(useKindFlags, ImplicitUseTargetFlags.Default) { }
+
+        [UsedImplicitly]
+        public UsedImplicitlyAttribute(ImplicitUseTargetFlags targetFlags)
+            : this(ImplicitUseKindFlags.Default, targetFlags) { }
+
+        [UsedImplicitly]
+        public ImplicitUseKindFlags UseKindFlags { get; private set; }
+
+        /// <summary>
+        /// Gets value indicating what is meant to be used
+        /// </summary>
+        [UsedImplicitly]
+        public ImplicitUseTargetFlags TargetFlags { get; private set; }
+    }
+
+    /// <summary>
+    /// Should be used on attributes and causes ReSharper to not mark symbols marked with such attributes as unused (as well as by other usage inspections)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    internal sealed class MeansImplicitUseAttribute : Attribute
+    {
+        [UsedImplicitly]
+        public MeansImplicitUseAttribute()
+            : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default) { }
+
+        [UsedImplicitly]
+        public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+        {
+            UseKindFlags = useKindFlags;
+            TargetFlags = targetFlags;
+        }
+
+        [UsedImplicitly]
+        public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags)
+            : this(useKindFlags, ImplicitUseTargetFlags.Default)
+        {
+        }
+
+        [UsedImplicitly]
+        public MeansImplicitUseAttribute(ImplicitUseTargetFlags targetFlags)
+            : this(ImplicitUseKindFlags.Default, targetFlags) { }
+
+        [UsedImplicitly]
+        public ImplicitUseKindFlags UseKindFlags { get; private set; }
+
+        /// <summary>
+        /// Gets value indicating what is meant to be used
+        /// </summary>
+        [UsedImplicitly]
+        public ImplicitUseTargetFlags TargetFlags { get; private set; }
+    }
+
+    [Flags]
+    internal enum ImplicitUseKindFlags
+    {
+        Default = Access | Assign | InstantiatedWithFixedConstructorSignature,
+
+        /// <summary>
+        /// Only entity marked with attribute considered used
+        /// </summary>
+        Access = 1,
+
+        /// <summary>
+        /// Indicates implicit assignment to a member
+        /// </summary>
+        Assign = 2,
+
+        /// <summary>
+        /// Indicates implicit instantiation of a type with fixed constructor signature.
+        /// That means any unused constructor parameters won't be reported as such.
+        /// </summary>
+        InstantiatedWithFixedConstructorSignature = 4,
+
+        /// <summary>
+        /// Indicates implicit instantiation of a type
+        /// </summary>
+        InstantiatedNoFixedConstructorSignature = 8,
+    }
+
+    /// <summary>
+    /// Specify what is considered used implicitly when marked with <see cref="MeansImplicitUseAttribute"/> or <see cref="UsedImplicitlyAttribute"/>
+    /// </summary>
+    [Flags]
+    internal enum ImplicitUseTargetFlags
+    {
+        Default = Itself,
+
+        Itself = 1,
+
+        /// <summary>
+        /// Members of entity marked with attribute are considered used
+        /// </summary>
+        Members = 2,
+
+        /// <summary>
+        /// Entity marked with attribute and all its members considered used
+        /// </summary>
+        WithMembers = Itself | Members
+    }
+
+    /// <summary>
+    /// This attribute is intended to mark publicly available API which should not be removed and so is treated as used.
+    /// </summary>
+    [MeansImplicitUse]
+    internal sealed class PublicAPIAttribute : Attribute
+    {
+        public PublicAPIAttribute() { }
+        public PublicAPIAttribute(string comment) { }
+    }
+
+    /// <summary>
+    /// Tells code analysis engine if the parameter is completely handled when the invoked method is on stack. 
+    /// If the parameter is delegate, indicates that delegate is executed while the method is executed.
+    /// If the parameter is enumerable, indicates that it is enumerated while the method is executed.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = true)]
+    internal sealed class InstantHandleAttribute : Attribute { }
+
+    /// <summary>
+    /// Indicates that method doesn't contain observable side effects.
+    /// The same as <see cref="System.Diagnostics.Contracts.PureAttribute"/>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+    internal sealed class PureAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal class PathReferenceAttribute : Attribute
+    {
+        public PathReferenceAttribute() { }
+
+        [UsedImplicitly]
+        public PathReferenceAttribute([PathReference] string basePath)
+        {
+            BasePath = basePath;
+        }
+
+        [UsedImplicitly]
+        public string BasePath { get; private set; }
+    }
+
+    // ASP.NET MVC attributes
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+    internal sealed class AspMvcActionAttribute : Attribute
+    {
+        [UsedImplicitly]
+        public string AnonymousProperty { get; private set; }
+
+        public AspMvcActionAttribute() { }
+
+        public AspMvcActionAttribute(string anonymousProperty)
+        {
+            AnonymousProperty = anonymousProperty;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class AspMvcAreaAttribute : PathReferenceAttribute
+    {
+        [UsedImplicitly]
+        public string AnonymousProperty { get; private set; }
+
+        [UsedImplicitly]
+        public AspMvcAreaAttribute() { }
+
+        public AspMvcAreaAttribute(string anonymousProperty)
+        {
+            AnonymousProperty = anonymousProperty;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+    internal sealed class AspMvcControllerAttribute : Attribute
+    {
+        [UsedImplicitly]
+        public string AnonymousProperty { get; private set; }
+
+        public AspMvcControllerAttribute() { }
+
+        public AspMvcControllerAttribute(string anonymousProperty)
+        {
+            AnonymousProperty = anonymousProperty;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class AspMvcMasterAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class AspMvcModelTypeAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+    internal sealed class AspMvcPartialViewAttribute : PathReferenceAttribute { }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    internal sealed class AspMvcSupressViewErrorAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class AspMvcDisplayTemplateAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class AspMvcEditorTemplateAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+    internal sealed class AspMvcViewAttribute : PathReferenceAttribute { }
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+    internal sealed class AspMvcActionSelectorAttribute : Attribute { }
+
+    // Razor attributes
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method, Inherited = true)]
+    internal sealed class RazorSectionAttribute : Attribute { }
+}

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -97,6 +97,7 @@
     <Compile Include="zmq\Poller.cs" />
     <Compile Include="zmq\PollerBase.cs" />
     <Compile Include="zmq\PollItem.cs" />
+    <Compile Include="JetBrains.Annotations.cs" />
     <None Include="zmq\Proxy.cs" />
     <Compile Include="zmq\Pub.cs" />
     <Compile Include="zmq\Pull.cs" />

--- a/src/NetMQ/zmq/Address.cs
+++ b/src/NetMQ/zmq/Address.cs
@@ -28,7 +28,6 @@ namespace NetMQ.zmq
 
 		public interface IZAddress
 		{
-			//String ToString();
 			void Resolve(String name, bool ip4Only);
 			IPEndPoint Address{get;}        
 		};
@@ -48,12 +47,12 @@ namespace NetMQ.zmq
 			if (endpoint is DnsEndPoint)
 			{
 				DnsEndPoint dnsEndpoint = endpoint as DnsEndPoint;
-				AddressString = dnsEndpoint.Host + ":" + dnsEndpoint.Port.ToString();
+				AddressString = dnsEndpoint.Host + ":" + dnsEndpoint.Port;
 			}
 			else if (endpoint is IPEndPoint)
 			{
 				IPEndPoint ipEndpoint = endpoint as IPEndPoint;
-				AddressString = ipEndpoint.Address.ToString() + ":" + ipEndpoint.Port.ToString();
+				AddressString = ipEndpoint.Address + ":" + ipEndpoint.Port;
 			}
 			else
 			{
@@ -84,7 +83,7 @@ namespace NetMQ.zmq
 				return Protocol + "://" + AddressString;
 			}
 
-			return null;
+			return null; //TODO: REVIEW - Although not explicitly prohibited, returning null from ToString seems sketchy; return string.Empty? 
 		}
 
 		public String Protocol

--- a/src/NetMQ/zmq/Dist.cs
+++ b/src/NetMQ/zmq/Dist.cs
@@ -166,8 +166,6 @@ namespace NetMQ.zmq
 			for (int i = 0; i < m_matching; ++i)
 				if(!Write (m_pipes[i], msg))
 					--i; //  Retry last write because index will have been swapped
-			return;
-        
 		}
     
 		public bool HasOut ()


### PR DESCRIPTION
Adds initial team-shared `.DotSettings` file and `JetBrans.Annotations` (internalized).

Configured to allow `m_` prefix for private instance members and I opted to turn most of the `redundant` warnings to only be hints to reduce noise... specifically...
- Redundant Assignment
- Redundant Cast
- Redundant Default Field Initializer
- Redundant Explicit Array Creation
- Redundant If Else Block
- Redundant This Qualifier
- Suggest Use Var Keyword
- Unused Parameter

Can evolve over time.

I might also suggest reviewing the implementation of `ToString` in `Address`; returning `null` is definitely unexpected, although not explicitly prohibited. 
