### PR TITLE
Guarding the NetMQMonitor against unsubscribe while invoking events.

### DIFF
--- a/src/NetMQ/Monitoring/NetMQMonitor.cs
+++ b/src/NetMQ/Monitoring/NetMQMonitor.cs
@@ -158,9 +158,10 @@ namespace NetMQ.Monitoring
 
         private void InvokeEvent<T>(EventHandler<T> handler, T args) where T : NetMQMonitorEventArgs
         {
-            if (handler != null)
+            var temp = handler;
+            if (temp != null)
             {
-                handler(this, args);
+                temp(this, args);
             }
         }
 


### PR DESCRIPTION
Found while trying to understand #126
