### PR TITLE
Messages sometimes not send

### DIFF
--- a/src/NetMQ/zmq/YPipe.cs
+++ b/src/NetMQ/zmq/YPipe.cs
@@ -71,7 +71,7 @@ namespace NetMQ.zmq
             //  Move the "flush up to here" poiter.
             if (!incomplete)
             {
-                m_flushToIndex = m_queue.BackPos;
+                Interlocked.Exchange(ref m_flushToIndex, m_queue.BackPos);
             }
         }
 


### PR DESCRIPTION
using Interlocked.Exchange instead of assignment (see http://stackoverflow.com/questions/6928357/using-of-interlocked-exchange-for-updating-of-references-and-int32)
