### PR TITLE
Fix ZMQ.Poll for NetMQ.Proxy

### DIFF
--- a/src/NetMQ.Tests/ProxyTests.cs
+++ b/src/NetMQ.Tests/ProxyTests.cs
@@ -1,11 +1,71 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using NetMQ.zmq;
+using NUnit.Framework;
 
 namespace NetMQ.Tests
 {
-	class ProxyTests
-	{
-	}
+    [TestFixture]
+    public class ProxyTests
+    {
+        [Test]
+        public void TestInfinitePolling()
+        {
+            using (var context = NetMQContext.Create())
+            {
+                using (var socket = context.CreateDealerSocket())
+                {
+                    socket.Bind("inproc://test");
+                    var items = new PollItem[1];
+                    items[0] = new PollItem(socket.SocketHandle, PollEvents.PollIn);
+
+                    Task.Factory.StartNew(() =>
+                    {
+                        Thread.Sleep(500);
+                        using (var monitor = context.CreateDealerSocket())
+                        {
+                            monitor.Connect("inproc://test");
+                            monitor.Send("ping");
+                        }
+                    });
+
+                    Assert.DoesNotThrow(() => ZMQ.Poll(items, -1));
+                    Assert.AreEqual(socket.ReceiveString(SendReceiveOptions.DontWait), "ping");
+                }
+            }
+        }
+
+        [Test]
+        public void TestProxySendAndReceive()
+        {
+            using (var ctx = NetMQContext.Create())
+            {
+                using (var front = ctx.CreateRouterSocket())
+                {
+                    front.Bind("inproc://frontend");
+
+                    using (var back = ctx.CreateDealerSocket())
+                    {
+                        back.Bind("inproc://backend");
+
+                        var proxy = new Proxy(front, back, null);
+                        Task.Factory.StartNew(proxy.Start);
+
+                        using (var client = ctx.CreateRequestSocket())
+                        {
+                            client.Connect("inproc://frontend");
+
+                            using (var server = ctx.CreateResponseSocket())
+                            {
+                                server.Connect("inproc://backend");
+
+                                client.Send("hello");
+                                Assert.AreEqual("hello", server.ReceiveString());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/NetMQ/Properties/AssemblyInfo.cs
+++ b/src/NetMQ/Properties/AssemblyInfo.cs
@@ -36,3 +36,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("3.3.0.5")]
 [assembly: AssemblyFileVersion("3.3.0.5")]
+[assembly: InternalsVisibleTo("NetMQ.Tests")]

--- a/src/NetMQ/zmq/ZMQ.cs
+++ b/src/NetMQ/zmq/ZMQ.cs
@@ -410,7 +410,7 @@ namespace NetMQ.zmq
 			}
 			if (itemsCount == 0)
 			{
-				if (timeout == 0)
+				if (timeout <= 0)
 					return 0;
 				Thread.Sleep(timeout);
 				return 0;
@@ -466,6 +466,10 @@ namespace NetMQ.zmq
 				if (firstPass)
 				{
 					currentTimeoutMicroSeconds = 0;
+				}
+				else if (timeout == -1)
+				{
+					currentTimeoutMicroSeconds = -1;
 				}
 				else
 				{


### PR DESCRIPTION
NetMQ.Proxy can't be started at all because ZMQ.Poll throws a null ref when called with an infinite timeout.
The null ref is on the stopwatch which is used to compute the current timeout but it was never instanciated in this case.
Moreover, the value returned is 0 when the timeout is negative so there is no way to have an actual infinite timeout on Select().
I also added a unit test on ZMQ.Poll(-1) and another one on a simple use case of NetMQ.Proxy.
