### PR TITLE
Avoid unhandled Poller exceptions

### DIFF
--- a/src/NetMQ/zmq/Signaler.cs
+++ b/src/NetMQ/zmq/Signaler.cs
@@ -130,7 +130,9 @@ namespace NetMQ.zmq
 
         public bool WaitEvent(int timeout)
         {
-            return m_r.Poll(timeout * 1000, SelectMode.SelectRead);
+            if(m_r.Connected)
+                return m_r.Poll(timeout * 1000, SelectMode.SelectRead);
+            return false;
         }
 
         public void Recv()

--- a/src/NetMQ/zmq/ZMQ.cs
+++ b/src/NetMQ/zmq/ZMQ.cs
@@ -491,9 +491,9 @@ namespace NetMQ.zmq
                     }
                 }
 
-                inset.AddRange(readList);
-                outset.AddRange(writeList);
-                errorset.AddRange(errorList);
+                inset.AddRange(readList.Where(x => x.Connected));
+                outset.AddRange(writeList.Where(x => x.Connected));
+                errorset.AddRange(errorList.Where(x => x.Connected));
 
                 try
                 {


### PR DESCRIPTION
The changes allow the Poller to avoid provoking unhandled NullReference or ObjectDisposed exceptions when its attached sockets are closed improperly. In runtime, these result in irrecoverable crashes. An alternative to the fixes is to perform sanity checks in the Socket.Close() method and throw exceptions accordingly.
