### PR TITLE
Fixed a duplicate link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ There are also a few blog posts available, which you can read about here
 + [The Socket Types](http://sachabarbs.wordpress.com/2014/08/21/zeromq-2-the-socket-types-2/)
 + [Socket Options/Identity and SendMore](http://sachabarbs.wordpress.com/2014/08/26/zeromq-3-socket-optionsidentity-and-sendmore/)
 + [Multiple Socket Polling](http://sachabarbs.wordpress.com/2014/08/27/zeromq-4-multiple-sockets-polling/)
++ [Sending From Multiple Sockets](https://sachabarbs.wordpress.com/2014/08/30/zeromq-sending-from-multiple-sockets/)
 + [Divide And Conquer](http://sachabarbs.wordpress.com/2014/09/01/zeromq-6-divide-and-conquer/)
-+ [Multiple Socket Polling](http://sachabarbs.wordpress.com/2014/08/27/zeromq-4-multiple-sockets-polling/)
 
 
 Here is a small example


### PR DESCRIPTION
Multiple Socket Polling (part 4) link was a duplicate, and
Sending From Multiple Sockets (part 5) was missing.