### PR TITLE
Test multiple publishers and single/multiple subscribers.

### DIFF
--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -104,7 +104,9 @@
       <Name>NetMQ</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="NetMQ.Testing.crt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/NetMQ.Tests/XPubSubTests.cs
+++ b/src/NetMQ.Tests/XPubSubTests.cs
@@ -216,6 +216,147 @@ namespace NetMQ.Tests
             }
         }
 
+
+        [Test]
+        public void MultiplePublishers() {
+            using (NetMQContext contex = NetMQContext.Create()) {
+                using (var pub = contex.CreateXPublisherSocket())
+                using (var pub2 = contex.CreateXPublisherSocket()) {
+                    var address = "tcp://127.0.0.1:5002";
+                    var address2 = "tcp://127.0.0.1:5003";
+                    pub.Bind(address);
+                    pub2.Bind(address2);
+
+                    // see comments below why verbose option is needed in this test
+                    pub.Options.XPubVerbose = true;
+                    pub2.Options.XPubVerbose = true;
+
+                    using (var sub = contex.CreateXSubscriberSocket())
+                    using (var sub2 = contex.CreateXSubscriberSocket())
+                    {
+
+                        sub.Connect(address);
+                        sub.Connect(address2);
+
+                        sub2.Connect(address);
+                        sub2.Connect(address2);
+
+                        // should subscribe to both
+                        sub.Send(new byte[] { 1, (byte)'A' });
+                        sub2.Send(new byte[] { 1, (byte)'A' });
+
+                        Thread.Sleep(500);
+
+                        var msg = pub.ReceiveString();
+                        Assert.AreEqual(2, msg.Length);
+                        Assert.AreEqual(1, msg[0]);
+                        Assert.AreEqual('A', msg[1]);
+
+                        var msg2 = pub2.Receive();
+                        Assert.AreEqual(2, msg2.Length);
+                        Assert.AreEqual(1, msg2[0]);
+                        Assert.AreEqual('A', msg2[1]);
+
+
+                        // Next two blocks (pub(2).Receive) will hang without XPub verbose option: 
+                        // sub and sub2 both have sent `.Send(new byte[] { 1, (byte)'A' });` messages
+                        // which are the same, so XPub will discard the second message for .Receive()
+                        // because it is normally used to pass topics upstream.
+                        // (un)subs are done in XPub.cs at line 150-175, quote:
+                        // >> If the subscription is not a duplicate, store it so that it can be
+                        // >> passed to used on next recv call.
+                        // For verbose:
+                        // >> If true, send all subscription messages upstream, not just unique ones
+
+                        // These options must be set before sub2.Send(new byte[] { 1, (byte)'A' });
+                        // pub.Options.XPubVerbose = true;
+                        // pub2.Options.XPubVerbose = true;
+                        // Note that resending sub2.Send(..) here wont help because XSub won't resent existing subs to XPub - quite sane behavior
+                        // Comment out the verbose options and the next 8 lines and the test will 
+                        // still pass, even with non-unique messages from subscribers (see the bottom of the test)
+
+                        msg = pub.ReceiveString();
+                        Assert.AreEqual(2, msg.Length);
+                        Assert.AreEqual(1, msg[0]);
+                        Assert.AreEqual('A', msg[1]);
+
+                        msg2 = pub2.Receive();
+                        Assert.AreEqual(2, msg2.Length);
+                        Assert.AreEqual(1, msg2[0]);
+                        Assert.AreEqual('A', msg2[1]);
+
+
+                        pub.SendMore("A");
+                        pub.Send("Hello from the first publisher");
+
+                        bool more;
+                        string m = sub.ReceiveString(out more);
+                        Assert.AreEqual("A", m);
+                        Assert.IsTrue(more);
+                        string m2 = sub.ReceiveString(out more);
+                        Assert.AreEqual("Hello from the first publisher", m2);
+                        Assert.False(more);
+                        // this returns the result of the latest 
+                        // connect - address2, not the source of the message
+                        // This is documented here: http://api.zeromq.org/3-2:zmq-getsockopt
+                        var ep = sub2.Options.GetLastEndpoint;
+                        //Assert.AreEqual(address, ep);
+
+                        // same for sub2
+                        m = sub2.ReceiveString(out more);
+                        Assert.AreEqual("A", m);
+                        Assert.IsTrue(more);
+                        m2 = sub2.ReceiveString(out more);
+                        Assert.AreEqual("Hello from the first publisher", m2);
+                        Assert.False(more);
+
+
+
+                        pub2.SendMore("A");
+                        pub2.Send("Hello from the second publisher");
+
+                        string m3 = sub.ReceiveString(out more);
+
+                        Assert.AreEqual("A", m3);
+                        Assert.IsTrue(more);
+
+                        string m4 = sub.ReceiveString(out more);
+
+                        Assert.AreEqual("Hello from the second publisher", m4);
+                        Assert.False(more);
+                        ep = sub2.Options.GetLastEndpoint;
+                        Assert.AreEqual(address2, ep);
+
+
+                        // same for sub2
+                        m3 = sub2.ReceiveString(out more);
+                        Assert.AreEqual("A", m3);
+                        Assert.IsTrue(more);
+                        m4 = sub2.ReceiveString(out more);
+                        Assert.AreEqual("Hello from the second publisher", m4);
+                        Assert.False(more);
+
+                        // send both to address and address2
+                        sub.Send("Message from subscriber");
+                        sub2.Send("Message from subscriber 2");
+
+                        var txt = pub.ReceiveString();
+                        Assert.AreEqual("Message from subscriber", txt);
+                        var txt2 = pub2.ReceiveString();
+                        Assert.AreEqual("Message from subscriber", txt2);
+
+                        // Does not hang even though is the same as above, but the first byte is not 1 or 0.
+                        // Won't hang even when messages are equal
+                        txt = pub.ReceiveString();
+                        Assert.AreEqual("Message from subscriber 2", txt);
+                        txt2 = pub2.ReceiveString();
+                        Assert.AreEqual("Message from subscriber 2", txt2);
+
+                    }
+                }
+            }
+        }
+
         [Test, ExpectedException(typeof (AgainException))]
         public void UnSubscribe()
         {


### PR DESCRIPTION
The behavior was not obvious from docs before testing and looking into the source.