### PR TITLE
Fix XSub subscriptions.

### DIFF
--- a/src/NetMQ/zmq/Patterns/Utils/ArrayExtensions.cs
+++ b/src/NetMQ/zmq/Patterns/Utils/ArrayExtensions.cs
@@ -7,6 +7,14 @@ namespace NetMQ.zmq.Patterns.Utils
 {
     static class ArrayExtensions
     {
+        /// <summary>
+        /// Make resize operation on array.
+        /// </summary>
+        /// <typeparam name="T">Type of containing data.</typeparam>
+        /// <param name="src">Source array.</param>
+        /// <param name="size">New size of array.</param>
+        /// <param name="ended">If grow/shrink operation should be applied to the end of array.</param>
+        /// <returns>Resized array.</returns>
         public static T[] Resize<T>(this T[] src, int size, bool ended)
         {
             T[] dest;

--- a/src/NetMQ/zmq/Patterns/Utils/Trie.cs
+++ b/src/NetMQ/zmq/Patterns/Utils/Trie.cs
@@ -212,7 +212,7 @@ namespace NetMQ.zmq.Patterns.Utils
                         Debug.Assert(m_count > newMin - m_minCharacter);
                         m_count = (short)(m_count - (newMin - m_minCharacter));
 
-                        m_next = m_next.Resize(m_count, true);
+                        m_next = m_next.Resize(m_count, false);
 
                         m_minCharacter = newMin;
                     }
@@ -231,7 +231,7 @@ namespace NetMQ.zmq.Patterns.Utils
                         Debug.Assert(newCount != m_count);
                         m_count = newCount;
 
-                        m_next = m_next.Resize(m_count, false);
+                        m_next = m_next.Resize(m_count, true);
                     }
                 }
             }


### PR DESCRIPTION
I've noticed that Unsubscribe operation is broken for both Sub and XSub sockets. When you make unsubscription you can break trie structure that handles subscriptions.

You can reproduce situation with the following simple app. I've just copied ArrayExtension and Trie classes to not depend on other code.

It adds several tokens to the Trie and prints Trie content. Then removes one token and prints again. You can see that Trie content becomes broken.

```csharp
using System;
using System.Collections.Generic;
using System.Diagnostics;
using System.Text;

namespace Test
{
    static class ArrayExtensions
    {
        public static T[] Resize<T>(this T[] src, int size, bool ended)
        {
            T[] dest;

            if (size > src.Length) {
                dest = new T[size];
                if (ended)
                    Array.Copy(src, 0, dest, 0, src.Length);
                else
                    Array.Copy(src, 0, dest, size - src.Length, src.Length);
            } else if (size < src.Length) {
                dest = new T[size];
                if (ended)
                    Array.Copy(src, 0, dest, 0, size);
                else
                    Array.Copy(src, src.Length - size, dest, 0, size);
            } else {
                dest = src;
            }
            return dest;
        }

        public static void Swap<T>(this List<T> items, int index1, int index2) where T : class
        {
            if (index1 == index2)
                return;

            T item1 = items[index1];
            T item2 = items[index2];
            if (item1 != null)
                items[index2] = item1;
            if (item2 != null)
                items[index1] = item2;
        }
    }

    class Trie
    {
        private int m_referenceCount;

        private byte m_minCharacter;
        private short m_count;
        private short m_liveNodes;

        public delegate void TrieDelegate(byte[] data, int size, Object arg);

        Trie[] m_next;

        public Trie()
        {
            m_minCharacter = 0;
            m_count = 0;
            m_liveNodes = 0;

            m_referenceCount = 0;
            m_next = null;
        }

        /// <summary>
        /// Add key to the trie. Returns true if this is a new item in the trie
        ///  rather than a duplicate.
        /// </summary>
        /// <param name="prefix"></param>
        /// <param name="start"></param>
        /// <param name="size"></param>
        /// <returns></returns>
        public bool Add(byte[] prefix, int start, int size)
        {
            //  We are at the node corresponding to the prefix. We are done.
            if (size == 0) {
                ++m_referenceCount;
                return m_referenceCount == 1;
            }

            byte currentCharacter = prefix[start];
            if (currentCharacter < m_minCharacter || currentCharacter >= m_minCharacter + m_count) {
                //  The character is out of range of currently handled
                //  charcters. We have to extend the table.
                if (m_count == 0) {
                    m_minCharacter = currentCharacter;
                    m_count = 1;
                    m_next = null;
                } else if (m_count == 1) {
                    byte oldc = m_minCharacter;
                    Trie oldp = m_next[0];
                    m_count = (short)((m_minCharacter < currentCharacter ? currentCharacter - m_minCharacter : m_minCharacter - currentCharacter) + 1);
                    m_next = new Trie[m_count];
                    m_minCharacter = Math.Min(m_minCharacter, currentCharacter);
                    m_next[oldc - m_minCharacter] = oldp;
                } else if (m_minCharacter < currentCharacter) {
                    //  The new character is above the current character range.
                    m_count = (short)(currentCharacter - m_minCharacter + 1);
                    m_next = m_next.Resize(m_count, true);
                } else {
                    //  The new character is below the current character range.
                    m_count = (short)((m_minCharacter + m_count) - currentCharacter);
                    m_next = m_next.Resize(m_count, false);
                    m_minCharacter = currentCharacter;
                }
            }

            //  If next node does not exist, create one.
            if (m_count == 1) {
                if (m_next == null) {
                    m_next = new Trie[1];
                    m_next[0] = new Trie();
                    ++m_liveNodes;
                    //alloc_Debug.Assert(next.node);
                }
                return m_next[0].Add(prefix, start + 1, size - 1);
            } else {
                if (m_next[currentCharacter - m_minCharacter] == null) {
                    m_next[currentCharacter - m_minCharacter] = new Trie();
                    ++m_liveNodes;
                    //alloc_Debug.Assert(next.table [c - min]);
                }
                return m_next[currentCharacter - m_minCharacter].Add(prefix, start + 1, size - 1);
            }
        }


        /// <summary>
        //  Remove key from the trie. Returns true if the item is actually
        ///  removed from the trie.
        /// </summary>
        /// <param name="prefix"></param>
        /// <param name="start"></param>
        /// <param name="size"></param>
        /// <returns></returns>
        public bool Remove(byte[] prefix, int start, int size)
        {
            if (size == 0) {
                if (m_referenceCount == 0)
                    return false;
                m_referenceCount--;
                return m_referenceCount == 0;
            }

            byte currentCharacter = prefix[start];
            if (m_count == 0 || currentCharacter < m_minCharacter || currentCharacter >= m_minCharacter + m_count)
                return false;

            Trie nextNode = m_count == 1 ? m_next[0] : m_next[currentCharacter - m_minCharacter];

            if (nextNode == null)
                return false;

            bool wasRemoved = nextNode.Remove(prefix, start + 1, size - 1);

            if (nextNode.IsRedundant()) {
                //delete next_node;
                Debug.Assert(m_count > 0);

                if (m_count == 1) {
                    m_next = null;
                    m_count = 0;
                    --m_liveNodes;
                    Debug.Assert(m_liveNodes == 0);
                } else {
                    m_next[currentCharacter - m_minCharacter] = null;
                    Debug.Assert(m_liveNodes > 1);
                    --m_liveNodes;

                    //  Compact the table if possible
                    if (m_liveNodes == 1) {
                        //  If there's only one live node in the table we can
                        //  switch to using the more compact single-node
                        //  representation
                        Trie node = null;
                        for (short i = 0; i < m_count; ++i) {
                            if (m_next[i] != null) {
                                node = m_next[i];
                                m_minCharacter = (byte)(i + m_minCharacter);
                                break;
                            }
                        }

                        Debug.Assert(node != null);

                        m_next = null;
                        m_next = new Trie[] { node };
                        m_count = 1;
                    } else if (currentCharacter == m_minCharacter) {
                        //  We can compact the table "from the left"
                        byte newMin = m_minCharacter;
                        for (short i = 1; i < m_count; ++i) {
                            if (m_next[i] != null) {
                                newMin = (byte)(i + m_minCharacter);
                                break;
                            }
                        }
                        Debug.Assert(newMin != m_minCharacter);

                        Debug.Assert(newMin > m_minCharacter);
                        Debug.Assert(m_count > newMin - m_minCharacter);
                        m_count = (short)(m_count - (newMin - m_minCharacter));

                        m_next = m_next.Resize(m_count, true);

                        m_minCharacter = newMin;
                    } else if (currentCharacter == m_minCharacter + m_count - 1) {
                        //  We can compact the table "from the right"
                        short newCount = m_count;
                        for (short i = 1; i < m_count; ++i) {
                            if (m_next[m_count - 1 - i] != null) {
                                newCount = (short)(m_count - i);
                                break;
                            }
                        }
                        Debug.Assert(newCount != m_count);
                        m_count = newCount;

                        m_next = m_next.Resize(m_count, false);
                    }
                }
            }

            return wasRemoved;
        }

        /// <summary>
        ///  Check whether particular key is in the trie.
        /// </summary>
        /// <param name="data"></param>
        /// <param name="size"></param>
        /// <returns></returns>
        public bool Check(byte[] data, int size)
        {
            //  This function is on critical path. It deliberately doesn't use
            //  recursion to get a bit better performance.
            Trie current = this;
            int start = 0;
            while (true) {
                //  We've found a corresponding subscription!
                if (current.m_referenceCount > 0)
                    return true;

                //  We've checked all the data and haven't found matching subscription.
                if (size == 0)
                    return false;

                //  If there's no corresponding slot for the first character
                //  of the prefix, the message does not match.
                byte character = data[start];
                if (character < current.m_minCharacter || character >= current.m_minCharacter + current.m_count)
                    return false;

                //  Move to the next character.
                if (current.m_count == 1)
                    current = current.m_next[0];
                else {
                    current = current.m_next[character - current.m_minCharacter];

                    if (current == null)
                        return false;
                }
                start++;
                size--;
            }
        }

        //  Apply the function supplied to each subscription in the trie.
        public void Apply(TrieDelegate func, Object arg)
        {
            ApplyHelper(null, 0, 0, func, arg);
        }

        private void ApplyHelper(byte[] buffer, int bufferSize, int maxBufferSize, TrieDelegate func, Object arg)
        {
            //  If this node is a subscription, apply the function.
            if (m_referenceCount > 0)
                func(buffer, bufferSize, arg);

            //  Adjust the buffer.
            if (bufferSize >= maxBufferSize) {
                maxBufferSize = bufferSize + 256;
                Array.Resize(ref buffer, maxBufferSize);
                Debug.Assert(buffer != null);
            }

            //  If there are no subnodes in the trie, return.
            if (m_count == 0)
                return;

            //  If there's one subnode (optimisation).
            if (m_count == 1) {
                buffer[bufferSize] = m_minCharacter;
                bufferSize++;
                m_next[0].ApplyHelper(buffer, bufferSize, maxBufferSize, func, arg);
                return;
            }

            //  If there are multiple subnodes.
            for (short c = 0; c != m_count; c++) {
                buffer[bufferSize] = (byte)(m_minCharacter + c);
                if (m_next[c] != null)
                    m_next[c].ApplyHelper(buffer, bufferSize + 1, maxBufferSize, func, arg);
            }
        }

        private bool IsRedundant()
        {
            return m_referenceCount == 0 && m_liveNodes == 0;
        }
    }

    class Program
    {
        static void Main(string[] args)
        {
            string aapl = "quote.XNAS.AAPL";
            string msft = "quote.XNAS.MSFT";
            string goog = "quote.XNAS.GOOG";

            var trie = new Trie();

            trie.Add(Encoding.ASCII.GetBytes(aapl), 0, aapl.Length);
            trie.Add(Encoding.ASCII.GetBytes(msft), 0, msft.Length);
            trie.Add(Encoding.ASCII.GetBytes(goog), 0, goog.Length);

            trie.Apply((b, s, _) => Console.WriteLine(Encoding.ASCII.GetString(b, 0, s)), null);

            Console.WriteLine("--------------------------------------------------------------");

            trie.Remove(Encoding.ASCII.GetBytes(aapl), 0, aapl.Length);

            trie.Apply((b, s, _) => Console.WriteLine(Encoding.ASCII.GetString(b, 0, s)), null);

            Console.ReadKey();
        }
    }
}

```