### PR TITLE
Fix issue in PGM with high frequency

### DIFF
--- a/src/NetMQ/zmq/DecoderBase.cs
+++ b/src/NetMQ/zmq/DecoderBase.cs
@@ -100,7 +100,7 @@ namespace NetMQ.zmq
             //  In case of zero-copy simply adjust the pointers, no copying
             //  is required. Also, run the state machine in case all the data
             //  were processed.
-            if (data.Equals(m_readPos))
+            if (data != null && data.Equals(m_readPos))
             {
                 m_readPos.AdvanceOffset(size);
                 m_toRead -= size;


### PR DESCRIPTION
The issue was that the process buffer can be called with null as data, however the method tried to access the parameter before checking the value
