### PR TITLE
Fix typo. Receivev* -> Receive*

### DIFF
--- a/src/NetMQ.Tests/PgmTests.cs
+++ b/src/NetMQ.Tests/PgmTests.cs
@@ -147,7 +147,7 @@ namespace NetMQ.Tests
 
                     using (var sub = context.CreateSubscriberSocket())
                     {
-                        sub.Options.ReceivevBuffer = MegaByte * 10;
+                        sub.Options.ReceiveBuffer = MegaByte * 10;
                         sub.Bind("pgm://224.0.0.1:5555");
 
                         sub.Subscribe("");
@@ -164,7 +164,7 @@ namespace NetMQ.Tests
                         Assert.AreEqual(40 * MegaBit, pub.Options.MulticastRate);
                         Assert.AreEqual(TimeSpan.FromMinutes(10), pub.Options.MulticastRecoveryInterval);
                         Assert.AreEqual(MegaByte * 10, pub.Options.SendBuffer);
-                        Assert.AreEqual(MegaByte * 10, sub.Options.ReceivevBuffer);
+                        Assert.AreEqual(MegaByte * 10, sub.Options.ReceiveBuffer);
                     }
                 }
             }

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -47,10 +47,11 @@ namespace NetMQ
             get { return m_socket.GetSocketOption(ZmqSocketOptions.SendBuffer); }
             set { m_socket.SetSocketOption(ZmqSocketOptions.SendBuffer, value); }
         }
-        public int ReceivevBuffer
+
+        public int ReceiveBuffer
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.ReceivevBuffer); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.ReceivevBuffer, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOptions.ReceiveBuffer); }
+            set { m_socket.SetSocketOption(ZmqSocketOptions.ReceiveBuffer, value); }
         }
 
         public bool ReceiveMore
@@ -97,8 +98,8 @@ namespace NetMQ
 
         public int ReceiveHighWatermark
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.ReceivevHighWatermark); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.ReceivevHighWatermark, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOptions.ReceiveHighWatermark); }
+            set { m_socket.SetSocketOption(ZmqSocketOptions.ReceiveHighWatermark, value); }
         }
 
         public int MulticastHops

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -48,6 +48,13 @@ namespace NetMQ
             set { m_socket.SetSocketOption(ZmqSocketOptions.SendBuffer, value); }
         }
 
+        [Obsolete("Use ReceiveBuffer instead")]
+        public int ReceivevBuffer
+        {
+            get { return ReceiveBuffer; }
+            set { ReceiveBuffer = value; }
+        }
+
         public int ReceiveBuffer
         {
             get { return m_socket.GetSocketOption(ZmqSocketOptions.ReceiveBuffer); }

--- a/src/NetMQ/zmq/Enums.cs
+++ b/src/NetMQ/zmq/Enums.cs
@@ -35,7 +35,7 @@ namespace NetMQ.zmq
         Rate = 8,
         RecoveryIvl = 9,
         SendBuffer = 11,
-        ReceivevBuffer = 12,
+        ReceiveBuffer = 12,
         ReceiveMore = 13,
         
         [Obsolete("Use Handle")]
@@ -52,7 +52,7 @@ namespace NetMQ.zmq
         ReconnectIvlMax = 21,
         Maxmsgsize = 22,
         SendHighWatermark = 23,
-        ReceivevHighWatermark = 24,
+        ReceiveHighWatermark = 24,
         MulticastHops = 25,
         ReceiveTimeout = 27,
         SendTimeout = 28,

--- a/src/NetMQ/zmq/Enums.cs
+++ b/src/NetMQ/zmq/Enums.cs
@@ -35,6 +35,8 @@ namespace NetMQ.zmq
         Rate = 8,
         RecoveryIvl = 9,
         SendBuffer = 11,
+        [Obsolete("Use ReceiveBuffer instead")]
+        ReceivevBuffer = ReceiveBuffer,
         ReceiveBuffer = 12,
         ReceiveMore = 13,
         
@@ -52,6 +54,8 @@ namespace NetMQ.zmq
         ReconnectIvlMax = 21,
         Maxmsgsize = 22,
         SendHighWatermark = 23,
+        [Obsolete("Use ReceiveHighWatermark instead")]
+        ReceivevHighWatermark = ReceiveHighWatermark,
         ReceiveHighWatermark = 24,
         MulticastHops = 25,
         ReceiveTimeout = 27,

--- a/src/NetMQ/zmq/Options.cs
+++ b/src/NetMQ/zmq/Options.cs
@@ -167,7 +167,7 @@ namespace NetMQ.zmq
                 case ZmqSocketOptions.SendHighWatermark:
                     SendHighWatermark = (int)optval;
                     break;
-                case ZmqSocketOptions.ReceivevHighWatermark:
+                case ZmqSocketOptions.ReceiveHighWatermark:
                     ReceiveHighWatermark = (int)optval;
                     break;
 
@@ -203,7 +203,7 @@ namespace NetMQ.zmq
                 case ZmqSocketOptions.SendBuffer:
                     SendBuffer = (int)optval;
                     break;
-                case ZmqSocketOptions.ReceivevBuffer:
+                case ZmqSocketOptions.ReceiveBuffer:
                     ReceiveBuffer = (int)optval;
                     break;
                 case ZmqSocketOptions.Linger:
@@ -303,7 +303,7 @@ namespace NetMQ.zmq
                 case ZmqSocketOptions.SendHighWatermark:
                     return SendHighWatermark;
 
-                case ZmqSocketOptions.ReceivevHighWatermark:
+                case ZmqSocketOptions.ReceiveHighWatermark:
                     return ReceiveHighWatermark;
 
                 case ZmqSocketOptions.Affinity:
@@ -321,7 +321,7 @@ namespace NetMQ.zmq
                 case ZmqSocketOptions.SendBuffer:
                     return SendBuffer;
 
-                case ZmqSocketOptions.ReceivevBuffer:
+                case ZmqSocketOptions.ReceiveBuffer:
                     return ReceiveBuffer;
 
                 case ZmqSocketOptions.Type:


### PR DESCRIPTION
This changes the public API, but in quite an obvious way. Instead the old symbols could also be retained and marked obsolete. Let me know if that's preferred and I'll update the PR.