### PR TITLE
remove all sockets in Poller.Dispose

### DIFF
--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -101,6 +101,11 @@ namespace NetMQ
                     {
                         Stop(false);
                     }
+
+                    foreach (var socket in m_sockets.ToList())
+                    {
+                        RemoveSocket(socket);
+                    }
                 }
 
                 m_disposed = true;


### PR DESCRIPTION
Removes all sockets from the Poller when it is disposed of. This fixes the memory leak issue described in issue #131.
