### PR TITLE
removes all sockets at the end of Poller.Start

### DIFF
--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -344,6 +344,11 @@ namespace NetMQ
             finally
             {
                 m_isStoppedEvent.Set();
+
+                foreach (var socket in m_sockets.ToList())
+                {
+                    RemoveSocket(socket);
+                }
             }
         }
 


### PR DESCRIPTION
Cleaning up sockets at the end of Poller.Start. This fixes the memory leak issue described in issue #131, unless the Poller is never started (but I can't see a reason why you would create Pollers if not to start them).
