### PR TITLE
Identity is sent on reconnect for StreamSocket.

### DIFF
--- a/src/NetMQ/zmq/SessionBase.cs
+++ b/src/NetMQ/zmq/SessionBase.cs
@@ -244,8 +244,15 @@ namespace NetMQ.zmq
         protected virtual void Reset()
         {
             //  Restore identity flags.
-            m_identitySent = false;
-            m_identityReceived = false;
+            if (m_options.RawSocket)
+            {
+                m_identitySent = true;
+                m_identityReceived = true;
+            } else
+            {
+                m_identitySent = false;
+                m_identityReceived = false;
+            }
         }
 
         public void Flush()


### PR DESCRIPTION
When a remote connection is lost the identity is sent to the remote connection when the connection is reestablished. 
