### PR TITLE
Fix typo in enum NetMQ.zmq.SendReceiveOptions

### DIFF
--- a/src/NetMQ/IOutgoingSocket.cs
+++ b/src/NetMQ/IOutgoingSocket.cs
@@ -8,7 +8,7 @@ namespace NetMQ
 {
 	public interface IOutgoingSocket
 	{
-		void Send(byte[] data, int length, SendRecieveOptions options);
+		void Send(byte[] data, int length, SendReceiveOptions options);
 		void Send(byte[] data);
 
 		void Send(byte[] data, int length);

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -219,7 +219,7 @@ namespace NetMQ
 			}
 		}
 
-		protected internal virtual Msg ReceiveInternal(SendRecieveOptions options, out bool hasMore)
+		protected internal virtual Msg ReceiveInternal(SendReceiveOptions options, out bool hasMore)
 		{
 			var msg = ZMQ.Recv(m_socketHandle, options);
 
@@ -228,7 +228,7 @@ namespace NetMQ
 			return msg;
 		}
 
-		public byte[] Receive(SendRecieveOptions options, out bool hasMore)
+		public byte[] Receive(SendReceiveOptions options, out bool hasMore)
 		{
 			var msg = ReceiveInternal(options, out hasMore);
 
@@ -237,12 +237,12 @@ namespace NetMQ
 
 		public byte[] Receive(out bool hasMore)
 		{
-			var msg = ReceiveInternal(SendRecieveOptions.None, out hasMore);
+			var msg = ReceiveInternal(SendReceiveOptions.None, out hasMore);
 
 			return msg.Data;
 		}
 
-		public byte[] Receive(SendRecieveOptions options)
+		public byte[] Receive(SendReceiveOptions options)
 		{
 			bool hasMore;
 
@@ -255,24 +255,24 @@ namespace NetMQ
 		{
 			bool hasMore;
 
-			var msg = ReceiveInternal(SendRecieveOptions.None, out hasMore);
+			var msg = ReceiveInternal(SendReceiveOptions.None, out hasMore);
 
 			return msg.Data;
 		}
 
 		public byte[] Receive(bool dontWait, out bool hasMore)
 		{
-			return Receive(dontWait ? SendRecieveOptions.DontWait : SendRecieveOptions.None, out hasMore);
+			return Receive(dontWait ? SendReceiveOptions.DontWait : SendReceiveOptions.None, out hasMore);
 		}
 
-		public string ReceiveString(SendRecieveOptions options, out bool hasMore)
+		public string ReceiveString(SendReceiveOptions options, out bool hasMore)
 		{
 			var msg = ReceiveInternal(options, out hasMore);
 
 			return Encoding.ASCII.GetString(msg.Data);
 		}
 
-		public string ReceiveString(SendRecieveOptions options)
+		public string ReceiveString(SendReceiveOptions options)
 		{
 			bool more;
 
@@ -281,17 +281,17 @@ namespace NetMQ
 
 		public string ReceiveString(out bool more)
 		{
-			return ReceiveString(SendRecieveOptions.None, out more);
+			return ReceiveString(SendReceiveOptions.None, out more);
 		}
 
 		public string ReceiveString()
 		{
-			return ReceiveString(SendRecieveOptions.None);
+			return ReceiveString(SendReceiveOptions.None);
 		}
 
 		public string ReceiveString(bool dontWait, out bool hasMore)
 		{
-			return ReceiveString(dontWait ? SendRecieveOptions.DontWait : SendRecieveOptions.None, out hasMore);
+			return ReceiveString(dontWait ? SendReceiveOptions.DontWait : SendReceiveOptions.None, out hasMore);
 		}
 
 		public IList<byte[]> ReceiveAll()
@@ -300,12 +300,12 @@ namespace NetMQ
 
 			IList<byte[]> messages = new List<byte[]>();
 
-			Msg msg = ReceiveInternal(SendRecieveOptions.None, out hasMore);
+			Msg msg = ReceiveInternal(SendReceiveOptions.None, out hasMore);
 			messages.Add(msg.Data);
 
 			while (hasMore)
 			{
-				msg = ReceiveInternal(SendRecieveOptions.None, out hasMore);
+				msg = ReceiveInternal(SendReceiveOptions.None, out hasMore);
 				messages.Add(msg.Data);
 			}
 
@@ -318,12 +318,12 @@ namespace NetMQ
 
 			IList<string> messages = new List<string>();
 
-			var msg = ReceiveString(SendRecieveOptions.None, out hasMore);
+			var msg = ReceiveString(SendReceiveOptions.None, out hasMore);
 			messages.Add(msg);
 
 			while (hasMore)
 			{
-				msg = ReceiveString(SendRecieveOptions.None, out hasMore);
+				msg = ReceiveString(SendReceiveOptions.None, out hasMore);
 				messages.Add(msg);
 			}
 
@@ -378,7 +378,7 @@ namespace NetMQ
 			Send(message.Last.Buffer, message.Last.MessageSize);
 		}
 
-		public virtual void Send(byte[] data, int length, SendRecieveOptions options)
+		public virtual void Send(byte[] data, int length, SendReceiveOptions options)
 		{
 			Msg msg = new Msg(data, length, Options.CopyMessages);
 
@@ -397,19 +397,19 @@ namespace NetMQ
 
 		public void Send(byte[] data, int length, bool dontWait, bool sendMore)
 		{
-			SendRecieveOptions sendRecieveOptions = SendRecieveOptions.None;
+			SendReceiveOptions sendReceiveOptions = SendReceiveOptions.None;
 
 			if (dontWait)
 			{
-				sendRecieveOptions |= SendRecieveOptions.DontWait;
+				sendReceiveOptions |= SendReceiveOptions.DontWait;
 			}
 
 			if (sendMore)
 			{
-				sendRecieveOptions |= SendRecieveOptions.SendMore;
+				sendReceiveOptions |= SendReceiveOptions.SendMore;
 			}
 
-			Send(data, length, sendRecieveOptions);
+			Send(data, length, sendReceiveOptions);
 		}
 
 		public void Send(string message, bool dontWait, bool sendMore)

--- a/src/NetMQ/Sockets/PublisherSocket.cs
+++ b/src/NetMQ/Sockets/PublisherSocket.cs
@@ -13,7 +13,7 @@ namespace NetMQ.Sockets
 		{
 		}
 
-		protected internal override Msg ReceiveInternal(SendRecieveOptions options, out bool hasMore)
+		protected internal override Msg ReceiveInternal(SendReceiveOptions options, out bool hasMore)
 		{
 			throw new NotSupportedException("Publisher doesn't support receiving");
 		}

--- a/src/NetMQ/Sockets/PullSocket.cs
+++ b/src/NetMQ/Sockets/PullSocket.cs
@@ -13,7 +13,7 @@ namespace NetMQ.Sockets
 		{
 		}
 
-		public override void Send(byte[] data, int length, SendRecieveOptions options)
+		public override void Send(byte[] data, int length, SendReceiveOptions options)
 		{
 			throw  new NotSupportedException("Pull socket doesn't support sending");
 		}

--- a/src/NetMQ/Sockets/PushSocket.cs
+++ b/src/NetMQ/Sockets/PushSocket.cs
@@ -13,7 +13,7 @@ namespace NetMQ.Sockets
 		{
 		}
 
-		protected internal override Msg ReceiveInternal(SendRecieveOptions options, out bool hasMore)
+		protected internal override Msg ReceiveInternal(SendReceiveOptions options, out bool hasMore)
 		{
 			throw new NotSupportedException("Push socket doesn't support receiving");
 		}

--- a/src/NetMQ/Sockets/SubscriberSocket.cs
+++ b/src/NetMQ/Sockets/SubscriberSocket.cs
@@ -14,7 +14,7 @@ namespace NetMQ.Sockets
 		{
 		}
 
-		public override void Send(byte[] data, int length, SendRecieveOptions options)
+		public override void Send(byte[] data, int length, SendReceiveOptions options)
 		{
 			throw new NotSupportedException("Subscriber socket doesn't support sending");
 		}	

--- a/src/NetMQ/zmq/Dealer.cs
+++ b/src/NetMQ/zmq/Dealer.cs
@@ -75,18 +75,18 @@ namespace NetMQ.zmq
 			m_lb.Attach(pipe);
 		}
 
-		protected override void XSend(Msg msg, SendRecieveOptions flags)
+		protected override void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			m_lb.Send(msg, flags);
 		}
 
 
-		protected override Msg XRecv(SendRecieveOptions flags)
+		protected override Msg XRecv(SendReceiveOptions flags)
 		{
 			return xxrecv(flags);
 		}
 
-		private Msg xxrecv(SendRecieveOptions flags_)
+		private Msg xxrecv(SendReceiveOptions flags_)
 		{
 			Msg msg_ = null;
 			//  If there is a prefetched message, return it.
@@ -119,7 +119,7 @@ namespace NetMQ.zmq
 			//  Try to read the next message to the pre-fetch buffer.
 			try
 			{
-				m_prefetchedMsg = xxrecv(SendRecieveOptions.DontWait);
+				m_prefetchedMsg = xxrecv(SendReceiveOptions.DontWait);
 			}
 			catch (AgainException ex)
 			{

--- a/src/NetMQ/zmq/Dist.cs
+++ b/src/NetMQ/zmq/Dist.cs
@@ -130,14 +130,14 @@ namespace NetMQ.zmq
 		}
 
 		//  Send the message to all the outbound pipes.
-		public void SendToAll(Msg msg, SendRecieveOptions flags)
+		public void SendToAll(Msg msg, SendReceiveOptions flags)
 		{
 			m_matching = m_active;
 			SendToMatching (msg, flags);
 		}
 
 		//  Send the message to the matching outbound pipes.
-		public void SendToMatching(Msg msg, SendRecieveOptions flags)
+		public void SendToMatching(Msg msg, SendReceiveOptions flags)
 		{
 			//  Is this end of a multipart message?
 			bool msg_more = msg.HasMore;
@@ -153,7 +153,7 @@ namespace NetMQ.zmq
 		}
 
 		//  Put the message to all active pipes.
-		private void Distribute(Msg msg, SendRecieveOptions flags)
+		private void Distribute(Msg msg, SendReceiveOptions flags)
 		{
 			//  If there are no matching pipes available, simply drop the message.
 			if (m_matching == 0) {

--- a/src/NetMQ/zmq/Enums.cs
+++ b/src/NetMQ/zmq/Enums.cs
@@ -68,7 +68,7 @@ namespace NetMQ.zmq
 }
 
 	[Flags]
-	public enum SendRecieveOptions
+	public enum SendReceiveOptions
 	{
 		None = 0,
 		DontWait = 1,

--- a/src/NetMQ/zmq/LB.cs
+++ b/src/NetMQ/zmq/LB.cs
@@ -89,7 +89,7 @@ namespace NetMQ.zmq
 			m_active++;
 		}
 
-		public void Send(Msg msg, SendRecieveOptions flags)
+		public void Send(Msg msg, SendReceiveOptions flags)
 		{
 			//  Drop the message if required. If we are at the end of the message
 			//  switch back to non-dropping mode.

--- a/src/NetMQ/zmq/Pair.cs
+++ b/src/NetMQ/zmq/Pair.cs
@@ -77,13 +77,13 @@ namespace NetMQ.zmq
 		}
     
 		override
-			protected void XSend(Msg msg, SendRecieveOptions flags)
+			protected void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			if (m_pipe == null || !m_pipe.Write (msg)) {
 				throw AgainException.Create();
 			}
 
-			if ((flags & SendRecieveOptions.SendMore) == 0)
+			if ((flags & SendReceiveOptions.SendMore) == 0)
 				m_pipe.Flush ();
 
 			//  Detach the original message from the data buffer.
@@ -91,7 +91,7 @@ namespace NetMQ.zmq
 		}
 
 		override
-			protected Msg XRecv(SendRecieveOptions flags)
+			protected Msg XRecv(SendReceiveOptions flags)
 		{
 			//  Deallocate old content of the message.
 

--- a/src/NetMQ/zmq/Proxy.cs
+++ b/src/NetMQ/zmq/Proxy.cs
@@ -68,10 +68,10 @@ namespace NetMQ.zmq
 						if (capture != null)
 						{
 							Msg ctrl = new Msg(msg);
-							capture.Send(ctrl, more > 0 ? SendRecieveOptions.SendMore : 0);							
+							capture.Send(ctrl, more > 0 ? SendReceiveOptions.SendMore : 0);							
 						}
 
-						backend.Send(msg, more > 0 ? SendRecieveOptions.SendMore : 0);
+						backend.Send(msg, more > 0 ? SendReceiveOptions.SendMore : 0);
 						if (more == 0)
 							break;
 					}
@@ -96,11 +96,11 @@ namespace NetMQ.zmq
 						if (capture != null)
 						{
 							Msg ctrl = new Msg(msg);
-							capture.Send(ctrl, more > 0 ? SendRecieveOptions.SendMore : 0);
+							capture.Send(ctrl, more > 0 ? SendReceiveOptions.SendMore : 0);
 							
 						}
 
-						frontend.Send(msg, more > 0 ? SendRecieveOptions.SendMore : 0);
+						frontend.Send(msg, more > 0 ? SendReceiveOptions.SendMore : 0);
 						if (more == 0)
 							break;
 					}

--- a/src/NetMQ/zmq/Pub.cs
+++ b/src/NetMQ/zmq/Pub.cs
@@ -37,7 +37,7 @@ namespace NetMQ.zmq
 			m_options.SocketType = ZmqSocketType.Pub;
 		}
 
-		protected override Msg XRecv(SendRecieveOptions flags)
+		protected override Msg XRecv(SendReceiveOptions flags)
 		{
 			//  Messages cannot be received from PUB socket.
 			throw NetMQException.Create("Messages cannot be received from PUB socket", ErrorCode.ENOTSUP);

--- a/src/NetMQ/zmq/Pull.cs
+++ b/src/NetMQ/zmq/Pull.cs
@@ -64,7 +64,7 @@ namespace NetMQ.zmq
 			}
 
 		override
-			protected Msg XRecv(SendRecieveOptions flags)
+			protected Msg XRecv(SendReceiveOptions flags)
 		{
 			return m_fq.Recv ();
 		}

--- a/src/NetMQ/zmq/Push.cs
+++ b/src/NetMQ/zmq/Push.cs
@@ -61,7 +61,7 @@ namespace NetMQ.zmq
 			}
 
 		override
-			protected void XSend(Msg msg, SendRecieveOptions flags)
+			protected void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			lb.Send (msg, flags);
 		}

--- a/src/NetMQ/zmq/Rep.cs
+++ b/src/NetMQ/zmq/Rep.cs
@@ -52,7 +52,7 @@ namespace NetMQ.zmq
 		}
     
 		override
-			protected void XSend(Msg msg, SendRecieveOptions flags)
+			protected void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			//  If we are in the middle of receiving a request, we cannot send reply.
 			if (!m_sendingReply) {
@@ -70,7 +70,7 @@ namespace NetMQ.zmq
 		}
     
 		override
-			protected Msg XRecv(SendRecieveOptions flags)
+			protected Msg XRecv(SendReceiveOptions flags)
 		{
 			Msg msg;
 

--- a/src/NetMQ/zmq/Req.cs
+++ b/src/NetMQ/zmq/Req.cs
@@ -49,7 +49,7 @@ namespace NetMQ.zmq
 		}
 
 
-		protected override void XSend(Msg msg, SendRecieveOptions flags)
+		protected override void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			//  If we've sent a request and we still haven't got the reply,
 			//  we can't send another request.
@@ -81,7 +81,7 @@ namespace NetMQ.zmq
 		}
 
 		override
-			protected Msg XRecv(SendRecieveOptions flags)
+			protected Msg XRecv(SendReceiveOptions flags)
 		{
 			Msg msg = null;
 			//  If request wasn't send, we can't wait for reply.

--- a/src/NetMQ/zmq/Router.cs
+++ b/src/NetMQ/zmq/Router.cs
@@ -186,7 +186,7 @@ namespace NetMQ.zmq
 		}
 
 
-		protected override void XSend(Msg msg, SendRecieveOptions flags)
+		protected override void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			//  If this is the first part of the message it's the ID of the
 			//  peer to send the message to.
@@ -247,7 +247,7 @@ namespace NetMQ.zmq
 
 
 
-		protected override Msg XRecv(SendRecieveOptions flags)
+		protected override Msg XRecv(SendReceiveOptions flags)
 		{
 			Msg msg = null;
 			if (m_prefetched) {

--- a/src/NetMQ/zmq/SocketBase.cs
+++ b/src/NetMQ/zmq/SocketBase.cs
@@ -675,7 +675,7 @@ namespace NetMQ.zmq
 
 		}
 
-		public void Send(Msg msg, SendRecieveOptions flags)
+		public void Send(Msg msg, SendReceiveOptions flags)
 		{
 			if (m_ctxTerminated)
 			{
@@ -695,7 +695,7 @@ namespace NetMQ.zmq
 			msg.ResetFlags(MsgFlags.More);
 
 			//  At this point we impose the flags on the message.
-			if ((flags & SendRecieveOptions.SendMore) > 0)
+			if ((flags & SendReceiveOptions.SendMore) > 0)
 				msg.SetFlags(MsgFlags.More);
 
 			//  Try to send the message.
@@ -710,7 +710,7 @@ namespace NetMQ.zmq
 
 			//  In case of non-blocking send we'll simply propagate
 			//  the error - including EAGAIN - up the stack.
-			if ((flags & SendRecieveOptions.DontWait) > 0 || m_options.SendTimeout == 0)
+			if ((flags & SendReceiveOptions.DontWait) > 0 || m_options.SendTimeout == 0)
 				throw AgainException.Create();
 
 			//  Compute the time when the timeout should occur.
@@ -745,7 +745,7 @@ namespace NetMQ.zmq
 			}
 		}
 
-		public Msg Recv(SendRecieveOptions flags)
+		public Msg Recv(SendReceiveOptions flags)
 		{
 			if (m_ctxTerminated)
 			{
@@ -788,7 +788,7 @@ namespace NetMQ.zmq
 			//  For non-blocking recv, commands are processed in case there's an
 			//  activate_reader command already waiting int a command pipe.
 			//  If it's not, return EAGAIN.
-			if ((flags & SendRecieveOptions.DontWait) > 0 || m_options.ReceiveTimeout == 0)
+			if ((flags & SendReceiveOptions.DontWait) > 0 || m_options.ReceiveTimeout == 0)
 			{
 				ProcessCommands(0, false);
 				m_ticks = 0;
@@ -994,7 +994,7 @@ namespace NetMQ.zmq
 			return false;
 		}
 
-		protected virtual void XSend(Msg msg, SendRecieveOptions flags)
+		protected virtual void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			throw new NotSupportedException("Must Override");
 		}
@@ -1005,7 +1005,7 @@ namespace NetMQ.zmq
 		}
 
 
-		protected virtual Msg XRecv(SendRecieveOptions flags)
+		protected virtual Msg XRecv(SendReceiveOptions flags)
 		{
 			throw new NotSupportedException("Must Override");
 		}

--- a/src/NetMQ/zmq/Sub.cs
+++ b/src/NetMQ/zmq/Sub.cs
@@ -71,7 +71,7 @@ namespace NetMQ.zmq
 			base.XSend (msg, 0);
 		}
 
-		protected override void XSend(Msg msg, SendRecieveOptions flags)
+		protected override void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			//  Overload the XSUB's send.
 			throw NetMQException.Create("Send not supported on sub socket", ErrorCode.ENOTSUP);

--- a/src/NetMQ/zmq/XPub.cs
+++ b/src/NetMQ/zmq/XPub.cs
@@ -167,7 +167,7 @@ namespace NetMQ.zmq
 			m_dist.Terminated(pipe);
 		}
 
-		protected override void XSend(Msg msg, SendRecieveOptions flags)
+		protected override void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			bool msgMore = msg.HasMore;
 
@@ -194,7 +194,7 @@ namespace NetMQ.zmq
 			return m_dist.HasOut();
 		}
 
-		protected override Msg XRecv(SendRecieveOptions flags)
+		protected override Msg XRecv(SendReceiveOptions flags)
 		{
 			//  If there is at least one 
 			if (m_pending.Count == 0)

--- a/src/NetMQ/zmq/XSub.cs
+++ b/src/NetMQ/zmq/XSub.cs
@@ -128,7 +128,7 @@ namespace NetMQ.zmq
 			pipe.Flush ();
 		}
 
-		protected override void XSend(Msg msg, SendRecieveOptions flags)
+		protected override void XSend(Msg msg, SendReceiveOptions flags)
 		{
 			byte[] data = msg.Data; 
 			// Malformed subscriptions.
@@ -156,7 +156,7 @@ namespace NetMQ.zmq
 			return true;
 		}
 
-		protected override Msg XRecv(SendRecieveOptions flags)
+		protected override Msg XRecv(SendReceiveOptions flags)
 		{
 			//  If there's already a message prepared by a previous call to zmq_poll,
 			//  return it straight ahead.

--- a/src/NetMQ/zmq/ZMQ.cs
+++ b/src/NetMQ/zmq/ZMQ.cs
@@ -210,18 +210,18 @@ namespace NetMQ.zmq
 		}
 
 		// Sending functions.
-		public static void Send(SocketBase s, String str, SendRecieveOptions flags)
+		public static void Send(SocketBase s, String str, SendReceiveOptions flags)
 		{
 			byte[] data = Encoding.ASCII.GetBytes(str);
 			Send(s, data, data.Length, flags);
 		}
 
-		public static void Send(SocketBase s, Msg msg, SendRecieveOptions flags)
+		public static void Send(SocketBase s, Msg msg, SendReceiveOptions flags)
 		{
 			SendMsg(s, msg, flags);
 		}
 
-		public static void Send(SocketBase s, byte[] buf, int len, SendRecieveOptions flags)
+		public static void Send(SocketBase s, byte[] buf, int len, SendReceiveOptions flags)
 		{
 			if (s == null || !s.CheckTag())
 			{
@@ -240,7 +240,7 @@ namespace NetMQ.zmq
 		// a single multi-part message, i.e. the last message has
 		// ZMQ_SNDMORE bit switched off.
 		//
-		public void SendIOv(SocketBase s, byte[][] a, int count, SendRecieveOptions flags)
+		public void SendIOv(SocketBase s, byte[][] a, int count, SendReceiveOptions flags)
 		{
 			if (s == null || !s.CheckTag())
 			{
@@ -252,13 +252,13 @@ namespace NetMQ.zmq
 			{
 				msg = new Msg(a[i]);
 				if (i == count - 1)
-					flags = flags & ~SendRecieveOptions.SendMore;
+					flags = flags & ~SendReceiveOptions.SendMore;
 				SendMsg(s, msg, flags);
 				
 			}			
 		}
 
-		private static void SendMsg(SocketBase s, Msg msg, SendRecieveOptions flags)
+		private static void SendMsg(SocketBase s, Msg msg, SendReceiveOptions flags)
 		{			
 			s.Send(msg, flags);
 		}
@@ -266,7 +266,7 @@ namespace NetMQ.zmq
 
 		// Receiving functions.
 
-		public static Msg Recv(SocketBase s, SendRecieveOptions flags)
+		public static Msg Recv(SocketBase s, SendReceiveOptions flags)
 		{
 			if (s == null || !s.CheckTag())
 			{
@@ -305,7 +305,7 @@ namespace NetMQ.zmq
 		// We assume it is safe to steal these buffers by simply
 		// not closing the zmq::msg_t.
 		//
-		public int RecvIOv(SocketBase s, byte[][] a, int count, SendRecieveOptions flags)
+		public int RecvIOv(SocketBase s, byte[][] a, int count, SendReceiveOptions flags)
 		{
 			if (s == null || !s.CheckTag())
 			{
@@ -336,7 +336,7 @@ namespace NetMQ.zmq
 		}
 
 
-		public static Msg RecvMsg(SocketBase s, SendRecieveOptions flags)
+		public static Msg RecvMsg(SocketBase s, SendReceiveOptions flags)
 		{
 			return s.Recv(flags);
 		}

--- a/src/Performance/local_lat/Program.cs
+++ b/src/Performance/local_lat/Program.cs
@@ -23,14 +23,14 @@ namespace local_lat
             
             for (int i = 0; i != roundtripCount; i++)
             {
-                Msg message = repSocket.Recv(SendRecieveOptions.None);
+                Msg message = repSocket.Recv(SendReceiveOptions.None);
                 if (ZMQ.MsgSize(message) != messageSize)
                 {
                     Console.WriteLine("message of incorrect size received. Received: " + message.Size + " Expected: " + messageSize);
                     return -1;
                 }
 
-                repSocket.Send(message, SendRecieveOptions.None);                
+                repSocket.Send(message, SendReceiveOptions.None);                
             }
 
             repSocket.Close();

--- a/src/Performance/local_thr/Program.cs
+++ b/src/Performance/local_thr/Program.cs
@@ -22,12 +22,12 @@ namespace local_thr
             var pullSocket = ZMQ.Socket(context, ZmqSocketType.Pull);
             pullSocket.Bind(bindTo);
 
-            var message = pullSocket.Recv(SendRecieveOptions.None);
+            var message = pullSocket.Recv(SendReceiveOptions.None);
 
             var stopWatch = Stopwatch.StartNew();
             for (int i = 0; i != messageCount - 1; i++)
             {
-                message = pullSocket.Recv(SendRecieveOptions.None);
+                message = pullSocket.Recv(SendReceiveOptions.None);
                 if (message.Size != messageSize)
                 {
                     Console.WriteLine("message of incorrect size received. Received: " + message.Size + " Expected: " + messageSize);

--- a/src/Performance/remote_lat/Program.cs
+++ b/src/Performance/remote_lat/Program.cs
@@ -29,9 +29,9 @@ namespace remote_lat
 
 			for (int i = 0; i != roundtripCount; i++)
 			{
-				reqSocket.Send(message, SendRecieveOptions.None);				
+				reqSocket.Send(message, SendReceiveOptions.None);				
 
-				message = reqSocket.Recv(SendRecieveOptions.None);
+				message = reqSocket.Recv(SendReceiveOptions.None);
 				if (message.Size != messageSize)
 				{
 					Console.WriteLine("message of incorrect size received. Received: " + message.Size + " Expected: " + messageSize);

--- a/src/Performance/remote_thr/Program.cs
+++ b/src/Performance/remote_thr/Program.cs
@@ -24,7 +24,7 @@ namespace remote_thr
             for (int i = 0; i != messageCount; i++)
             {
                 var message = new Msg(messageSize);
-                pushSocket.Send(message, SendRecieveOptions.None);
+                pushSocket.Send(message, SendReceiveOptions.None);
             }
 
             pushSocket.Close();


### PR DESCRIPTION
Unfortunately, a lot of files are impacted by this typo.
