### PR TITLE
&& takes precedence over ||

### DIFF
--- a/src/NetMQ/zmq/PgmSocket.cs
+++ b/src/NetMQ/zmq/PgmSocket.cs
@@ -77,7 +77,7 @@ namespace NetMQ.zmq
             FD.SetSocketOption(PGM_LEVEL, EnableGigabitOption, BitConverter.GetBytes((uint)1));
 
             // set the receive buffer size for receiver and listener
-            if (m_options.ReceiveBuffer > 0 && m_pgmSocketType == PgmSocketType.Receiver || m_pgmSocketType == PgmSocketType.Listener)
+            if (m_options.ReceiveBuffer > 0 && (m_pgmSocketType == PgmSocketType.Receiver || m_pgmSocketType == PgmSocketType.Listener))
             {
                 FD.ReceiveBufferSize = m_options.ReceiveBuffer;
             }


### PR DESCRIPTION
There was

```
if (m_options.ReceiveBuffer > 0 && m_pgmSocketType == PgmSocketType.Receiver
    || m_pgmSocketType == PgmSocketType.Listener)
```

which [is equivalent](https://msdn.microsoft.com/en-us/library/aa691323%28v=vs.71%29.aspx) to

```
if ((m_options.ReceiveBuffer > 0 && m_pgmSocketType == PgmSocketType.Receiver)
    || m_pgmSocketType == PgmSocketType.Listener)
```

but I think you want

```
if (m_options.ReceiveBuffer > 0 && (m_pgmSocketType == PgmSocketType.Receiver
    || m_pgmSocketType == PgmSocketType.Listener))
```
