### PR TITLE
A simple NetMQMessage.ToString() and test

### DIFF
--- a/src/NetMQ.Tests/MessageTests.cs
+++ b/src/NetMQ.Tests/MessageTests.cs
@@ -147,11 +147,14 @@ namespace NetMQ.Tests
         public void MessageToString()
         {
             var message = new NetMQMessage();
+            Assert.AreEqual("NetMQMessage[<no frames>]", message.ToString());
+
             message.Append("Hello");
+            Assert.AreEqual("NetMQMessage[Hello]", message.ToString());
+
             message.AppendEmptyFrame();
             message.Append("World");
-
-            Assert.AreEqual("HelloWorld", message.ToString());
+            Assert.AreEqual("NetMQMessage[Hello,,World]", message.ToString());
         }
     }
 }

--- a/src/NetMQ/NetMQMessage.cs
+++ b/src/NetMQ/NetMQMessage.cs
@@ -153,15 +153,23 @@ namespace NetMQ
         }
 
         /// <summary>
-        /// Returns a string consisting of all frames concatenated together.
+        /// Returns a string showing the frame contents.
         /// </summary>
         /// <returns></returns>
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder();
+            if (m_frames.Count == 0)
+                return "NetMQMessage[<no frames>]";
+            StringBuilder sb = new StringBuilder("NetMQMessage[");
+            bool first = true;
             foreach (NetMQFrame f in m_frames)
+            {
+                if (!first)
+                    sb.Append(",");
                 sb.Append(f.ConvertToString());
-            return sb.ToString();
+                first = false;
+            }
+            return sb.Append("]").ToString();
         }
     }
 }


### PR DESCRIPTION
Not sure if you'll take this, but I thought it odd that NetMQMessage didn't have one.  It's certainly not worse than the default implementation.

Note: this is better than the bad one I pasted to the mailing list earlier.  See the unit test.
