### PR TITLE
Can't connect sockets when the endpoint address is not an IP Address

### DIFF
--- a/src/NetMQ.Tests/ReqRepTests.cs
+++ b/src/NetMQ.Tests/ReqRepTests.cs
@@ -14,6 +14,7 @@ namespace NetMQ.Tests
 		[Test]
 		[TestCase("tcp://localhost:5001")]
 		[TestCase("tcp://127.0.0.1:5001")]
+		[TestCase("tcp://unknownhostname:5001", ExpectedException = typeof(System.Net.Sockets.SocketException))]
 		public void SimpleReqRep(string address)
 		{
 			using (NetMQContext ctx = NetMQContext.Create())

--- a/src/NetMQ/zmq/TcpAddress.cs
+++ b/src/NetMQ/zmq/TcpAddress.cs
@@ -92,7 +92,17 @@ namespace NetMQ.zmq
 				addrStr = "0.0.0.0";
 			}
 
-			IPAddress ipAddress = Dns.GetHostEntry(addrStr).AddressList.First();
+			IPAddress ipAddress;
+ 
+			if (!IPAddress.TryParse(addrStr, out ipAddress))
+			{
+				ipAddress = Dns.GetHostEntry(addrStr).AddressList.FirstOrDefault();
+
+				if (ipAddress == null)
+				{
+					throw InvalidException.Create(string.Format("Unable to find an IP address for {0}", name));
+				}
+			}
 
 			addrNet  = new IPEndPoint(ipAddress, port);
         


### PR DESCRIPTION
Connecting or binding to "tcp://127.0.0.1:5001" works, but "tcp://localhost:5001" fails.
