### PR TITLE
Generate XML documentation file for release builds.

### DIFF
--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -30,6 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <DocumentationFile>bin\Release\NetMQ.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
To get the most out of @JamesWHurst's hard work documenting the API, we should ship XML docs in the NuGet package as `NetMQ.XML`, sitting alongside `NetMQ.dll`.

I'm not sure exactly how the NuGet package is built, but this seems a likely part of the puzzle.

Relates to #273.