### PR TITLE
Make (almost) all types in NetMQ.zmq.* namespaces internal

### DIFF
--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -12,6 +12,8 @@
     <AssemblyName>NetMQ.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\NetMQ\NetMQ.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NetMQ.Tests/NetMQ3.5.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ3.5.Tests.csproj
@@ -13,6 +13,8 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <BaseIntermediateOutputPath>obj\3.5\</BaseIntermediateOutputPath>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\NetMQ\NetMQ.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -17,7 +17,7 @@ namespace NetMQ
 
         private readonly Selector m_selector;
 
-        protected NetMQSocket(SocketBase socketHandle)
+        internal NetMQSocket(SocketBase socketHandle)
         {
             m_selector = new Selector();
             m_socketHandle = socketHandle;

--- a/src/NetMQ/Properties/AssemblyInfo.cs
+++ b/src/NetMQ/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -35,3 +36,17 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("3.3.1.15040")]
 [assembly: AssemblyFileVersion("3.3.1.15040")]
+
+[assembly: InternalsVisibleTo("NetMQ.Tests,PublicKey=" +
+    "0024000004800000940000000602000000240000525341310004000001000100c90e1ebf352af7" +
+    "132744cbb228ff09b10d7d758048085a392c57540a48f08321db8e92bc5605fb28a71339857b8d" +
+    "63752de08cb94943b292139b34616fd8a1f216a708c0bab9685e6114bf6b8d3cbba58c556fa0bc" +
+    "1f46970c8bd46e94c34b2c67f2220db09153f84fa0c39f5d341d84d59e3f0ccdfa033f4cfb9af5" +
+    "01767fbb")]
+
+[assembly: InternalsVisibleTo("NetMQ.3.5.Tests,PublicKey=" +
+    "0024000004800000940000000602000000240000525341310004000001000100c90e1ebf352af7" +
+    "132744cbb228ff09b10d7d758048085a392c57540a48f08321db8e92bc5605fb28a71339857b8d" +
+    "63752de08cb94943b292139b34616fd8a1f216a708c0bab9685e6114bf6b8d3cbba58c556fa0bc" +
+    "1f46970c8bd46e94c34b2c67f2220db09153f84fa0c39f5d341d84d59e3f0ccdfa033f4cfb9af5" +
+    "01767fbb")]

--- a/src/NetMQ/Sockets/DealerSocket.cs
+++ b/src/NetMQ/Sockets/DealerSocket.cs
@@ -7,7 +7,7 @@ namespace NetMQ.Sockets
     /// </summary>
     public class DealerSocket : NetMQSocket
     {
-        public DealerSocket(SocketBase socketHandle)
+        internal DealerSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/PairSocket.cs
+++ b/src/NetMQ/Sockets/PairSocket.cs
@@ -7,7 +7,7 @@ namespace NetMQ.Sockets
     /// </summary>
     public class PairSocket : NetMQSocket
     {
-        public PairSocket(SocketBase socketHandle)
+        internal PairSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/PublisherSocket.cs
+++ b/src/NetMQ/Sockets/PublisherSocket.cs
@@ -8,7 +8,7 @@ namespace NetMQ.Sockets
     /// </summary>
     public class PublisherSocket : NetMQSocket
     {
-        public PublisherSocket(SocketBase socketHandle)
+        internal PublisherSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/PullSocket.cs
+++ b/src/NetMQ/Sockets/PullSocket.cs
@@ -8,7 +8,7 @@ namespace NetMQ.Sockets
     /// </summary>
     public class PullSocket : NetMQSocket
     {
-        public PullSocket(SocketBase socketHandle)
+        internal PullSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/PushSocket.cs
+++ b/src/NetMQ/Sockets/PushSocket.cs
@@ -8,7 +8,7 @@ namespace NetMQ.Sockets
     /// </summary>
     public class PushSocket : NetMQSocket
     {
-        public PushSocket(SocketBase socketHandle)
+        internal PushSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/RequestSocket.cs
+++ b/src/NetMQ/Sockets/RequestSocket.cs
@@ -7,7 +7,7 @@ namespace NetMQ.Sockets
     /// </summary>
     public class RequestSocket : NetMQSocket
     {
-        public RequestSocket(SocketBase socketHandle)
+        internal RequestSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/ResponseSocket.cs
+++ b/src/NetMQ/Sockets/ResponseSocket.cs
@@ -7,7 +7,7 @@ namespace NetMQ.Sockets
     /// </summary>
     public class ResponseSocket : NetMQSocket
     {
-        public ResponseSocket(SocketBase socketHandle)
+        internal ResponseSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/RouterSocket.cs
+++ b/src/NetMQ/Sockets/RouterSocket.cs
@@ -7,7 +7,7 @@ namespace NetMQ.Sockets
     /// </summary>
     public class RouterSocket : NetMQSocket
     {
-        public RouterSocket(SocketBase socketHandle)
+        internal RouterSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/StreamSocket.cs
+++ b/src/NetMQ/Sockets/StreamSocket.cs
@@ -4,7 +4,7 @@ namespace NetMQ.Sockets
 {
     public class StreamSocket : NetMQSocket
     {
-        public StreamSocket(SocketBase socketHandle)
+        internal StreamSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/SubscriberSocket.cs
+++ b/src/NetMQ/Sockets/SubscriberSocket.cs
@@ -9,7 +9,7 @@ namespace NetMQ.Sockets
     /// </summary>
     public class SubscriberSocket : NetMQSocket
     {
-        public SubscriberSocket(SocketBase socketHandle)
+        internal SubscriberSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/XPublisherSocket.cs
+++ b/src/NetMQ/Sockets/XPublisherSocket.cs
@@ -5,7 +5,7 @@ namespace NetMQ.Sockets
 {
     public class XPublisherSocket : NetMQSocket
     {
-        public XPublisherSocket(SocketBase socketHandle)
+        internal XPublisherSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/Sockets/XSubscriberSocket.cs
+++ b/src/NetMQ/Sockets/XSubscriberSocket.cs
@@ -5,7 +5,7 @@ namespace NetMQ.Sockets
 {
     public class XSubscriberSocket : NetMQSocket
     {
-        public XSubscriberSocket(SocketBase socketHandle)
+        internal XSubscriberSocket(SocketBase socketHandle)
             : base(socketHandle)
         {
         }

--- a/src/NetMQ/zmq/Address.cs
+++ b/src/NetMQ/zmq/Address.cs
@@ -23,7 +23,7 @@ using System.Net;
 
 namespace NetMQ.zmq
 {
-    public class Address
+    internal class Address
     {
         public const string InProcProtocol = "inproc";
         public const string TcpProtocol = "tcp";

--- a/src/NetMQ/zmq/Command.cs
+++ b/src/NetMQ/zmq/Command.cs
@@ -24,7 +24,7 @@ using System;
 //  This structure defines the commands that can be sent between threads.
 namespace NetMQ.zmq
 {
-    public class Command
+    internal class Command
     {
 
         //  Object to process the command.		

--- a/src/NetMQ/zmq/Config.cs
+++ b/src/NetMQ/zmq/Config.cs
@@ -22,7 +22,7 @@
 
 namespace NetMQ.zmq
 {
-    public static class Config
+    internal static class Config
     {
 
         //  Number of new messages in message pipe needed to trigger new memory

--- a/src/NetMQ/zmq/Ctx.cs
+++ b/src/NetMQ/zmq/Ctx.cs
@@ -30,7 +30,7 @@ using System.Threading;
 
 namespace NetMQ.zmq
 {
-    public class Ctx
+    internal class Ctx
     {
         /*  Default for new contexts                                                  */
         public const int DefaultIOThreads = 1;

--- a/src/NetMQ/zmq/ErrorHelper.cs
+++ b/src/NetMQ/zmq/ErrorHelper.cs
@@ -3,7 +3,7 @@ using System.Net.Sockets;
 
 namespace NetMQ.zmq
 {
-    public static class ErrorHelper
+    internal static class ErrorHelper
     {
         public static ErrorCode SocketErrorToErrorCode(SocketError error)
         {

--- a/src/NetMQ/zmq/IMsgSink.cs
+++ b/src/NetMQ/zmq/IMsgSink.cs
@@ -1,6 +1,6 @@
 namespace NetMQ.zmq
 {
-    public interface IMsgSink
+    internal interface IMsgSink
     {
         //  Delivers a message. Returns true if successful; false otherwise.
         //  The function takes ownership of the passed message.

--- a/src/NetMQ/zmq/IMsgSource.cs
+++ b/src/NetMQ/zmq/IMsgSource.cs
@@ -1,6 +1,6 @@
 namespace NetMQ.zmq
 {
-    public interface IMsgSource
+    internal interface IMsgSource
     {
         //  Fetch a message. Returns a Msg instance if successful; null otherwise.
         bool PullMsg(ref Msg msg);

--- a/src/NetMQ/zmq/IOObject.cs
+++ b/src/NetMQ/zmq/IOObject.cs
@@ -28,7 +28,7 @@ using AsyncIO;
 
 namespace NetMQ.zmq
 {
-    public class IOObject : IProcatorEvents
+    internal class IOObject : IProcatorEvents
     {
         private IOThread m_ioThread;
         private IProcatorEvents m_handler;

--- a/src/NetMQ/zmq/IOThread.cs
+++ b/src/NetMQ/zmq/IOThread.cs
@@ -24,7 +24,7 @@ using NetMQ.zmq.Utils;
 
 namespace NetMQ.zmq
 {
-    public class IOThread : ZObject, IMailboxEvent
+    internal class IOThread : ZObject, IMailboxEvent
     {
 
         //  I/O thread accesses incoming commands via this mailbox.

--- a/src/NetMQ/zmq/IPollEvents.cs
+++ b/src/NetMQ/zmq/IPollEvents.cs
@@ -21,7 +21,7 @@
 
 namespace NetMQ.zmq
 {
-    public interface IPollEvents : ITimerEvent
+    internal interface IPollEvents : ITimerEvent
     {
         // Called by I/O thread when file descriptor is ready for reading.
         void InEvent();

--- a/src/NetMQ/zmq/IProcatorEvents.cs
+++ b/src/NetMQ/zmq/IProcatorEvents.cs
@@ -23,7 +23,7 @@ using System.Net.Sockets;
 
 namespace NetMQ.zmq
 {
-    public interface IProcatorEvents : ITimerEvent
+    internal interface IProcatorEvents : ITimerEvent
     {
         // Called by I/O thread when file descriptor is ready for reading.
         void InCompleted(SocketError socketError, int bytesTransferred);

--- a/src/NetMQ/zmq/ITimerEvent.cs
+++ b/src/NetMQ/zmq/ITimerEvent.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetMQ.zmq
 {
-    public interface ITimerEvent
+    internal interface ITimerEvent
     {
         // Called when timer expires.
         void TimerEvent(int id);     

--- a/src/NetMQ/zmq/IZmqMonitor.cs
+++ b/src/NetMQ/zmq/IZmqMonitor.cs
@@ -23,7 +23,7 @@ using System;
 
 namespace NetMQ.zmq
 {
-    public interface IZmqMonitor
+    internal interface IZmqMonitor
     {
 
         void Monitor(SocketBase socket, int monitorEvent, Object[] args);

--- a/src/NetMQ/zmq/Mailbox.cs
+++ b/src/NetMQ/zmq/Mailbox.cs
@@ -28,13 +28,13 @@ using NetMQ.zmq.Utils;
 
 namespace NetMQ.zmq
 {
-    public interface IMailbox
+    internal interface IMailbox
     {
         void Send(Command command);
         void Close();
     }
 
-    public interface IMailboxEvent
+    internal interface IMailboxEvent
     {
         void Ready();
     }
@@ -118,7 +118,7 @@ namespace NetMQ.zmq
         }
     }
 
-    public class Mailbox : IMailbox
+    internal class Mailbox : IMailbox
     {
         //private static Logger LOG = LoggerFactory.getLogger(Mailbox.class);
 

--- a/src/NetMQ/zmq/MonitorEvent.cs
+++ b/src/NetMQ/zmq/MonitorEvent.cs
@@ -5,7 +5,7 @@ using NetMQ.zmq.Transports;
 
 namespace NetMQ.zmq
 {
-    public class MonitorEvent
+    internal class MonitorEvent
     {
         private const int ValueInteger = 1;
         private const int ValueChannel = 2;

--- a/src/NetMQ/zmq/Options.cs
+++ b/src/NetMQ/zmq/Options.cs
@@ -27,7 +27,7 @@ using NetMQ.zmq.Transports.Tcp;
 
 namespace NetMQ.zmq
 {
-    public class Options
+    internal class Options
     {
         public Options()
         {

--- a/src/NetMQ/zmq/Own.cs
+++ b/src/NetMQ/zmq/Own.cs
@@ -28,7 +28,7 @@ namespace NetMQ.zmq
     /// Base class for objects forming a part of ownership hierarchy.
     /// It handles initialisation and destruction of such objects.
     /// </summary>
-    public abstract class Own : ZObject
+    internal abstract class Own : ZObject
     {
         protected readonly Options m_options;
 

--- a/src/NetMQ/zmq/Patterns/Pair.cs
+++ b/src/NetMQ/zmq/Patterns/Pair.cs
@@ -23,7 +23,7 @@ using System.Diagnostics;
 
 namespace NetMQ.zmq.Patterns
 {
-    public class Pair : SocketBase
+    internal class Pair : SocketBase
     {
 
         public class PairSession : SessionBase

--- a/src/NetMQ/zmq/Pipe.cs
+++ b/src/NetMQ/zmq/Pipe.cs
@@ -31,7 +31,7 @@ using System.Diagnostics;
 //  the generic array of pipes to deallocate (3).
 namespace NetMQ.zmq
 {
-    public class Pipe : ZObject
+    internal class Pipe : ZObject
     {
 
         //private static Logger LOG = LoggerFactory.getLogger(Pipe.class);

--- a/src/NetMQ/zmq/Reaper.cs
+++ b/src/NetMQ/zmq/Reaper.cs
@@ -23,7 +23,7 @@ using System.Net.Sockets;
 
 namespace NetMQ.zmq
 {
-    public class Reaper : ZObject, IPollEvents
+    internal class Reaper : ZObject, IPollEvents
     {
 
         //  Reaper thread accesses incoming commands via this mailbox.

--- a/src/NetMQ/zmq/SessionBase.cs
+++ b/src/NetMQ/zmq/SessionBase.cs
@@ -32,7 +32,7 @@ using NetMQ.zmq.Transports.Tcp;
 
 namespace NetMQ.zmq
 {
-    public class SessionBase : Own,
+    internal class SessionBase : Own,
                                                          Pipe.IPipeEvents, IProcatorEvents,
                                                          IMsgSink, IMsgSource
     {

--- a/src/NetMQ/zmq/SocketBase.cs
+++ b/src/NetMQ/zmq/SocketBase.cs
@@ -35,7 +35,7 @@ using TcpListener = NetMQ.zmq.Transports.Tcp.TcpListener;
 
 namespace NetMQ.zmq
 {
-    public abstract class SocketBase : Own, IPollEvents, Pipe.IPipeEvents
+    internal abstract class SocketBase : Own, IPollEvents, Pipe.IPipeEvents
     {
         private readonly Dictionary<String, Own> m_endpoints;
 

--- a/src/NetMQ/zmq/Transports/ByteArraySegment.cs
+++ b/src/NetMQ/zmq/Transports/ByteArraySegment.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace NetMQ.zmq.Transports
 {
-    public class ByteArraySegment
+    internal class ByteArraySegment
     {
         private readonly byte[] m_innerBuffer;
 

--- a/src/NetMQ/zmq/Transports/IEngine.cs
+++ b/src/NetMQ/zmq/Transports/IEngine.cs
@@ -23,7 +23,7 @@
 //  Abstract interface to be implemented by various engines.
 namespace NetMQ.zmq.Transports
 {
-    public interface IEngine
+    internal interface IEngine
     {
 
         //  Plug the engine to the session.

--- a/src/NetMQ/zmq/Transports/Ipc/IpcAddress.cs
+++ b/src/NetMQ/zmq/Transports/Ipc/IpcAddress.cs
@@ -23,7 +23,7 @@ using System.Net;
 
 namespace NetMQ.zmq.Transports.Ipc
 {
-    public class IpcAddress : Address.IZAddress
+    internal class IpcAddress : Address.IZAddress
     {
 
         private String m_name;

--- a/src/NetMQ/zmq/Transports/Ipc/IpcConnecter.cs
+++ b/src/NetMQ/zmq/Transports/Ipc/IpcConnecter.cs
@@ -22,7 +22,7 @@ using NetMQ.zmq.Transports.Tcp;
 
 namespace NetMQ.zmq.Transports.Ipc
 {
-    public class IpcConnecter : TcpConnecter
+    internal class IpcConnecter : TcpConnecter
     {
 
         public IpcConnecter(IOThread ioThread,

--- a/src/NetMQ/zmq/Transports/Ipc/IpcListener.cs
+++ b/src/NetMQ/zmq/Transports/Ipc/IpcListener.cs
@@ -23,7 +23,7 @@ using NetMQ.zmq.Transports.Tcp;
 
 namespace NetMQ.zmq.Transports.Ipc
 {
-    public class IpcListener : TcpListener
+    internal class IpcListener : TcpListener
     {
 
         private readonly IpcAddress m_address;

--- a/src/NetMQ/zmq/Transports/Pgm/PgmAddress.cs
+++ b/src/NetMQ/zmq/Transports/Pgm/PgmAddress.cs
@@ -4,7 +4,7 @@ using System.Net.Sockets;
 
 namespace NetMQ.zmq.Transports.PGM
 {
-    public class PgmAddress : Address.IZAddress
+    internal class PgmAddress : Address.IZAddress
     {
         private string m_network;
 

--- a/src/NetMQ/zmq/Transports/Pgm/PgmSocket.cs
+++ b/src/NetMQ/zmq/Transports/Pgm/PgmSocket.cs
@@ -4,21 +4,21 @@ using AsyncIO;
 
 namespace NetMQ.zmq.Transports.PGM
 {
-    public enum PgmSocketType
+    internal enum PgmSocketType
     {
         Publisher,
         Receiver,
         Listener
     }
 
-    public struct RM_SEND_WINDOW
+    internal struct RM_SEND_WINDOW
     {
         public uint RateKbitsPerSec; // Send rate
         public uint WindowSizeInMSecs;
         public uint WindowSizeInBytes;
     }
 
-    public class PgmSocket
+    internal class PgmSocket
     {
         public static readonly int PROTOCOL_TYPE_NUMBER = 113;
         public static readonly ProtocolType PGM_PROTOCOL_TYPE = (ProtocolType)113;

--- a/src/NetMQ/zmq/Transports/Tcp/TcpAddress.cs
+++ b/src/NetMQ/zmq/Transports/Tcp/TcpAddress.cs
@@ -26,7 +26,7 @@ using System.Net.Sockets;
 
 namespace NetMQ.zmq.Transports.Tcp
 {
-    public class TcpAddress : Address.IZAddress
+    internal class TcpAddress : Address.IZAddress
     {
         public class TcpAddressMask : TcpAddress
         {

--- a/src/NetMQ/zmq/Transports/Tcp/TcpConnecter.cs
+++ b/src/NetMQ/zmq/Transports/Tcp/TcpConnecter.cs
@@ -28,7 +28,7 @@ using AsyncIO;
 
 namespace NetMQ.zmq.Transports.Tcp
 {
-    public class TcpConnecter : Own, IProcatorEvents
+    internal class TcpConnecter : Own, IProcatorEvents
     {
 
         //private static Logger LOG = LoggerFactory.getLogger(TcpConnecter.class);

--- a/src/NetMQ/zmq/Transports/Tcp/TcpListener.cs
+++ b/src/NetMQ/zmq/Transports/Tcp/TcpListener.cs
@@ -26,7 +26,7 @@ using AsyncIO;
 
 namespace NetMQ.zmq.Transports.Tcp
 {
-    public class TcpListener : Own, IProcatorEvents
+    internal class TcpListener : Own, IProcatorEvents
     {
         private const SocketOptionName IPv6Only = (SocketOptionName) 27;
 

--- a/src/NetMQ/zmq/Utils/ByteArrayEqualityComparer.cs
+++ b/src/NetMQ/zmq/Utils/ByteArrayEqualityComparer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace NetMQ.zmq.Utils
 {
-    public class ByteArrayEqualityComparer : IEqualityComparer<byte[]>
+    internal class ByteArrayEqualityComparer : IEqualityComparer<byte[]>
     {
         protected const uint C1 = 0xcc9e2d51;
         protected const uint C2 = 0x1b873593;

--- a/src/NetMQ/zmq/Utils/OpCode.cs
+++ b/src/NetMQ/zmq/Utils/OpCode.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace NetMQ.zmq.Utils
 {
 
-    public static class Opcode
+    internal static class Opcode
     {
 
         private static IntPtr codeBuffer;

--- a/src/NetMQ/zmq/Utils/YQueue.cs
+++ b/src/NetMQ/zmq/Utils/YQueue.cs
@@ -24,7 +24,7 @@ using System.Diagnostics;
 
 namespace NetMQ.zmq.Utils
 {
-    public class YQueue<T>
+    internal class YQueue<T>
     {
         /// <summary> Individual memory chunk to hold N elements. </summary>
         private class Chunk

--- a/src/NetMQ/zmq/YPipe.cs
+++ b/src/NetMQ/zmq/YPipe.cs
@@ -25,7 +25,7 @@ using NetMQ.zmq.Utils;
 
 namespace NetMQ.zmq
 {
-    public class YPipe<T>
+    internal class YPipe<T>
     {
 
         //  Allocation-efficient queue to store pipe items.

--- a/src/NetMQ/zmq/ZObject.cs
+++ b/src/NetMQ/zmq/ZObject.cs
@@ -26,7 +26,7 @@ namespace NetMQ.zmq
     /// <summary>
     /// Base class for all objects that participate in inter-thread communication.
     /// </summary>
-    public abstract class ZObject
+    internal abstract class ZObject
     {
         //  Context provides access to the global state.
         private readonly Ctx m_ctx;


### PR DESCRIPTION
This PR Is a proposed solution to issue #241.

The assumption and motivation here is that types in `NetMQ.zmq` are not intended to be available to users of NetMQ. Making them internal hides them from view and simplifies the API.

The only remaining public types are enums in: `src\NetMQ\zmq\Enums.cs`

Unit test projects can still see these types via `[InternalsVisibleTo]`, which required signing the test assemblies.

Reducing the visibility is potentially a breaking change, but it also makes the library more user-friendly by hiding parts they're not supposed to use. I don't know enough to make an informed judgement about this tradeoff.

Thoughts?