### PR TITLE
remove pinvoke, fix issue #34

### DIFF
--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="PubSubTests.cs" />
     <Compile Include="PushPullTests.cs" />
     <Compile Include="ReqRepTests.cs" />
+    <Compile Include="SocketTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NetMQ\NetMQ.csproj">

--- a/src/NetMQ.Tests/SocketTests.cs
+++ b/src/NetMQ.Tests/SocketTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace NetMQ.Tests
+{
+	[TestFixture]
+	public class SocketTests
+	{
+		[Test]
+		public void TestKeepAlive()
+		{
+			// there is no way to test tcp keep alive without disconnect the cable, we just testing that is not crashing the system
+			using (Context context = Context.Create())
+			{
+				using (ResponseSocket responseSocket = context.CreateResponseSocket())
+				{
+					responseSocket.Options.TcpKeepalive = true;
+					responseSocket.Options.TcpKeepaliveIdle = TimeSpan.FromSeconds(5);
+					responseSocket.Options.TcpKeepaliveInterval = TimeSpan.FromSeconds(1);
+
+					responseSocket.Bind("tcp://127.0.0.1:5555");
+					
+					using (RequestSocket requestSocket = context.CreateRequestSocket())
+					{
+						requestSocket.Options.TcpKeepalive = true;
+						requestSocket.Options.TcpKeepaliveIdle = TimeSpan.FromSeconds(5);
+						requestSocket.Options.TcpKeepaliveInterval = TimeSpan.FromSeconds(1);
+
+						requestSocket.Connect("tcp://127.0.0.1:5555");
+
+						requestSocket.Send("1");
+
+						bool more;
+						string m = responseSocket.ReceiveString(out more);
+
+						Assert.IsFalse(more);
+						Assert.AreEqual("1", m);
+
+						responseSocket.Send("2");
+
+						string m2 = requestSocket.ReceiveString(out more);
+
+						Assert.IsFalse(more);
+						Assert.AreEqual("2", m2);
+
+						Assert.IsTrue(requestSocket.Options.TcpKeepalive);
+						Assert.AreEqual(TimeSpan.FromSeconds(5), requestSocket.Options.TcpKeepaliveIdle);
+						Assert.AreEqual(TimeSpan.FromSeconds(1), requestSocket.Options.TcpKeepaliveInterval);
+
+						Assert.IsTrue(responseSocket.Options.TcpKeepalive);
+						Assert.AreEqual(TimeSpan.FromSeconds(5), responseSocket.Options.TcpKeepaliveIdle);
+						Assert.AreEqual(TimeSpan.FromSeconds(1), responseSocket.Options.TcpKeepaliveInterval);
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -137,20 +137,20 @@ namespace NetMQ
 
         public bool TcpKeepalive
         {
-            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.TcpKeepalive); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.TcpKeepalive, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOptions.TcpKeepalive) == 1; }
+            set { m_socket.SetSocketOption(ZmqSocketOptions.TcpKeepalive, value ? 1: 0); }
         }
 
         public int TcpKeepaliveCnt
         {
             get { return m_socket.GetSocketOption(ZmqSocketOptions.TcpKeepaliveCnt); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.Rate, value); }
+					set { m_socket.SetSocketOption(ZmqSocketOptions.TcpKeepaliveCnt, value); }
         }
 
         public TimeSpan TcpKeepaliveIdle
         {
             get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOptions.TcpKeepaliveIdle); }
-            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.Rate, value); }
+            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.TcpKeepaliveIdle, value); }
         }
 
         public TimeSpan TcpKeepaliveInterval

--- a/src/NetMQ/zmq/Options.cs
+++ b/src/NetMQ/zmq/Options.cs
@@ -277,9 +277,13 @@ namespace NetMQ.zmq
 					return true;
 
 				case ZmqSocketOptions.TcpKeepaliveCnt:
-				case ZmqSocketOptions.TcpKeepaliveIdle:
-				case ZmqSocketOptions.TcpKeepaliveIntvl:
 					// not supported
+					return true;
+				case ZmqSocketOptions.TcpKeepaliveIdle:
+					TcpKeepaliveIdle = (int) optval;
+					return true;
+				case ZmqSocketOptions.TcpKeepaliveIntvl:
+					TcpKeepaliveIntvl = (int) optval;
 					return true;
 
 				case ZmqSocketOptions.TcpAcceptFilter:
@@ -373,10 +377,12 @@ namespace NetMQ.zmq
 					return DelayAttachOnConnect;
 
 				case ZmqSocketOptions.TcpKeepaliveCnt:
-				case ZmqSocketOptions.TcpKeepaliveIdle:
-				case ZmqSocketOptions.TcpKeepaliveIntvl:
 					// not supported
 					return 0;
+				case ZmqSocketOptions.TcpKeepaliveIdle:
+					return TcpKeepaliveIdle;
+				case ZmqSocketOptions.TcpKeepaliveIntvl:
+					return TcpKeepaliveIntvl;
 
 				case ZmqSocketOptions.LastEndpoint:
 					return LastEndpoint;

--- a/src/NetMQ/zmq/SocketBase.cs
+++ b/src/NetMQ/zmq/SocketBase.cs
@@ -235,8 +235,7 @@ namespace NetMQ.zmq
         }
 
         public bool SetSocketOption(ZmqSocketOptions option, Object optval)
-        {
-
+        {					
             if (m_ctxTerminated)
             {
                 ZError.ErrorNumber = ErrorNumber.ETERM;


### PR DESCRIPTION
one new class added called OpCode to provide the RDTSC CPU instructions which give the timestamp of the CPU, this is very important for ZEROMQ performance.
the OpCode use native methods of windows and Mono.Posix on unix and linux platforms, on other platform this feature is not supported but the library should compile and work.
