### PR TITLE
Fix XpubVerbose option. C# can't cast bool to int.

### DIFF
--- a/src/NetMQ/zmq/Patterns/XPub.cs
+++ b/src/NetMQ/zmq/Patterns/XPub.cs
@@ -187,7 +187,7 @@ namespace NetMQ.zmq.Patterns
         {
             if (option == ZmqSocketOptions.XpubVerbose)
             {
-                m_verbose = (int)optval == 1;
+                m_verbose = (bool)optval;
                 return true;
             }
             if (option == ZmqSocketOptions.XPublisherManual)


### PR DESCRIPTION
I've playing with XPUB verbose option and noticed that publisher crashes in runtime. Problem was in invalid cast.
