### PR TITLE
NetMQ Serialization feature

### DIFF
--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -74,6 +74,8 @@
     <Compile Include="PushPullTests.cs" />
     <Compile Include="ReqRepTests.cs" />
     <Compile Include="Security\SecureChannelTests.cs" />
+    <Compile Include="Serialization\SerializerBuilderTests.cs" />
+    <Compile Include="Serialization\ProtocolTests.cs" />
     <Compile Include="SocketTests.cs" />
     <Compile Include="zmq\YQueueTests.cs" />
     <Compile Include="zmq\ZMQPollTests.cs" />

--- a/src/NetMQ.Tests/Serialization/ProtocolTests.cs
+++ b/src/NetMQ.Tests/Serialization/ProtocolTests.cs
@@ -1,0 +1,235 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using NetMQ.Serialization;
+
+namespace NetMQ.Tests.Serialization
+{    
+  [TestFixture]
+  public class ProtocolTests
+  {
+    public class RequestMessage
+    {
+      [NetMQMember(0)]
+      public string Text { get; set; }      
+    }
+
+    public class ResponseMessage
+    {
+      [NetMQMember(0)]
+      public string Text { get; set; }
+    }
+
+    [Test]
+    public void IntegerBaseProtocol()
+    {
+      using (NetMQContext context = NetMQContext.Create())
+      {
+        using (NetMQSocket responseSocket = context.CreateResponseSocket())
+        {
+          responseSocket.Bind("tcp://127.0.0.1:5556");
+
+          using (NetMQSocket requestSocket = context.CreateRequestSocket())
+          {
+            requestSocket.Connect("tcp://127.0.0.1:5556");
+
+            IntegerBasedProtocol protocol = new IntegerBasedProtocol();
+            protocol.RegisterMessage<RequestMessage>(0);
+            protocol.RegisterMessage<ResponseMessage>(1);
+
+            requestSocket.SendProtocolMessage(protocol, new RequestMessage { Text = "request" });
+
+            var requestMessage = responseSocket.ReceiveProtocolMessage(protocol) as RequestMessage;
+
+            Assert.IsNotNull(requestMessage);
+            Assert.AreEqual(requestMessage.Text, "request");
+
+            responseSocket.SendProtocolMessage(protocol, new ResponseMessage { Text = "response"});
+
+            var responseMessage = requestSocket.ReceiveProtocolMessage(protocol) as ResponseMessage;
+            Assert.IsNotNull(responseMessage);
+            Assert.AreEqual(responseMessage.Text, "response");
+          }
+        }
+      }      
+    }
+
+    [Test]
+    public void ByteBasedProtocol()
+    {
+      using (NetMQContext context = NetMQContext.Create())
+      {
+        using (NetMQSocket responseSocket = context.CreateResponseSocket())
+        {
+          responseSocket.Bind("tcp://127.0.0.1:5556");
+
+          using (NetMQSocket requestSocket = context.CreateRequestSocket())
+          {
+            requestSocket.Connect("tcp://127.0.0.1:5556");
+
+            ByteBasedProtocol protocol = new ByteBasedProtocol();
+            protocol.RegisterMessage<RequestMessage>(0);
+            protocol.RegisterMessage<ResponseMessage>(1);
+
+            requestSocket.SendProtocolMessage(protocol, new RequestMessage { Text = "request" });
+
+            var requestMessage = responseSocket.ReceiveProtocolMessage(protocol) as RequestMessage;
+
+            Assert.IsNotNull(requestMessage);
+            Assert.AreEqual(requestMessage.Text, "request");
+
+            responseSocket.SendProtocolMessage(protocol, new ResponseMessage { Text = "response" });
+
+            var responseMessage = requestSocket.ReceiveProtocolMessage(protocol) as ResponseMessage;
+            Assert.IsNotNull(responseMessage);
+            Assert.AreEqual(responseMessage.Text, "response");
+          }
+        }
+      }
+    }
+
+    [Test]
+    public void ShortBasedProtocol()
+    {
+      using (NetMQContext context = NetMQContext.Create())
+      {
+        using (NetMQSocket responseSocket = context.CreateResponseSocket())
+        {
+          responseSocket.Bind("tcp://127.0.0.1:5556");
+
+          using (NetMQSocket requestSocket = context.CreateRequestSocket())
+          {
+            requestSocket.Connect("tcp://127.0.0.1:5556");
+
+            ShortBasedProtocol protocol = new ShortBasedProtocol();
+            protocol.RegisterMessage<RequestMessage>(0);
+            protocol.RegisterMessage<ResponseMessage>(1);
+
+            requestSocket.SendProtocolMessage(protocol, new RequestMessage { Text = "request" });
+
+            var requestMessage = responseSocket.ReceiveProtocolMessage(protocol) as RequestMessage;
+
+            Assert.IsNotNull(requestMessage);
+            Assert.AreEqual(requestMessage.Text, "request");
+
+            responseSocket.SendProtocolMessage(protocol, new ResponseMessage { Text = "response" });
+
+            var responseMessage = requestSocket.ReceiveProtocolMessage(protocol) as ResponseMessage;
+            Assert.IsNotNull(responseMessage);
+            Assert.AreEqual(responseMessage.Text, "response");
+          }
+        }
+      }
+    }
+
+    [Test]
+    public void StringBasedProtocol()
+    {
+      using (NetMQContext context = NetMQContext.Create())
+      {
+        using (NetMQSocket responseSocket = context.CreateResponseSocket())
+        {
+          responseSocket.Bind("tcp://127.0.0.1:5556");
+
+          using (NetMQSocket requestSocket = context.CreateRequestSocket())
+          {
+            requestSocket.Connect("tcp://127.0.0.1:5556");
+
+            StringBasedProtocol protocol = new StringBasedProtocol();
+            protocol.RegisterMessage<RequestMessage>("0");
+            protocol.RegisterMessage<ResponseMessage>("1");
+
+            requestSocket.SendProtocolMessage(protocol, new RequestMessage { Text = "request" });
+
+            var requestMessage = responseSocket.ReceiveProtocolMessage(protocol) as RequestMessage;
+
+            Assert.IsNotNull(requestMessage);
+            Assert.AreEqual(requestMessage.Text, "request");
+
+            responseSocket.SendProtocolMessage(protocol, new ResponseMessage { Text = "response" });
+
+            var responseMessage = requestSocket.ReceiveProtocolMessage(protocol) as ResponseMessage;
+            Assert.IsNotNull(responseMessage);
+            Assert.AreEqual(responseMessage.Text, "response");
+          }
+        }
+      }
+    }
+
+    public enum MessageType
+    {
+      Request =0, Reply = 1
+    }
+
+    [Test]
+    public void EnumInt32BasedProtocol()
+    {
+      using (NetMQContext context = NetMQContext.Create())
+      {
+        using (NetMQSocket responseSocket = context.CreateResponseSocket())
+        {
+          responseSocket.Bind("tcp://127.0.0.1:5556");
+
+          using (NetMQSocket requestSocket = context.CreateRequestSocket())
+          {
+            requestSocket.Connect("tcp://127.0.0.1:5556");
+
+            EnumBasedProtocol<MessageType> protocol = new EnumBasedProtocol<MessageType>(EnumSerializationType.Int32);
+            protocol.RegisterMessage<RequestMessage>(MessageType.Request);
+            protocol.RegisterMessage<ResponseMessage>(MessageType.Reply);
+
+            requestSocket.SendProtocolMessage(protocol, new RequestMessage { Text = "request" });
+
+            var requestMessage = responseSocket.ReceiveProtocolMessage(protocol) as RequestMessage;
+
+            Assert.IsNotNull(requestMessage);
+            Assert.AreEqual(requestMessage.Text, "request");
+
+            responseSocket.SendProtocolMessage(protocol, new ResponseMessage { Text = "response" });
+
+            var responseMessage = requestSocket.ReceiveProtocolMessage(protocol) as ResponseMessage;
+            Assert.IsNotNull(responseMessage);
+            Assert.AreEqual(responseMessage.Text, "response");
+          }
+        }
+      }
+    }
+
+    [Test]
+    public void EnumStringBasedProtocol()
+    {
+      using (NetMQContext context = NetMQContext.Create())
+      {
+        using (NetMQSocket responseSocket = context.CreateResponseSocket())
+        {
+          responseSocket.Bind("tcp://127.0.0.1:5556");
+
+          using (NetMQSocket requestSocket = context.CreateRequestSocket())
+          {
+            requestSocket.Connect("tcp://127.0.0.1:5556");
+
+            EnumBasedProtocol<MessageType> protocol = new EnumBasedProtocol<MessageType>(EnumSerializationType.MemberName);
+            protocol.RegisterMessage<RequestMessage>(MessageType.Request);
+            protocol.RegisterMessage<ResponseMessage>(MessageType.Reply);
+
+            requestSocket.SendProtocolMessage(protocol, new RequestMessage { Text = "request" });
+
+            var requestMessage = responseSocket.ReceiveProtocolMessage(protocol) as RequestMessage;
+
+            Assert.IsNotNull(requestMessage);
+            Assert.AreEqual(requestMessage.Text, "request");
+
+            responseSocket.SendProtocolMessage(protocol, new ResponseMessage { Text = "response" });
+
+            var responseMessage = requestSocket.ReceiveProtocolMessage(protocol) as ResponseMessage;
+            Assert.IsNotNull(responseMessage);
+            Assert.AreEqual(responseMessage.Text, "response");
+          }
+        }
+      }
+    }
+
+  }
+}

--- a/src/NetMQ.Tests/Serialization/SerializerBuilderTests.cs
+++ b/src/NetMQ.Tests/Serialization/SerializerBuilderTests.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using NetMQ.Serialization;
+using NetMQ.zmq;
+
+namespace NetMQ.Tests.Serialization
+{
+  [TestFixture]
+  class SerializerBuilderTests
+  {
+    class TestMessage
+    {
+      public TestMessage()
+      {
+        
+      }      
+
+      [NetMQMember(0, Endianness = Endianness.Little)]
+      public int Number32 { get; set; }
+
+      [NetMQMember(1, Endianness = Endianness.Little)]
+      public short Number16 { get; set; }
+
+      [NetMQMember(2, Endianness = Endianness.Little)]
+      public long Number64 { get; set; }
+
+      [NetMQMember(3, Endianness = Endianness.Little)]
+      public uint NumberU32 { get; set; }
+
+      [NetMQMember(4, Endianness = Endianness.Little)]
+      public ulong NumberU64 { get; set; }
+
+      [NetMQMember(5, Endianness = Endianness.Little)]
+      public ushort NumberU16 { get; set; }
+
+      [NetMQMember(6, Endianness = Endianness.Little)]
+      public double Double { get; set; }
+
+      [NetMQMember(7, Endianness = Endianness.Little)]
+      public float Float { get; set; }
+
+      [NetMQMember(8)]
+      public string Str { get; set; }
+
+      [NetMQMember(9)]
+      public DateTime DateTime { get; set; }
+
+      [NetMQMember(10, EnumSerializationType = EnumSerializationType.MemberName)]
+      public ZmqSocketType SocketType { get; set; }
+
+      [NetMQMember(11, EnumSerializationType = EnumSerializationType.Int32)]
+      public ZmqSocketType SocketType2 { get; set; }
+
+      [NetMQMember(12)]
+      public byte Byte { get; set; }
+
+      [NetMQMember(13)]
+      public char Char { get; set; }
+
+      [NetMQMember(14)]
+      public bool Boolean { get; set; }
+    }
+
+    [Test]
+    public void SerializeMessage()
+    {      
+      SerializerBuilder serializerBuilder = new SerializerBuilder(typeof(TestMessage));
+
+      var serializer = serializerBuilder.CreateSerializer();
+
+      TestMessage message = new TestMessage();
+      message.DateTime = new DateTime(2015, 7,15);
+      message.Double = 23.00005;
+      message.Float = 0.1f;
+      message.Number16 = 5;
+      message.Number32 = 10000000;
+      message.Number64 = int.MaxValue + 100000L;
+      message.NumberU16 = short.MaxValue + 1;
+      message.NumberU32 = ((uint)int.MaxValue) + 10;
+      message.NumberU64 = ((ulong)long.MaxValue) + 10;
+      message.SocketType = ZmqSocketType.Dealer;
+      message.SocketType2 = ZmqSocketType.Pub;
+      message.Str = "Hello world";
+      message.Byte = 1;
+      message.Char = 'a';
+      message.Boolean = true;
+
+      var array = serializer(message);
+
+      Assert.AreEqual(array.Length, 15);
+
+      var deserializer = serializerBuilder.CreateDeserializer();
+
+      var deserializedMessage = (TestMessage)deserializer(array);
+
+      Assert.AreEqual(deserializedMessage.DateTime, message.DateTime);
+      Assert.AreEqual(deserializedMessage.Double, message.Double);
+      Assert.AreEqual(deserializedMessage.Float, message.Float);
+      Assert.AreEqual(deserializedMessage.Number16, message.Number16);
+      Assert.AreEqual(deserializedMessage.Number32, message.Number32);
+      Assert.AreEqual(deserializedMessage.Number64, message.Number64);
+      Assert.AreEqual(deserializedMessage.NumberU16, message.NumberU16);
+      Assert.AreEqual(deserializedMessage.NumberU32, message.NumberU32);
+      Assert.AreEqual(deserializedMessage.NumberU64, message.NumberU64);
+      Assert.AreEqual(deserializedMessage.SocketType, message.SocketType);
+      Assert.AreEqual(deserializedMessage.SocketType2, message.SocketType2);
+      Assert.AreEqual(deserializedMessage.Str, message.Str);
+      Assert.AreEqual(deserializedMessage.Boolean, message.Boolean);
+      Assert.AreEqual(deserializedMessage.Char, message.Char);
+      Assert.AreEqual(deserializedMessage.Byte, message.Byte);      
+    }
+         
+    class TestMessage2
+    {
+      [NetMQMember(0)]
+      public string Text { get; set; }  
+    }
+
+    [Test]
+    public void NullString()
+    {
+      SerializerBuilder serializerBuilder = new SerializerBuilder(typeof(TestMessage2));
+
+      var serializer = serializerBuilder.CreateSerializer();
+
+      var byteArries = serializer(new TestMessage2
+        {
+          Text = null
+        });
+
+      var deserializer = serializerBuilder.CreateDeserializer();
+
+      var message = (TestMessage2)deserializer(byteArries);
+
+      Assert.AreEqual("", message.Text);
+    }
+
+    public class TestMessage3
+    {
+      [NetMQMember(1)]
+      public string Text { get; set; }
+    }
+
+    [Test, ExpectedException(typeof(ArgumentException))]
+    public void MissingFrame()
+    {
+      SerializerBuilder serializerBuilder = new SerializerBuilder(typeof(TestMessage3));      
+    }
+
+    public class TestMessage4
+    {
+      [NetMQMember(0)]
+      public string Text { get; set; }
+
+      [NetMQMember(0)]
+      public string Text2 { get; set; }
+
+      [NetMQMember(2)]
+      public string Text3 { get; set; }
+    }
+
+    [Test, ExpectedException(typeof(ArgumentException))]    
+    public void RepeatedFrame()
+    {
+      SerializerBuilder serializerBuilder = new SerializerBuilder(typeof(TestMessage4));        
+    }
+
+    public class TestMessage5
+    {
+      [NetMQMember(0)]
+      public NetMQMessage Text { get; set; }      
+    }
+
+    [Test, ExpectedException(typeof(ArgumentException))]
+    public void NotPrimitiveType()
+    {
+      SerializerBuilder serializerBuilder = new SerializerBuilder(typeof(TestMessage5));
+    }
+  }
+}

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -35,6 +35,10 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IReceivingSocket.cs" />
@@ -69,6 +73,18 @@
     <Compile Include="Security\V0_1\SecureChannel.cs" />
     <Compile Include="Security\V0_1\SecurityParameters.cs" />
     <Compile Include="Security\V0_1\SHA256PRF.cs" />
+    <Compile Include="Serialization\BaseProtocol.cs" />
+    <Compile Include="Serialization\ByteBasedProtocol.cs" />
+    <Compile Include="Serialization\Convertions.cs" />
+    <Compile Include="Serialization\EnumBasedProtocol.cs" />
+    <Compile Include="Serialization\IntegerBasedProtocol.cs" />
+    <Compile Include="Serialization\MemberTypeEnum.cs" />
+    <Compile Include="Serialization\NetMQMember.cs" />
+    <Compile Include="Serialization\NetMQProtocolException.cs" />
+    <Compile Include="Serialization\SerializerBuilder.cs" />
+    <Compile Include="Serialization\ShortBasedProtocol.cs" />
+    <Compile Include="Serialization\SocketExtensions.cs" />
+    <Compile Include="Serialization\StringBasedProtocol.cs" />
     <Compile Include="Sockets\DealerSocket.cs" />
     <Compile Include="Devices\DeviceBase.cs" />
     <Compile Include="Devices\DeviceMode.cs" />

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -245,6 +245,18 @@ namespace NetMQ
 			Send(message.Last.Buffer, message.Last.MessageSize, dontWait);
 		}
 
+    public void SendMultiple(byte[][] frames, bool dontWait = false)
+    {
+      for (int i = 0; i < frames.Length - 1; i++)
+      {
+        Send(frames[i], frames.Length, dontWait, true);
+      }
+
+      var lastFrame = frames[frames.Length - 1];
+
+      Send(lastFrame, lastFrame.Length, dontWait);
+    }
+
 		public virtual void Send(byte[] data, int length, SendReceiveOptions options)
 		{
 			Msg msg = new Msg(data, length, Options.CopyMessages);

--- a/src/NetMQ/Serialization/BaseProtocol.cs
+++ b/src/NetMQ/Serialization/BaseProtocol.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NetMQ.Serialization
+{
+  public abstract class BaseProtocol<TMessageType>
+  {
+    private Dictionary<TMessageType, Func<object, byte[][]>> m_serializers= new Dictionary<TMessageType, Func<object, byte[][]>>();
+ 
+    private Dictionary<TMessageType, Func<byte[][], object>> m_deserializers = new Dictionary<TMessageType, Func<byte[][], object>>(); 
+
+    private Dictionary<Type, TMessageType> m_typeToMessageType = new Dictionary<Type, TMessageType>();
+
+    public void RegisterMessage(TMessageType messageType, Type type)
+    {
+      if (m_typeToMessageType.ContainsKey(type))
+      {
+        throw new ArgumentException("type already registered");
+      }
+
+      if (m_serializers.ContainsKey(messageType))
+      {
+        throw new ArgumentException("message type already registered");
+      }
+
+      SerializerBuilder serializerBuilder = new SerializerBuilder(type);
+
+      var serializer = serializerBuilder.CreateSerializer();
+
+      var deserializer = serializerBuilder.CreateDeserializer();
+
+      m_serializers.Add(messageType, serializer);
+      m_deserializers.Add(messageType, deserializer);
+      m_typeToMessageType.Add(type, messageType);
+    }
+
+    public void RegisterMessage<TMessage>(TMessageType messageType)
+    {
+      RegisterMessage(messageType, typeof(TMessage));
+    }
+
+    internal Func<object, byte[][]> GetSerializer(TMessageType messageType)
+    {
+      Func<object, byte[][]> serializer;
+
+      if (m_serializers.TryGetValue(messageType, out serializer))
+      {
+        return serializer;
+      }
+      else
+      {
+        throw new NetMQProtocolException(string.Format("Message type {0} doesn't exist", messageType));
+      }
+    }
+
+    internal Func<byte[][], object> GetDeserializer(TMessageType messageType)
+    {      
+      Func<byte[][], object> deserializer;
+
+      if (m_deserializers.TryGetValue(messageType, out deserializer))
+      {
+        return deserializer;
+      }
+      else
+      {
+        throw new NetMQProtocolException(string.Format("Message type {0} doesn't exist", messageType));
+      }
+    }
+
+    public TMessageType GetMessageType(object message)
+    {
+      Type type = message.GetType();
+
+      TMessageType messageType;
+
+      if (m_typeToMessageType.TryGetValue(type, out messageType))
+      {
+        return messageType;
+      }
+      else
+      {
+        throw new NetMQProtocolException(string.Format("Type {0} is not registered", type.FullName));
+      }
+    }
+
+    protected internal abstract TMessageType ConvertBytesToMessageType(byte[] bytes);
+
+    protected internal abstract byte[] ConvertMessageTypeToBytes(TMessageType messageType);
+  }
+}

--- a/src/NetMQ/Serialization/ByteBasedProtocol.cs
+++ b/src/NetMQ/Serialization/ByteBasedProtocol.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NetMQ.Serialization
+{
+  public class ByteBasedProtocol : BaseProtocol<byte>
+  {   
+    protected internal override byte ConvertBytesToMessageType(byte[] bytes)
+    {
+      if (bytes.Length != 1)
+      {
+        throw new NetMQProtocolException("Wrong message type size");
+      }
+
+      return bytes[0];
+    }
+
+    protected internal override byte[] ConvertMessageTypeToBytes(byte messageType)
+    {
+      return new byte[] {messageType};
+    }
+  }
+}

--- a/src/NetMQ/Serialization/Convertions.cs
+++ b/src/NetMQ/Serialization/Convertions.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using NetMQ.zmq;
+
+namespace NetMQ.Serialization
+{
+  static class Convertions
+  {
+    public static int ToInt32(byte[] bytes, Endianness endian)
+    {
+      if (endian == Endianness.Little && BitConverter.IsLittleEndian)
+      {
+        return BitConverter.ToInt32(bytes, 0);
+      }
+      else
+      {
+        return BitConverter.ToInt32(bytes.Reverse().ToArray(), 0);
+      }
+    }
+
+    public static byte[] ToBytes(int num, Endianness endian)
+    {
+      byte[] bytes = BitConverter.GetBytes(num);
+
+      if (BitConverter.IsLittleEndian && endian != Endianness.Little)
+      {
+        return bytes.Reverse().ToArray();
+      }
+
+      return bytes;
+    }
+
+    public static Int16 ToInt16(byte[] bytes, Endianness endian)
+    {
+      if (endian == Endianness.Little && BitConverter.IsLittleEndian)
+      {
+        return BitConverter.ToInt16(bytes, 0);
+      }
+      else
+      {
+        return BitConverter.ToInt16(bytes.Reverse().ToArray(), 0);
+      }
+    }
+
+    public static byte[] ToBytes(Int16 num, Endianness endian)
+    {
+      byte[] bytes = BitConverter.GetBytes(num);
+
+      if (BitConverter.IsLittleEndian && endian != Endianness.Little)
+      {
+        return bytes.Reverse().ToArray();
+      }
+
+      return bytes;
+    }
+
+    public static Int64 ToInt64(byte[] bytes, Endianness endian)
+    {
+      if (endian == Endianness.Little && BitConverter.IsLittleEndian)
+      {
+        return BitConverter.ToInt64(bytes, 0);
+      }
+      else
+      {
+        return BitConverter.ToInt64(bytes.Reverse().ToArray(), 0);
+      }
+    }
+
+    public static byte[] ToBytes(Int64 num, Endianness endian)
+    {
+      byte[] bytes = BitConverter.GetBytes(num);
+
+      if (BitConverter.IsLittleEndian && endian != Endianness.Little)
+      {
+        return bytes.Reverse().ToArray();
+      }
+
+      return bytes;
+    }
+
+    public static uint ToUInt32(byte[] bytes, Endianness endian)
+    {
+      if (endian == Endianness.Little && BitConverter.IsLittleEndian)
+      {
+        return BitConverter.ToUInt32(bytes, 0);
+      }
+      else
+      {
+        return BitConverter.ToUInt32(bytes.Reverse().ToArray(), 0);
+      }
+    }
+
+    public static byte[] ToBytes(uint num, Endianness endian)
+    {
+      byte[] bytes = BitConverter.GetBytes(num);
+
+      if (BitConverter.IsLittleEndian && endian != Endianness.Little)
+      {
+        return bytes.Reverse().ToArray();
+      }
+
+      return bytes;
+    }
+
+    public static UInt16 ToUInt16(byte[] bytes, Endianness endian)
+    {
+      if (endian == Endianness.Little && BitConverter.IsLittleEndian)
+      {
+        return BitConverter.ToUInt16(bytes, 0);
+      }
+      else
+      {
+        return BitConverter.ToUInt16(bytes.Reverse().ToArray(), 0);
+      }
+    }
+
+    public static byte[] ToBytes(UInt16 num, Endianness endian)
+    {
+      byte[] bytes = BitConverter.GetBytes(num);
+
+      if (BitConverter.IsLittleEndian && endian != Endianness.Little)
+      {
+        return bytes.Reverse().ToArray();
+      }
+
+      return bytes;
+    }
+
+    public static UInt64 ToUInt64(byte[] bytes, Endianness endian)
+    {
+      if (endian == Endianness.Little && BitConverter.IsLittleEndian)
+      {
+        return BitConverter.ToUInt64(bytes, 0);
+      }
+      else
+      {
+        return BitConverter.ToUInt64(bytes.Reverse().ToArray(), 0);
+      }
+    }
+
+    public static byte[] ToBytes(UInt64 num, Endianness endian)
+    {
+      byte[] bytes = BitConverter.GetBytes(num);
+
+      if (BitConverter.IsLittleEndian && endian != Endianness.Little)
+      {
+        return bytes.Reverse().ToArray();
+      }
+
+      return bytes;
+    }
+
+    public static float ToFloat(byte[] bytes, Endianness endian)
+    {
+      if (endian == Endianness.Little && BitConverter.IsLittleEndian)
+      {
+        return BitConverter.ToSingle(bytes, 0);
+      }
+      else
+      {
+        return BitConverter.ToSingle(bytes.Reverse().ToArray(), 0);
+      }
+    }
+
+    public static byte[] ToBytes(float num, Endianness endian)
+    {
+      byte[] bytes = BitConverter.GetBytes(num);
+
+      if (BitConverter.IsLittleEndian && endian != Endianness.Little)
+      {
+        return bytes.Reverse().ToArray();
+      }
+
+      return bytes;
+    }
+
+    public static double ToDouble(byte[] bytes, Endianness endian)
+    {
+      if (endian == Endianness.Little && BitConverter.IsLittleEndian)
+      {
+        return BitConverter.ToDouble(bytes, 0);
+      }
+      else
+      {
+        return BitConverter.ToDouble(bytes.Reverse().ToArray(), 0);
+      }
+    }
+
+    public static byte[] ToBytes(double num, Endianness endian)
+    {
+      byte[] bytes = BitConverter.GetBytes(num);
+
+      if (BitConverter.IsLittleEndian && endian != Endianness.Little)
+      {
+        return bytes.Reverse().ToArray();
+      }
+
+      return bytes;
+    }
+
+    public static bool ToBoolean(byte[] bytes)
+    {
+      return BitConverter.ToBoolean(bytes, 0);
+    }
+
+    public static byte[] ToBytes(bool boolean)
+    {
+      byte[] bytes = BitConverter.GetBytes(boolean);
+
+      
+
+      return bytes;
+    }
+
+    public static string ToString(byte[] bytes, Encoding encoding)
+    {     
+      if (bytes.Length == 0)
+      {
+        return string.Empty;
+      }
+      else
+      {
+        return encoding.GetString(bytes);
+      }
+    }
+
+    public static byte[] ToBytes(string str, Encoding encoding)
+    {
+      if (string.IsNullOrEmpty(str))
+      {
+        return new byte[0];
+      }
+      else
+      {
+        return encoding.GetBytes(str);
+      }
+    }
+
+    public static object ToEnum(Type type, byte[] bytes, EnumSerializationType serializationType, Endianness endian)
+    {
+      object value;
+
+      switch (serializationType)
+      {
+        case EnumSerializationType.Int32:          
+          value = Enum.ToObject(type, ToInt32(bytes, endian));
+          break;
+        case EnumSerializationType.Int16:
+          value = Enum.ToObject(type, ToInt16(bytes, endian));
+          break;
+        case EnumSerializationType.Byte:
+          value = Enum.ToObject(type, bytes[0]);
+          break;
+        case EnumSerializationType.MemberName:
+          string text = ToString(bytes, Encoding.ASCII);
+          value = Enum.Parse(type, text);
+
+          break;
+        default:
+          throw new ArgumentOutOfRangeException();
+      }
+
+      return value;
+    }
+
+    public static byte[] ToBytes(IConvertible value, EnumSerializationType serializationType, Endianness endian)
+    {
+      switch (serializationType)
+      {
+        case EnumSerializationType.Int32:
+          return Convertions.ToBytes(value.ToInt32(CultureInfo.InvariantCulture), endian);
+          break;
+        case EnumSerializationType.Int16:
+          return Convertions.ToBytes(value.ToInt16(CultureInfo.InvariantCulture), endian);
+          break;
+        case EnumSerializationType.Byte:
+          return Convertions.ToBytes(value.ToByte(CultureInfo.InvariantCulture), endian);
+          break;
+        case EnumSerializationType.MemberName:
+          return Convertions.ToBytes(Enum.GetName(value.GetType(), value), Encoding.ASCII);
+          break;
+        default:
+          throw new ArgumentOutOfRangeException();
+      }
+    }
+  }
+}

--- a/src/NetMQ/Serialization/EnumBasedProtocol.cs
+++ b/src/NetMQ/Serialization/EnumBasedProtocol.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using NetMQ.zmq;
+
+namespace NetMQ.Serialization
+{
+  
+
+  public class EnumBasedProtocol<T> : BaseProtocol<T> where T : struct, IConvertible
+  {
+    public EnumBasedProtocol(EnumSerializationType enumSerializationType, Endianness endian = Endianness.Big)
+    {
+      EnumSerializationType = enumSerializationType;
+      Endian = endian;
+      if (!typeof(T).IsEnum)
+      {
+        throw new ArgumentException("T must be an enumerated type");
+      }
+    }
+
+    public EnumSerializationType EnumSerializationType { get; private set; }
+    public Endianness Endian { get; private set; }
+
+
+    protected internal override T ConvertBytesToMessageType(byte[] bytes)
+    {
+      switch (EnumSerializationType)
+      {
+        case EnumSerializationType.Int32:
+          if (bytes.Length != 4)
+          {
+            throw new NetMQProtocolException("Wrong message type size");
+          }          
+          break;
+        case EnumSerializationType.Int16:
+          if (bytes.Length != 2)
+          {
+            throw new NetMQProtocolException("Wrong message type size");
+          }
+          break;
+        case EnumSerializationType.Byte:
+          if (bytes.Length != 1)
+          {
+            throw new NetMQProtocolException("Wrong message type size");
+          }
+          break;
+        case EnumSerializationType.MemberName:
+          T value;
+          
+          string text = Convertions.ToString(bytes, Encoding.ASCII);
+          bool result = Enum.TryParse(text, out value);                    
+
+          if (!result)
+          {
+            throw new NetMQProtocolException("Unknown enum value: " + text);
+          }
+          break;
+        default:
+          throw new ArgumentOutOfRangeException();
+      }
+
+      return (T)Convertions.ToEnum(typeof(T), bytes, EnumSerializationType, Endian);
+    }
+
+    protected internal override byte[] ConvertMessageTypeToBytes(T messageType)
+    {
+      return Convertions.ToBytes(messageType, EnumSerializationType, Endian);
+    }
+  }
+}

--- a/src/NetMQ/Serialization/IntegerBasedProtocol.cs
+++ b/src/NetMQ/Serialization/IntegerBasedProtocol.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NetMQ.zmq;
+
+namespace NetMQ.Serialization
+{
+  public class IntegerBasedProtocol : BaseProtocol<int>
+  {
+    public IntegerBasedProtocol(Endianness endian = Endianness.Big)
+    {
+      Endian = endian;
+    }
+
+    public Endianness Endian { get; private set; }
+
+    protected internal override int ConvertBytesToMessageType(byte[] bytes)
+    {
+      if (bytes.Length != 4)
+      {
+        throw new NetMQProtocolException("Wrong message type size");
+      }
+
+
+      return Convertions.ToInt32(bytes, Endian);
+    }
+
+    protected internal override byte[] ConvertMessageTypeToBytes(int messageType)
+    {
+      return Convertions.ToBytes(messageType, Endian);
+    }
+  }
+}

--- a/src/NetMQ/Serialization/MemberTypeEnum.cs
+++ b/src/NetMQ/Serialization/MemberTypeEnum.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NetMQ.Serialization
+{
+  enum MemberTypeEnum
+  {
+    Boolean, Byte, Char, 
+    Int16, Int32, Int64, UInt16, UInt32,UInt64,Float,Double,String, Unknown,
+    DateTime, Enum
+  }
+
+  
+}

--- a/src/NetMQ/Serialization/NetMQMember.cs
+++ b/src/NetMQ/Serialization/NetMQMember.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NetMQ.zmq;
+
+namespace NetMQ.Serialization
+{
+  public enum EnumSerializationType
+  {
+    Int32, Int16, Byte, MemberName
+  }
+
+  [AttributeUsage(AttributeTargets.Property)]
+  public class NetMQMemberAttribute : Attribute
+  {
+    public NetMQMemberAttribute(int frame)
+    {
+      Frame = frame;
+      Endianness = Endianness.Big;
+      EncodingCodePage = Encoding.Unicode.CodePage;
+      EnumSerializationType = EnumSerializationType.Int32;
+    }
+
+    internal int Frame { get; private set; }
+
+    public Endianness Endianness
+    {
+      get;
+      set;
+    }
+
+    public int EncodingCodePage { get; set; }
+
+    public EnumSerializationType EnumSerializationType { get; set; }
+
+    public const int CodePageASCII = 20127;
+    public const int CodePageUnicode = 1200;
+    public const int CodePageUTF8 = 65001;
+    public const int CodePageUTF32 = 12000;
+
+    internal Encoding Encoding
+    {
+      get { return Encoding.GetEncoding(EncodingCodePage); }
+    }
+  }
+}

--- a/src/NetMQ/Serialization/NetMQProtocolException.cs
+++ b/src/NetMQ/Serialization/NetMQProtocolException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NetMQ.Serialization
+{
+  public class NetMQProtocolException : Exception
+  {
+    public NetMQProtocolException(string message) : base(message)
+    {
+    }
+  }
+}

--- a/src/NetMQ/Serialization/SerializerBuilder.cs
+++ b/src/NetMQ/Serialization/SerializerBuilder.cs
@@ -1,0 +1,516 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using NetMQ.zmq;
+
+namespace NetMQ.Serialization
+{
+  public class SerializerBuilder
+  {
+    private class PropertyInfoAttribute
+    {
+      public PropertyInfoAttribute(PropertyInfo propertyInfo, NetMQMemberAttribute attribute)
+      {
+        PropertyInfo = propertyInfo;
+        Attribute = attribute;
+
+        if (PropertyInfo.PropertyType.Equals(typeof(byte)))
+        {
+          MemberType = MemberTypeEnum.Byte;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(char)))
+        {
+          MemberType = MemberTypeEnum.Char;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(bool)))
+        {
+          MemberType = MemberTypeEnum.Boolean;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(short)))
+        {
+          MemberType = MemberTypeEnum.Int16;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(int)))
+        {
+          MemberType = MemberTypeEnum.Int32;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(long)))
+        {
+          MemberType = MemberTypeEnum.Int64;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(ushort)))
+        {
+          MemberType = MemberTypeEnum.UInt16;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(uint)))
+        {
+          MemberType = MemberTypeEnum.UInt32;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(ulong)))
+        {
+          MemberType = MemberTypeEnum.UInt64;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(float)))
+        {
+          MemberType = MemberTypeEnum.Float;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(double)))
+        {
+          MemberType = MemberTypeEnum.Double;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(string)))
+        {
+          MemberType = MemberTypeEnum.String;
+        }
+        else if (PropertyInfo.PropertyType.Equals(typeof(DateTime)))
+        {
+          MemberType = MemberTypeEnum.DateTime;
+        }
+        else if (PropertyInfo.PropertyType.IsEnum)
+        {
+          MemberType = MemberTypeEnum.Enum;
+        }
+        else
+        {
+          MemberType = MemberTypeEnum.Unknown;
+        }
+      }
+
+      public PropertyInfo PropertyInfo { get; private set; }
+
+      public NetMQMemberAttribute Attribute { get; private set; }
+
+      public MemberTypeEnum MemberType { get; private set; }
+    }
+
+    private readonly Type m_type;
+    private IList<PropertyInfoAttribute> m_properties;
+
+    public SerializerBuilder(Type type)
+    {
+      m_type = type;
+      m_properties = type.GetProperties().Where(p => p.GetCustomAttributes(typeof(NetMQMemberAttribute), false).Any()).
+                          Select(p => new PropertyInfoAttribute(p, ((NetMQMemberAttribute)(p.GetCustomAttributes(typeof(NetMQMemberAttribute), false)[0]))))
+                         .OrderBy(p => p.Attribute.Frame).ToList();
+
+      int maxFrameNumber = m_properties.Max(p => p.Attribute.Frame);
+
+      if (maxFrameNumber != m_properties.Count() - 1)
+      {
+        throw new ArgumentException("No missing frames is allowed");
+      }
+
+      int maxFrameCount = m_properties.GroupBy(p => p.Attribute.Frame).Select(g => g.Count()).Max();
+
+      if (maxFrameCount > 1)
+      {
+        throw new ArgumentException("Each frame can used only once");
+      }
+
+      if (m_properties.Any(p => p.MemberType == MemberTypeEnum.Unknown))
+      {
+        throw new ArgumentException("Member must be primitive type only");
+      }
+    }
+
+    public Func<byte[][], object> CreateDeserializer()
+    {
+      ParameterExpression framesParameterExpression = Expression.Parameter(typeof(byte[][]), "frames");
+
+      ParameterExpression messageVariableExpression = Expression.Variable(m_type, "message");
+
+      IList<Expression> expressions = new List<Expression>();
+
+      Expression createMessage = Expression.Assign(messageVariableExpression,
+                                                            Expression.New(m_type));
+
+      expressions.Add(createMessage);
+
+      Expression arrayLength = Expression.ArrayLength(framesParameterExpression);
+
+      foreach (PropertyInfoAttribute property in m_properties)
+      {
+        Expression frameNumberConstantExpression = Expression.Constant(property.Attribute.Frame);
+
+        Expression arrayItem = Expression.ArrayAccess(framesParameterExpression, frameNumberConstantExpression);
+
+        Expression invokeExpression;
+
+        switch (property.MemberType)
+        {
+          case MemberTypeEnum.Boolean:
+            invokeExpression = CreateToBooleanExpression(arrayItem, property);
+            break;
+          case MemberTypeEnum.Byte:
+            invokeExpression = CreateToByteExpression(arrayItem, property);
+            break;
+          case MemberTypeEnum.Char:
+            invokeExpression = CreateToCharExpression(arrayItem, property);
+            break;
+          case MemberTypeEnum.Int16:
+            invokeExpression = CreateToInt16Expression(arrayItem, property);
+            break;
+          case MemberTypeEnum.Int64:
+            invokeExpression = CreateToInt64Expression(arrayItem, property);
+            break;
+          case MemberTypeEnum.Int32:
+            invokeExpression = CreateToInt32Expression(arrayItem, property);
+            break;
+          case MemberTypeEnum.UInt16:
+            invokeExpression = CreateToUInt16Expression(arrayItem, property);
+            break;
+          case MemberTypeEnum.UInt32:
+            invokeExpression = CreateToUInt32Expression(arrayItem, property);
+            break;
+          case MemberTypeEnum.UInt64:
+            invokeExpression = CreateToUInt64Expression(arrayItem, property);
+            break;
+          case MemberTypeEnum.Float:
+            invokeExpression = CreateToFloatExpression(arrayItem, property);
+            break;
+          case MemberTypeEnum.Double:
+            invokeExpression = CreateToDoubleExpression(arrayItem, property);
+            break;
+          case MemberTypeEnum.String:
+            invokeExpression = CreateToStringExpression(arrayItem, property);
+            break;
+          case MemberTypeEnum.DateTime:
+            invokeExpression = CreateToDateTimeExpression(arrayItem, property);
+            break;
+          case MemberTypeEnum.Enum:
+            invokeExpression = CreateToEnumExpression(arrayItem, property);
+            break;
+          default:
+            throw new ArgumentOutOfRangeException();
+        }
+
+        Expression propertyExpression = Expression.Property(messageVariableExpression, property.PropertyInfo);
+
+        Expression assignExpression = Expression.Assign(propertyExpression, invokeExpression);
+
+        Expression ifArrayItemExist =
+          Expression.IfThen(Expression.GreaterThan(arrayLength, frameNumberConstantExpression), assignExpression);
+
+        expressions.Add(ifArrayItemExist);
+      }
+
+      // add the return expression
+      expressions.Add(messageVariableExpression);
+
+      Expression blockExpression = Expression.Block(new ParameterExpression[]
+        {
+          messageVariableExpression
+        }, expressions);
+
+      return Expression.Lambda<Func<byte[][], object>>(blockExpression, framesParameterExpression).Compile();
+    }
+
+    private Expression CreateToEnumExpression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, EnumSerializationType, Type, object>> convertExpression =
+        (bytes, endian, serializationType, type) => Convertions.ToEnum(type, bytes, serializationType, endian);
+
+      return Expression.Convert(
+        Expression.Invoke(convertExpression, arrayItem,
+        Expression.Constant(property.Attribute.Endianness),
+        Expression.Constant(property.Attribute.EnumSerializationType),
+        Expression.Constant(property.PropertyInfo.PropertyType)), property.PropertyInfo.PropertyType);
+    }
+
+    private Expression CreateToDateTimeExpression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, DateTime>> convertExpression =
+        (bytes, endian) => DateTime.FromBinary(Convertions.ToInt64(bytes, endian));
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToStringExpression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Encoding, string>> convertExpression = (bytes, encoding) => Convertions.ToString(bytes, encoding);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Encoding));
+    }
+
+    private Expression CreateToDoubleExpression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, double>> convertExpression = (bytes, endian) => Convertions.ToDouble(bytes, endian);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToFloatExpression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, float>> convertExpression = (bytes, endian) => Convertions.ToFloat(bytes, endian);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToUInt64Expression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, ulong>> convertExpression = (bytes, endian) => Convertions.ToUInt64(bytes, endian);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToUInt32Expression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, uint>> convertExpression = (bytes, endian) => Convertions.ToUInt32(bytes, endian);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToUInt16Expression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, ushort>> convertExpression = (bytes, endian) => Convertions.ToUInt16(bytes, endian);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToInt32Expression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, int>> convertExpression = (bytes, endian) => Convertions.ToInt32(bytes, endian);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToInt64Expression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, long>> convertExpression = (bytes, endian) => Convertions.ToInt64(bytes, endian);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToInt16Expression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, short>> convertExpression = (bytes, endian) => Convertions.ToInt16(bytes, endian);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToCharExpression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], Endianness, char>> convertExpression = (bytes, endian) => (char)Convertions.ToInt16(bytes, endian);
+
+      return Expression.Invoke(convertExpression, arrayItem, Expression.Constant(property.Attribute.Endianness));
+    }
+
+    private Expression CreateToByteExpression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], byte>> convertExpression = (bytes) => bytes[0];
+
+      return Expression.Invoke(convertExpression, arrayItem);
+    }
+
+    private Expression CreateToBooleanExpression(Expression arrayItem, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte[], bool>> convertExpression = (bytes) => BitConverter.ToBoolean(bytes, 0);
+
+      return Expression.Invoke(convertExpression, arrayItem);
+    }
+
+    public Func<object, byte[][]> CreateSerializer()
+    {
+      ParameterExpression objectParameterExpression = Expression.Parameter(typeof(object), "obj");
+
+      ParameterExpression castedObjectParameterExpression = Expression.Variable(m_type, "message");
+
+      IList<Expression> propertiesExpressions = new List<Expression>();
+
+      foreach (var property in m_properties)
+      {
+        Expression propertyExpression = Expression.Property(castedObjectParameterExpression, property.PropertyInfo);
+
+        Expression invokeExpression;
+
+        switch (property.MemberType)
+        {
+          case MemberTypeEnum.Boolean:
+            invokeExpression = CreateFromBooleanExpression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.Byte:
+            invokeExpression = CreateFromByteExpression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.Char:
+            invokeExpression = CreateFromCharExpression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.Int16:
+            invokeExpression = CreateFromInt16Expression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.Int64:
+            invokeExpression = CreateFromInt64Expression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.Int32:
+            invokeExpression = CreateFromInt32Expression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.UInt16:
+            invokeExpression = CreateFromUInt16Expression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.UInt32:
+            invokeExpression = CreateFromUInt32Expression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.UInt64:
+            invokeExpression = CreateFromUInt64Expression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.Float:
+            invokeExpression = CreateFromFloatExpression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.Double:
+            invokeExpression = CreateFromDoubleExpression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.String:
+            invokeExpression = CreateFromStringExpression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.DateTime:
+            invokeExpression = CreateFromDateTimeExpression(propertyExpression, property);
+            break;
+          case MemberTypeEnum.Enum:
+            invokeExpression = CreateFromEnumExpression(propertyExpression, property);
+            break;
+          default:
+            throw new ArgumentOutOfRangeException();
+        }
+
+        propertiesExpressions.Add(invokeExpression);
+      }
+
+      ParameterExpression framesVariableExpression = Expression.Variable(typeof(byte[][]), "frames");
+
+      Expression initFramesArray = Expression.Assign(framesVariableExpression,
+        Expression.NewArrayInit(typeof(byte[]), propertiesExpressions));
+
+      Expression castObjectToType = Expression.Assign(castedObjectParameterExpression,
+        Expression.TypeAs(objectParameterExpression, m_type));
+
+      Expression blockExpression = Expression.Block(new ParameterExpression[]
+        {
+          framesVariableExpression,
+          castedObjectParameterExpression
+        },
+        castObjectToType,
+        initFramesArray,
+        framesVariableExpression);
+
+      return Expression.Lambda<Func<object, byte[][]>>(blockExpression, objectParameterExpression).Compile();
+    }
+
+    private Expression CreateFromEnumExpression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<IConvertible, Endianness, EnumSerializationType, Byte[]>> convertExpression =
+        (e, endian, serializationType) => Convertions.ToBytes(e, serializationType, endian);
+
+
+      Expression invokeExpression = Expression.Invoke(convertExpression,
+        Expression.Convert(propertyExpression, typeof(IConvertible)),
+        Expression.Constant(property.Attribute.Endianness),
+        Expression.Constant(property.Attribute.EnumSerializationType));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromDateTimeExpression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<DateTime, Endianness, Byte[]>> convertExpression =
+        (d, endian) => Convertions.ToBytes(d.ToBinary(), endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromStringExpression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<string, Encoding, Byte[]>> convertExpression = (str, encoding) => Convertions.ToBytes(str, encoding);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Encoding));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromDoubleExpression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<double, Endianness, Byte[]>> convertExpression = (num, endian) => Convertions.ToBytes(num, endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromFloatExpression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<float, Endianness, Byte[]>> convertExpression = (num, endian) => Convertions.ToBytes(num, endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromUInt64Expression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<UInt64, Endianness, Byte[]>> convertExpression = (num, endian) => Convertions.ToBytes(num, endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromUInt32Expression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<UInt32, Endianness, Byte[]>> convertExpression = (num, endian) => Convertions.ToBytes(num, endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromUInt16Expression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<UInt16, Endianness, Byte[]>> convertExpression = (num, endian) => Convertions.ToBytes(num, endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromInt64Expression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<Int64, Endianness, Byte[]>> convertExpression = (num, endian) => Convertions.ToBytes(num, endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromInt16Expression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<Int16, Endianness, Byte[]>> convertExpression = (num, endian) => Convertions.ToBytes(num, endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromCharExpression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<char, Endianness, Byte[]>> convertExpression = (c, endian) => Convertions.ToBytes((short)c, endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+
+    private Expression CreateFromByteExpression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<byte, Byte[]>> convertExpression = (b) => new byte[] { b };
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression);
+      return invokeExpression;
+    }
+
+    private Expression CreateFromBooleanExpression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<bool, Byte[]>> convertExpression = (boolean) => Convertions.ToBytes(boolean);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression);
+      return invokeExpression;
+    }
+
+    private static Expression CreateFromInt32Expression(Expression propertyExpression, PropertyInfoAttribute property)
+    {
+      Expression<Func<int, Endianness, Byte[]>> convertExpression = (num, endian) => Convertions.ToBytes(num, endian);
+      Expression invokeExpression = Expression.Invoke(convertExpression, propertyExpression,
+                                                      Expression.Constant(property.Attribute.Endianness));
+      return invokeExpression;
+    }
+  }
+}

--- a/src/NetMQ/Serialization/ShortBasedProtocol.cs
+++ b/src/NetMQ/Serialization/ShortBasedProtocol.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NetMQ.zmq;
+
+namespace NetMQ.Serialization
+{
+  public class ShortBasedProtocol : BaseProtocol<short>
+  {    
+    public ShortBasedProtocol(Endianness endian = Endianness.Big)
+    {
+      Endian = endian;
+    }
+
+    public Endianness Endian { get; private set; }
+
+    protected internal override short ConvertBytesToMessageType(byte[] bytes)
+    {
+      if (bytes.Length != 2)
+      {
+        throw new NetMQProtocolException("Wrong message type size");
+      }
+
+
+      return Convertions.ToInt16(bytes, Endian);
+    }
+
+    protected internal override byte[] ConvertMessageTypeToBytes(short messageType)
+    {
+      return Convertions.ToBytes(messageType, Endian);
+    }
+  }
+}

--- a/src/NetMQ/Serialization/SocketExtensions.cs
+++ b/src/NetMQ/Serialization/SocketExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NetMQ;
+
+namespace NetMQ.Serialization
+{
+  public static class SocketExtensions
+  {
+    public static void SendProtocolMessage<TMessageType>(this NetMQSocket socket, 
+      BaseProtocol<TMessageType> protocol, object message, bool dontWait = false)
+    {
+      TMessageType messageType = protocol.GetMessageType(message);
+
+      var messsageTypeBytes = protocol.ConvertMessageTypeToBytes(messageType);
+
+      socket.SendMore(messsageTypeBytes);
+
+      var serializer = protocol.GetSerializer(messageType);
+
+      socket.SendMultiple(serializer(message), dontWait);
+    }
+
+    public static object ReceiveProtocolMessage<TMessageType>(this NetMQSocket socket,
+                                                              BaseProtocol<TMessageType> protocol, bool dontWait = false)
+    {
+      bool more;
+
+      byte[] messageTypeBytes = socket.Receive(dontWait, out more);
+
+      TMessageType messageType = protocol.ConvertBytesToMessageType(messageTypeBytes);
+
+      var deserializer = protocol.GetDeserializer(messageType);
+
+      if (more)
+      {
+        return deserializer(socket.ReceiveMessages().ToArray());
+      }
+      else
+      {
+        return deserializer(new byte[0][]);
+      }
+    }
+  }
+}

--- a/src/NetMQ/Serialization/StringBasedProtocol.cs
+++ b/src/NetMQ/Serialization/StringBasedProtocol.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NetMQ.Serialization
+{
+  public class StringBasedProtocol : BaseProtocol<string>
+  {
+    public StringBasedProtocol(Encoding encoding)
+    {
+      Encoding = encoding;
+    }
+
+    public StringBasedProtocol() : this(Encoding.ASCII)
+    {
+      
+    }
+
+    public Encoding Encoding { get; private set; }
+
+    protected internal override string ConvertBytesToMessageType(byte[] bytes)
+    {
+      return Convertions.ToString(bytes, Encoding);
+    }
+
+    protected internal override byte[] ConvertMessageTypeToBytes(string messageType)
+    {
+      return Convertions.ToBytes(messageType, Encoding);
+    }
+  }
+}


### PR DESCRIPTION
Now you can serialize classed and send them over NetMQ socket, make creating NetMQ protocol very easy. 
Also this can work when the other side is using simple zeromq and on the NetMQ side using NetMQ serialization.

Take a look at the test...

The idea is not support full serialization, only serialization of primitive messages (classes contains only primitive members),
each member is sent on a different frame.

This should have very good performance as well because it's using dynamic compiled code.
