### PR TITLE
Socket option test, fixes and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-
-#ignore thumbnails created by windows
+# Ignore Windows thumbnails
 Thumbs.db
-#Ignore files build by Visual Studio
+
+# Ignore Visual Studio files
 *.obj
 *.exe
 *.pdb
@@ -29,3 +29,9 @@ obj/
 [Rr]elease*/
 _ReSharper*/
 [Tt]est[Rr]esult*
+
+# Ignore MonoDevelop files
+*.userprefs
+
+# Ignore NUnit project files
+*.nunit

--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="SocketTests.cs" />
     <Compile Include="StreamTests.cs" />
     <Compile Include="zmq\YQueueTests.cs" />
+    <Compile Include="SocketOptionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NetMQ\NetMQ.csproj">

--- a/src/NetMQ.Tests/SocketOptionsTests.cs
+++ b/src/NetMQ.Tests/SocketOptionsTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using NUnit.Framework;
+using NetMQ.zmq;
+
+namespace NetMQ.Tests
+{
+    [TestFixture]
+    public class SocketOptionsTests
+    {
+        [Test]
+        public void DefaultValues()
+        {
+            using (var ctx = NetMQContext.Create())
+            using (var socket = ctx.CreateRouterSocket())
+            {
+                Assert.IsNull(socket.Options.Identity);
+//                Assert.IsNull(socket.Options.TcpAcceptFilter);
+                Assert.AreEqual(false, socket.Options.ReceiveMore);
+            }
+        }
+
+        [Test]
+        public void GetAndSetAllProperties()
+        {
+            using (var ctx = NetMQContext.Create())
+            using (var socket = ctx.CreateRouterSocket())
+            {
+                socket.Options.Affinity = 1L;
+                Assert.AreEqual(1L, socket.Options.Affinity);
+
+                socket.Options.Identity = new[] { (byte)1 };
+                Assert.AreEqual(1, socket.Options.Identity.Length);
+                Assert.AreEqual(1, socket.Options.Identity[0]);
+
+                socket.Options.MulticastRate = 100;
+                Assert.AreEqual(100, socket.Options.MulticastRate);
+
+                socket.Options.MulticastRecoveryInterval = TimeSpan.FromMilliseconds(100);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(100), socket.Options.MulticastRecoveryInterval);
+
+                socket.Options.ReceiveBuffer = 100;
+                Assert.AreEqual(100, socket.Options.ReceiveBuffer);
+
+//                socket.Options.ReceiveMore = true;
+
+                socket.Options.Linger = TimeSpan.FromMilliseconds(100);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(100), socket.Options.Linger);
+
+                socket.Options.ReconnectInterval = TimeSpan.FromMilliseconds(100);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(100), socket.Options.ReconnectInterval);
+
+                socket.Options.ReconnectIntervalMax = TimeSpan.FromMilliseconds(100);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(100), socket.Options.ReconnectIntervalMax);
+
+                socket.Options.Backlog = 100;
+                Assert.AreEqual(100, socket.Options.Backlog);
+
+                socket.Options.MaxMsgSize = 100;
+                Assert.AreEqual(100, socket.Options.MaxMsgSize);
+
+                socket.Options.SendHighWatermark = 100;
+                Assert.AreEqual(100, socket.Options.SendHighWatermark);
+
+                socket.Options.ReceiveHighWatermark = 100;
+                Assert.AreEqual(100, socket.Options.ReceiveHighWatermark);
+
+                socket.Options.MulticastHops = 100;
+                Assert.AreEqual(100, socket.Options.MulticastHops);
+
+                socket.Options.ReceiveTimeout = TimeSpan.FromMilliseconds(100);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(100), socket.Options.ReceiveTimeout);
+
+                socket.Options.SendTimeout = TimeSpan.FromMilliseconds(100);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(100), socket.Options.SendTimeout);
+
+                socket.Options.IPv4Only = true;
+                Assert.AreEqual(true, socket.Options.IPv4Only);
+
+                Assert.IsNull(socket.Options.LastEndpoint);
+
+                socket.Options.RouterMandatory = true;
+//                Assert.AreEqual(true, socket.Options.RouterMandatory);
+
+                socket.Options.TcpKeepalive = true;
+                Assert.AreEqual(true, socket.Options.TcpKeepalive);
+
+//                socket.Options.TcpKeepaliveCnt = 100;
+//                Assert.AreEqual(100, socket.Options.TcpKeepaliveCnt);
+
+                socket.Options.TcpKeepaliveIdle = TimeSpan.FromMilliseconds(100);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(100), socket.Options.TcpKeepaliveIdle);
+
+                socket.Options.TcpKeepaliveInterval = TimeSpan.FromMilliseconds(100);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(100), socket.Options.TcpKeepaliveInterval);
+
+                socket.Options.TcpAcceptFilter = "1.0.0.0:1234";
+//                Assert.AreEqual("1.0.0.0:1234", socket.Options.TcpAcceptFilter);
+
+                socket.Options.DelayAttachOnConnect = true;
+                Assert.AreEqual(true, socket.Options.DelayAttachOnConnect);
+
+                socket.Options.RouterRawSocket = true;
+//                Assert.AreEqual(true, socket.Options.RouterRawSocket);
+
+                socket.Options.Endian = Endianness.Little;
+                Assert.AreEqual(Endianness.Little, socket.Options.Endian);
+            }
+
+            using (var ctx = NetMQContext.Create())
+            using (var socket = ctx.CreateXPublisherSocket())
+            {
+                socket.Options.XPubVerbose = true;
+//                Assert.AreEqual(true, socket.Options.XPubVerbose);
+
+                socket.Options.ManualPublisher = true;
+//                Assert.AreEqual(true, socket.Options.ManualPublisher);
+            }
+        }
+    }
+}

--- a/src/NetMQ.sln
+++ b/src/NetMQ.sln
@@ -112,6 +112,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\COPYING.LESSER = ..\COPYING.LESSER
 		..\mkdocs.yml = ..\mkdocs.yml
 		..\README.md = ..\README.md
+		..\.gitattributes = ..\.gitattributes
+		..\.gitignore = ..\.gitignore
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{FF13931E-D7A0-489E-9530-0F972DAE1167}"

--- a/src/NetMQ/NetMQTimer.cs
+++ b/src/NetMQ/NetMQTimer.cs
@@ -45,14 +45,7 @@ namespace NetMQ
             {
                 m_interval = value;
 
-                if (Enable)
-                {
-                    When = Clock.NowMs() + Interval;
-                }
-                else
-                {
-                    When = -1;
-                }
+                When = Enable ? Clock.NowMs() + Interval : -1;
             }
         }
 
@@ -65,14 +58,7 @@ namespace NetMQ
                 {
                     m_enable = value;
 
-                    if (m_enable)
-                    {
-                        When = Clock.NowMs() + Interval;
-                    }
-                    else
-                    {
-                        When = -1;
-                    }
+                    When = m_enable ? Clock.NowMs() + Interval : -1;
                 }
             }
         }

--- a/src/NetMQ/NetMQTimer.cs
+++ b/src/NetMQ/NetMQTimer.cs
@@ -77,7 +77,7 @@ namespace NetMQ
             }
         }
 
-        internal Int64 When { get; set; }
+        internal long When { get; set; }
 
         internal void InvokeElapsed(object sender)
         {

--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -22,7 +22,7 @@ namespace NetMQ
         readonly List<NetMQTimer> m_zombies = new List<NetMQTimer>();
 
         private int m_cancel;
-        readonly ManualResetEvent m_isStoppedEvent = new ManualResetEvent(false);
+        private readonly ManualResetEvent m_isStoppedEvent = new ManualResetEvent(false);
         private bool m_isStarted;
 
         private bool m_isDirty = true;
@@ -253,8 +253,7 @@ namespace NetMQ
             m_isDirty = false;
         }
 
-
-        int TicklessTimer()
+        private int TicklessTimer()
         {
             //  Calculate tickless timer
             Int64 tickless = Clock.NowMs() + PollTimeout;

--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -256,7 +256,7 @@ namespace NetMQ
         private int TicklessTimer()
         {
             //  Calculate tickless timer
-            Int64 tickless = Clock.NowMs() + PollTimeout;
+            long tickless = Clock.NowMs() + PollTimeout;
 
             foreach (NetMQTimer timer in m_timers)
             {

--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -330,7 +330,7 @@ namespace NetMQ
             m_isStarted = true;
             try
             {
-                // the sockets may have been created in another thread, to make sure we can fully use them we do full memory barried
+                // the sockets may have been created in another thread, to make sure we can fully use them we do full memory barrier
                 // at the begining of the loop
                 Thread.MemoryBarrier();
 

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -24,7 +24,9 @@ namespace NetMQ
 
         public byte[] Identity
         {
+            [CanBeNull]
             get { return m_socket.GetSocketOptionX<byte[]>(ZmqSocketOptions.Identity); }
+            [NotNull]
             set { m_socket.SetSocketOption(ZmqSocketOptions.Identity, value); }
         }
 
@@ -166,6 +168,7 @@ namespace NetMQ
             set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.TcpKeepaliveIntvl, value); }
         }
 
+        [CanBeNull]
         public string TcpAcceptFilter
         {
             get { return m_socket.GetSocketOptionX<string>(ZmqSocketOptions.TcpAcceptFilter); }

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -61,10 +61,14 @@ namespace NetMQ
             set { m_socket.SetSocketOption(ZmqSocketOptions.ReceiveBuffer, value); }
         }
 
+        /// <summary>
+        /// Gets whether the last frame received on the socket had the <em>more</em> flag set or not.
+        /// </summary>
+        /// <value><c>true</c> if receive more; otherwise, <c>false</c>.</value>
         public bool ReceiveMore
         {
             get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.ReceiveMore); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.ReceiveMore, value); }
+//            set { m_socket.SetSocketOption(ZmqSocketOptions.ReceiveMore, value); }
         }
 
         public TimeSpan Linger
@@ -145,7 +149,7 @@ namespace NetMQ
 
         public bool RouterMandatory
         {
-            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.RouterMandatory); }
+//            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.RouterMandatory); }
             set { m_socket.SetSocketOption(ZmqSocketOptions.RouterMandatory, value); }
         }
 
@@ -158,8 +162,8 @@ namespace NetMQ
         [Obsolete("This option is not supported and has no effect")]
         public int TcpKeepaliveCnt
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.TcpKeepaliveCnt); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.TcpKeepaliveCnt, value); }
+//            get { return m_socket.GetSocketOption(ZmqSocketOptions.TcpKeepaliveCnt); }
+            set { /* m_socket.SetSocketOption(ZmqSocketOptions.TcpKeepaliveCnt, value); */ }
         }
 
         public TimeSpan TcpKeepaliveIdle
@@ -177,7 +181,8 @@ namespace NetMQ
         [CanBeNull]
         public string TcpAcceptFilter
         {
-            get { return m_socket.GetSocketOptionX<string>(ZmqSocketOptions.TcpAcceptFilter); }
+            // TODO the logic here doesn't really suit a setter -- set values are appended to a list, and null clear that list
+            // get { return m_socket.GetSocketOptionX<string>(ZmqSocketOptions.TcpAcceptFilter); }
             set { m_socket.SetSocketOption(ZmqSocketOptions.TcpAcceptFilter, value); }
         }
 
@@ -189,13 +194,13 @@ namespace NetMQ
 
         public bool XPubVerbose
         {
-            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.XpubVerbose); }
+//            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.XpubVerbose); }
             set { m_socket.SetSocketOption(ZmqSocketOptions.XpubVerbose, value); }
         }
 
         public bool RouterRawSocket
         {
-            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.RouterRawSocket); }
+//            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.RouterRawSocket); }
             set { m_socket.SetSocketOption(ZmqSocketOptions.RouterRawSocket, value); }
         }
 
@@ -207,7 +212,7 @@ namespace NetMQ
 
         public bool ManualPublisher
         {
-            // get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.XPublisherManual); }
+//            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.XPublisherManual); }
             set { m_socket.SetSocketOption(ZmqSocketOptions.XPublisherManual, value); }
         }
     }

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -133,7 +133,12 @@ namespace NetMQ
             set { m_socket.SetSocketOption(ZmqSocketOptions.IPv4Only, value); }
         }
 
-        public string GetLastEndpoint
+        [Obsolete("Use LastEndpoint instead")]
+        [CanBeNull]
+        public string GetLastEndpoint { get { return LastEndpoint; } }
+
+        [CanBeNull]
+        public string LastEndpoint
         {
             get { return m_socket.GetSocketOptionX<string>(ZmqSocketOptions.LastEndpoint); } 
         }

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -91,9 +91,9 @@ namespace NetMQ
             set { m_socket.SetSocketOption(ZmqSocketOptions.Backlog, value); }
         }
 
-        public int MaxMsgSize
+        public long MaxMsgSize
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.Maxmsgsize); }
+            get { return m_socket.GetSocketOptionLong(ZmqSocketOptions.Maxmsgsize); }
             set { m_socket.SetSocketOption(ZmqSocketOptions.Maxmsgsize, value); }
         }
 

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -169,7 +169,7 @@ namespace NetMQ
         public string TcpAcceptFilter
         {
             get { return m_socket.GetSocketOptionX<string>(ZmqSocketOptions.TcpAcceptFilter); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.TcpKeepaliveIntvl, value); }
+            set { m_socket.SetSocketOption(ZmqSocketOptions.TcpAcceptFilter, value); }
         }
 
         public bool DelayAttachOnConnect

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -150,6 +150,7 @@ namespace NetMQ
             set { m_socket.SetSocketOption(ZmqSocketOptions.TcpKeepalive, value ? 1 : 0); }
         }
 
+        [Obsolete("This option is not supported and has no effect")]
         public int TcpKeepaliveCnt
         {
             get { return m_socket.GetSocketOption(ZmqSocketOptions.TcpKeepaliveCnt); }

--- a/src/NetMQ/zmq/Enums.cs
+++ b/src/NetMQ/zmq/Enums.cs
@@ -61,6 +61,7 @@ namespace NetMQ.zmq
         LastEndpoint = 32,
         RouterMandatory = 33,
         TcpKeepalive = 34,
+        [Obsolete("Not supported and has no effect")]
         TcpKeepaliveCnt = 35,
         TcpKeepaliveIdle = 36,
         TcpKeepaliveIntvl = 37,

--- a/src/NetMQ/zmq/Options.cs
+++ b/src/NetMQ/zmq/Options.cs
@@ -170,13 +170,11 @@ namespace NetMQ.zmq
                 case ZmqSocketOptions.ReceiveHighWatermark:
                     ReceiveHighWatermark = (int)optval;
                     break;
-
                 case ZmqSocketOptions.Affinity:
                     Affinity = (long)optval;
                     break;
                 case ZmqSocketOptions.Identity:
                     byte[] val;
-
                     if (optval is String)
                         val = Encoding.ASCII.GetBytes((String)optval);
                     else if (optval is byte[])
@@ -217,7 +215,6 @@ namespace NetMQ.zmq
                 case ZmqSocketOptions.Backlog:
                     Backlog = (int)optval;
                     break;
-
                 case ZmqSocketOptions.Maxmsgsize:
                     Maxmsgsize = (long)optval;
                     break;
@@ -231,9 +228,7 @@ namespace NetMQ.zmq
                     SendTimeout = (int)optval;
                     break;
                 case ZmqSocketOptions.IPv4Only:
-
                     IPv4Only = (bool)optval;
-
                     break;
                 case ZmqSocketOptions.TcpKeepalive:
                     TcpKeepalive = (int)optval;
@@ -241,13 +236,10 @@ namespace NetMQ.zmq
                         throw new InvalidException("Value must be -1, 0 or 1 for ZmqSocketOptions.TcpKeepalive");
                     break;
                 case ZmqSocketOptions.DelayAttachOnConnect:
-
                     DelayAttachOnConnect = (bool)optval;
-
                     break;
-                case ZmqSocketOptions.TcpKeepaliveCnt:
-                    // not supported
-                    break;
+//                case ZmqSocketOptions.TcpKeepaliveCnt:
+//                    break; // not supported
                 case ZmqSocketOptions.TcpKeepaliveIdle:
                     TcpKeepaliveIdle = (int)optval;
                     break;
@@ -279,79 +271,56 @@ namespace NetMQ.zmq
             }
         }
 
-
         public Object GetSocketOption(ZmqSocketOptions option)
         {
             switch (option)
             {
                 case ZmqSocketOptions.SendHighWatermark:
                     return SendHighWatermark;
-
                 case ZmqSocketOptions.ReceiveHighWatermark:
                     return ReceiveHighWatermark;
-
                 case ZmqSocketOptions.Affinity:
                     return Affinity;
-
                 case ZmqSocketOptions.Identity:
                     return Identity;
-
                 case ZmqSocketOptions.Rate:
                     return Rate;
-
                 case ZmqSocketOptions.RecoveryIvl:
                     return RecoveryIvl;
-
                 case ZmqSocketOptions.SendBuffer:
                     return SendBuffer;
-
                 case ZmqSocketOptions.ReceiveBuffer:
                     return ReceiveBuffer;
-
                 case ZmqSocketOptions.Type:
                     return SocketType;
-
                 case ZmqSocketOptions.Linger:
                     return Linger;
-
                 case ZmqSocketOptions.ReconnectIvl:
                     return ReconnectIvl;
-
                 case ZmqSocketOptions.ReconnectIvlMax:
                     return ReconnectIvlMax;
-
                 case ZmqSocketOptions.Backlog:
                     return Backlog;
-
                 case ZmqSocketOptions.Maxmsgsize:
                     return Maxmsgsize;
-
                 case ZmqSocketOptions.MulticastHops:
                     return MulticastHops;
-
                 case ZmqSocketOptions.ReceiveTimeout:
                     return ReceiveTimeout;
-
                 case ZmqSocketOptions.SendTimeout:
                     return SendTimeout;
-
                 case ZmqSocketOptions.IPv4Only:
                     return IPv4Only;
-
                 case ZmqSocketOptions.TcpKeepalive:
                     return TcpKeepalive;
-
                 case ZmqSocketOptions.DelayAttachOnConnect:
                     return DelayAttachOnConnect;
-
-                case ZmqSocketOptions.TcpKeepaliveCnt:
-                    // not supported
-                    return 0;
+//                case ZmqSocketOptions.TcpKeepaliveCnt:
+//                    return 0; // not supported
                 case ZmqSocketOptions.TcpKeepaliveIdle:
                     return TcpKeepaliveIdle;
                 case ZmqSocketOptions.TcpKeepaliveIntvl:
                     return TcpKeepaliveIntvl;
-
                 case ZmqSocketOptions.LastEndpoint:
                     return LastEndpoint;
                 case ZmqSocketOptions.Endian:

--- a/src/NetMQ/zmq/Options.cs
+++ b/src/NetMQ/zmq/Options.cs
@@ -182,14 +182,9 @@ namespace NetMQ.zmq
                     else if (optval is byte[])
                         val = (byte[])optval;
                     else
-                    {
-                        throw new InvalidException();
-                    }
-
+                        throw new InvalidException("Invalid option value type for ZmqSocketOptions.Identity");
                     if (val.Length == 0 || val.Length > 255)
-                    {
-                        throw new InvalidException();
-                    }
+                        throw new InvalidException("Invalid length for ZmqSocketOptions.Identity");
                     Identity = new byte[val.Length];
                     val.CopyTo(Identity, 0);
                     IdentitySize = (byte)Identity.Length;
@@ -211,21 +206,13 @@ namespace NetMQ.zmq
                     break;
                 case ZmqSocketOptions.ReconnectIvl:
                     ReconnectIvl = (int)optval;
-
                     if (ReconnectIvl < -1)
-                    {
-                        throw new InvalidException();
-                    }
-
+                        throw new InvalidException("Value must be -1 or greater for ZmqSocketOptions.ReconnectIvl");
                     break;
                 case ZmqSocketOptions.ReconnectIvlMax:
                     ReconnectIvlMax = (int)optval;
-
                     if (ReconnectIvlMax < 0)
-                    {
-                        throw new InvalidException();
-                    }
-
+                        throw new InvalidException("Value must be 0 or greater for ZmqSocketOptions.ReconnectIvlMax");
                     break;
                 case ZmqSocketOptions.Backlog:
                     Backlog = (int)optval;
@@ -249,12 +236,9 @@ namespace NetMQ.zmq
 
                     break;
                 case ZmqSocketOptions.TcpKeepalive:
-
                     TcpKeepalive = (int)optval;
                     if (TcpKeepalive != -1 && TcpKeepalive != 0 && TcpKeepalive != 1)
-                    {
-                        throw new InvalidException();
-                    }
+                        throw new InvalidException("Value must be -1, 0 or 1 for ZmqSocketOptions.TcpKeepalive");
                     break;
                 case ZmqSocketOptions.DelayAttachOnConnect:
 
@@ -278,7 +262,7 @@ namespace NetMQ.zmq
                     }
                     else if (filterStr.Length == 0 || filterStr.Length > 255)
                     {
-                        throw new InvalidException();
+                        throw new InvalidException("Invalid length for ZmqSocketOptions.TcpAcceptFilter");
                     }
                     else
                     {
@@ -291,7 +275,7 @@ namespace NetMQ.zmq
                     Endian = (Endianness)optval;
                     break;
                 default:
-                    throw new InvalidException();
+                    throw new InvalidException("Unsupported ZmqSocketOptions enum value: " + option);
             }
         }
 
@@ -373,7 +357,7 @@ namespace NetMQ.zmq
                 case ZmqSocketOptions.Endian:
                     return Endian;
                 default:
-                    throw new InvalidException();
+                    throw new InvalidException("Unsupported ZmqSocketOptions enum value: " + option);
             }
         }
     }

--- a/src/NetMQ/zmq/Patterns/Router.cs
+++ b/src/NetMQ/zmq/Patterns/Router.cs
@@ -30,6 +30,8 @@ namespace NetMQ.zmq.Patterns
 {
     internal class Router : SocketBase
     {
+        private static readonly Random s_random = new Random();
+
         public class RouterSession : SessionBase
         {
             public RouterSession(IOThread ioThread, bool connect,
@@ -100,7 +102,7 @@ namespace NetMQ.zmq.Patterns
             m_moreIn = false;
             m_currentOut = null;
             m_moreOut = false;
-            m_nextPeerId = new Random().Next();
+            m_nextPeerId = s_random.Next();
             m_mandatory = false;
             m_rawSocket = false;
 

--- a/src/NetMQ/zmq/Patterns/Router.cs
+++ b/src/NetMQ/zmq/Patterns/Router.cs
@@ -40,6 +40,18 @@ namespace NetMQ.zmq.Patterns
             }
         }
 
+        private class Outpipe
+        {
+            public Outpipe(Pipe pipe, bool active)
+            {
+                Pipe = pipe;
+                Active = active;
+            }
+
+            public Pipe Pipe { get; private set; }
+            public bool Active;
+        };
+
         //  Fair queueing object for inbound pipes.
         private readonly FairQueueing m_fairQueueing;
 
@@ -58,18 +70,6 @@ namespace NetMQ.zmq.Patterns
 
         //  If true, more incoming message parts are expected.
         private bool m_moreIn;
-
-        class Outpipe
-        {
-            public Outpipe(Pipe pipe, bool active)
-            {
-                Pipe = pipe;
-                Active = active;
-            }
-
-            public Pipe Pipe { get; private set; }
-            public bool Active;
-        };
 
         //  We keep a set of pipes that have not been identified yet.
         private readonly HashSet<Pipe> m_anonymousPipes;

--- a/src/NetMQ/zmq/Patterns/Stream.cs
+++ b/src/NetMQ/zmq/Patterns/Stream.cs
@@ -40,7 +40,7 @@ namespace NetMQ.zmq.Patterns
             }
         }
 
-        class Outpipe
+        private class Outpipe
         {
             public Outpipe(Pipe pipe, bool active)
             {

--- a/src/NetMQ/zmq/Patterns/Stream.cs
+++ b/src/NetMQ/zmq/Patterns/Stream.cs
@@ -30,6 +30,8 @@ namespace NetMQ.zmq.Patterns
 {
     internal class Stream : SocketBase
     {
+        private static readonly Random s_random = new Random();
+
         public class StreamSession : SessionBase
         {
             public StreamSession(IOThread ioThread, bool connect,
@@ -88,7 +90,7 @@ namespace NetMQ.zmq.Patterns
             m_identitySent = false;
             m_currentOut = null;
             m_moreOut = false;
-            m_nextPeerId = new Random().Next();
+            m_nextPeerId = s_random.Next();
 
             m_options.SocketType = ZmqSocketType.Stream;
 

--- a/src/NetMQ/zmq/Transports/Tcp/TcpAddress.cs
+++ b/src/NetMQ/zmq/Transports/Tcp/TcpAddress.cs
@@ -71,7 +71,7 @@ namespace NetMQ.zmq.Transports.Tcp
             int delimiter = name.LastIndexOf(':');
             if (delimiter < 0)
             {
-                throw new InvalidException();
+                throw new InvalidException("TCP address must include a port number");
             }
 
             //  Separate the address/port.
@@ -94,7 +94,7 @@ namespace NetMQ.zmq.Transports.Tcp
                 port = Convert.ToInt32(portStr);
                 if (port == 0)
                 {
-                    throw new InvalidException();
+                    throw new InvalidException("Unable to parse port number as an integer");
                 }
             }         
 

--- a/src/NetMQ/zmq/Utils/Poller.cs
+++ b/src/NetMQ/zmq/Utils/Poller.cs
@@ -171,10 +171,7 @@ namespace NetMQ.zmq.Utils
 
             while (!m_stopping)
             {
-                foreach (var pollSet in m_addList)
-                {
-                    m_handles.Add(pollSet);
-                }
+                m_handles.AddRange(m_addList);
                 m_addList.Clear();
 
                 //  Execute any due timers.

--- a/src/NetMQ/zmq/Utils/Poller.cs
+++ b/src/NetMQ/zmq/Utils/Poller.cs
@@ -163,7 +163,7 @@ namespace NetMQ.zmq.Utils
             m_stopping = true;
         }
 
-        public void Loop()
+        private void Loop()
         {
             List<Socket> readList = new List<Socket>();
             List<Socket> writeList = new List<Socket>();

--- a/src/NetMQ/zmq/Utils/Poller.cs
+++ b/src/NetMQ/zmq/Utils/Poller.cs
@@ -47,6 +47,7 @@ namespace NetMQ.zmq.Utils
         //  This table stores data for registered descriptors.
         private readonly List<PollSet> m_handles;
 
+        //  List of handles to add at the start of the next loop
         private readonly List<PollSet> m_addList;
 
         //  If true, there's at least one retired event source.
@@ -67,7 +68,6 @@ namespace NetMQ.zmq.Utils
         public Poller()
             : this("poller")
         {
-
         }
 
         public Poller(String name)
@@ -206,7 +206,6 @@ namespace NetMQ.zmq.Utils
                         catch (TerminatingException)
                         {
                         }
-
                     }
 
                     if (pollSet.Cancelled)

--- a/src/Samples/Brokerless Reliability (Freelance Pattern)/Model One/Freelance.ModelOne.Server/Program.cs
+++ b/src/Samples/Brokerless Reliability (Freelance Pattern)/Model One/Freelance.ModelOne.Server/Program.cs
@@ -17,39 +17,32 @@ namespace Freelance.ModelOne.Server
                 {
                     string address = GetComputerLanIP();
 
-                    if (PORT_NUMBER > 0)
+                    if (!string.IsNullOrEmpty(address))
                     {
-                        if (!string.IsNullOrEmpty(address))
+                        Console.WriteLine("Binding tcp://{0}:{1}", address, PORT_NUMBER);
+                        response.Bind(string.Format("tcp://{0}:{1}", address, PORT_NUMBER));
+
+                        while (true)
                         {
-                            Console.WriteLine("Binding tcp://{0}:{1}", address, PORT_NUMBER);
-                            response.Bind(string.Format("tcp://{0}:{1}", address, PORT_NUMBER));
-
-                            while (true)
+                            bool hasMore = true;
+                            string msg = response.ReceiveString(out hasMore);
+                            if (string.IsNullOrEmpty(msg))
                             {
-                                bool hasMore = true;
-                                string msg = response.ReceiveString(out hasMore);
-                                if (string.IsNullOrEmpty(msg))
-                                {
-                                    Console.WriteLine("No msg received.");
-                                    break;
-                                }
-
-                                Console.WriteLine("Msg received! {0}", msg);
-                                response.Send(msg, false, hasMore);
-
-                                Thread.Sleep(1000);
+                                Console.WriteLine("No msg received.");
+                                break;
                             }
 
-                            response.Options.Linger = TimeSpan.Zero;
+                            Console.WriteLine("Msg received! {0}", msg);
+                            response.Send(msg, false, hasMore);
+
+                            Thread.Sleep(1000);
                         }
-                        else
-                        {
-                            Console.WriteLine("Wrong IP address");
-                        }
+
+                        response.Options.Linger = TimeSpan.Zero;
                     }
                     else
                     {
-                        Console.WriteLine("The port number should be greater than 0");
+                        Console.WriteLine("Wrong IP address");
                     }
 
                     Console.WriteLine("Press ENTER to exit...");


### PR DESCRIPTION
Prompted by #252, this PR adds a unit test that runs through all socket options.

Doing so revealed that several getters/setters are not usable and always throw InvalidException. They have been commented out. @somdoron it'd be great if you could review this.

Another small fix is that Router and Stream were each using `new Random().Next()` for `m_nextPeerId`. Sockets created in quick succession this way would have the same values.

Some string messages were added to exceptions observed during testing.