### PR TITLE
Make ZmqSocketOptions internal and rename

### DIFF
--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -366,25 +366,25 @@ namespace NetMQ
         [Obsolete("Do not use this method if the socket is different from Subscriber and XSubscriber")]
         public virtual void Subscribe(string topic)
         {
-            SetSocketOption(ZmqSocketOptions.Subscribe, topic);
+            SetSocketOption(ZmqSocketOption.Subscribe, topic);
         }
 
         [Obsolete("Do not use this method if the socket is different from Subscriber and XSubscriber")]
         public virtual void Subscribe(byte[] topic)
         {
-            SetSocketOption(ZmqSocketOptions.Subscribe, topic);
+            SetSocketOption(ZmqSocketOption.Subscribe, topic);
         }
 
         [Obsolete("Do not use this method if the socket is different from Subscriber and XSubscriber")]
         public virtual void Unsubscribe(string topic)
         {
-            SetSocketOption(ZmqSocketOptions.Unsubscribe, topic);
+            SetSocketOption(ZmqSocketOption.Unsubscribe, topic);
         }
 
         [Obsolete("Do not use this method if the socket is different from Subscriber and XSubscriber")]
         public virtual void Unsubscribe(byte[] topic)
         {
-            SetSocketOption(ZmqSocketOptions.Unsubscribe, topic);
+            SetSocketOption(ZmqSocketOption.Unsubscribe, topic);
         }
 
         #endregion
@@ -418,7 +418,7 @@ namespace NetMQ
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
         public bool HasIn
         {
-            get { return GetSocketOptionX<PollEvents>(ZmqSocketOptions.Events).HasIn(); }
+            get { return GetSocketOptionX<PollEvents>(ZmqSocketOption.Events).HasIn(); }
         }
 
         /// <summary>
@@ -430,98 +430,98 @@ namespace NetMQ
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
         public bool HasOut
         {
-            get { return GetSocketOptionX<PollEvents>(ZmqSocketOptions.Events).HasOut(); }
+            get { return GetSocketOptionX<PollEvents>(ZmqSocketOption.Events).HasOut(); }
         }
 
         #region Socket options
 
         /// <summary>
-        /// Get the integer-value of the specified <see cref="ZmqSocketOptions"/>.
+        /// Get the integer-value of the specified <see cref="ZmqSocketOption"/>.
         /// </summary>
-        /// <param name="socketOptions">a ZmqSocketOptions that specifies what to get</param>
+        /// <param name="option">a ZmqSocketOption that specifies what to get</param>
         /// <returns>an integer that is the value of that option</returns>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
         /// <exception cref="ObjectDisposedException">This object is already disposed.</exception>
-        internal int GetSocketOption(ZmqSocketOptions socketOptions)
+        internal int GetSocketOption(ZmqSocketOption option)
         {
             m_socketHandle.CheckDisposed();
 
-            return m_socketHandle.GetSocketOption(socketOptions);
+            return m_socketHandle.GetSocketOption(option);
         }
 
         /// <summary>
-        /// Get the (generically-typed) value of the specified <see cref="ZmqSocketOptions"/>.
+        /// Get the (generically-typed) value of the specified <see cref="ZmqSocketOption"/>.
         /// </summary>
-        /// <param name="socketOptions">a ZmqSocketOptions that specifies what to get</param>
+        /// <param name="option">a ZmqSocketOption that specifies what to get</param>
         /// <returns>an object of the given type, that is the value of that option</returns>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
         /// <exception cref="ObjectDisposedException">This object is already disposed.</exception>
-        internal T GetSocketOptionX<T>(ZmqSocketOptions socketOptions)
+        internal T GetSocketOptionX<T>(ZmqSocketOption option)
         {
             m_socketHandle.CheckDisposed();
 
-            return (T)m_socketHandle.GetSocketOptionX(socketOptions);
+            return (T)m_socketHandle.GetSocketOptionX(option);
         }
 
         /// <summary>
-        /// Get the <see cref="TimeSpan"/> value of the specified ZmqSocketOptions.
+        /// Get the <see cref="TimeSpan"/> value of the specified ZmqSocketOption.
         /// </summary>
-        /// <param name="socketOptions">a ZmqSocketOptions that specifies what to get</param>
+        /// <param name="option">a ZmqSocketOption that specifies what to get</param>
         /// <returns>a TimeSpan that is the value of that option</returns>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
-        internal TimeSpan GetSocketOptionTimeSpan(ZmqSocketOptions socketOptions)
+        internal TimeSpan GetSocketOptionTimeSpan(ZmqSocketOption option)
         {
-            return TimeSpan.FromMilliseconds(GetSocketOption(socketOptions));
+            return TimeSpan.FromMilliseconds(GetSocketOption(option));
         }
 
         /// <summary>
-        /// Get the 64-bit integer-value of the specified <see cref="ZmqSocketOptions"/>.
+        /// Get the 64-bit integer-value of the specified <see cref="ZmqSocketOption"/>.
         /// </summary>
-        /// <param name="socketOptions">a ZmqSocketOptions that specifies what to get</param>
+        /// <param name="option">a ZmqSocketOption that specifies what to get</param>
         /// <returns>a long that is the value of that option</returns>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
-        internal long GetSocketOptionLong(ZmqSocketOptions socketOptions)
+        internal long GetSocketOptionLong(ZmqSocketOption option)
         {
-            return GetSocketOptionX<long>(socketOptions);
+            return GetSocketOptionX<long>(option);
         }
 
         /// <summary>
-        /// Assign the given integer value to the specified <see cref="ZmqSocketOptions"/>.
+        /// Assign the given integer value to the specified <see cref="ZmqSocketOption"/>.
         /// </summary>
-        /// <param name="socketOptions">a ZmqSocketOptions that specifies what to set</param>
+        /// <param name="option">a ZmqSocketOption that specifies what to set</param>
         /// <param name="value">an integer that is the value to set that option to</param>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
         /// <exception cref="ObjectDisposedException">This object is already disposed.</exception>
-        internal void SetSocketOption(ZmqSocketOptions socketOptions, int value)
+        internal void SetSocketOption(ZmqSocketOption option, int value)
         {
             m_socketHandle.CheckDisposed();
 
-            m_socketHandle.SetSocketOption(socketOptions, value);
+            m_socketHandle.SetSocketOption(option, value);
         }
 
         /// <summary>
-        /// Assign the given TimeSpan to the specified <see cref="ZmqSocketOptions"/>.
+        /// Assign the given TimeSpan to the specified <see cref="ZmqSocketOption"/>.
         /// </summary>
-        /// <param name="socketOptions">a ZmqSocketOptions that specifies what to set</param>
+        /// <param name="option">a ZmqSocketOption that specifies what to set</param>
         /// <param name="value">a TimeSpan that is the value to set that option to</param>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
-        internal void SetSocketOptionTimeSpan(ZmqSocketOptions socketOptions, TimeSpan value)
+        internal void SetSocketOptionTimeSpan(ZmqSocketOption option, TimeSpan value)
         {
-            SetSocketOption(socketOptions, (int)value.TotalMilliseconds);
+            SetSocketOption(option, (int)value.TotalMilliseconds);
         }
 
         /// <summary>
-        /// Assign the given Object value to the specified <see cref="ZmqSocketOptions"/>.
+        /// Assign the given Object value to the specified <see cref="ZmqSocketOption"/>.
         /// </summary>
-        /// <param name="socketOptions">a ZmqSocketOptions that specifies what to set</param>
+        /// <param name="option">a ZmqSocketOption that specifies what to set</param>
         /// <param name="value">an object that is the value to set that option to</param>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
         /// <exception cref="ObjectDisposedException">This object is already disposed.</exception>
-        internal void SetSocketOption(ZmqSocketOptions socketOptions, object value)
+        internal void SetSocketOption(ZmqSocketOption option, object value)
         {
             m_socketHandle.CheckDisposed();
 
-            m_socketHandle.SetSocketOption(socketOptions, value);
+            m_socketHandle.SetSocketOption(option, value);
         }
 
         #endregion

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -33,8 +33,8 @@ namespace NetMQ
         /// </summary>
         public long Affinity
         {
-            get { return m_socket.GetSocketOptionLong(ZmqSocketOptions.Affinity); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.Affinity, value); }
+            get { return m_socket.GetSocketOptionLong(ZmqSocketOption.Affinity); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.Affinity, value); }
         }
 
         [Obsolete("This property doesn't effect NetMQ anymore")]
@@ -47,27 +47,27 @@ namespace NetMQ
         public byte[] Identity
         {
             [CanBeNull]
-            get { return m_socket.GetSocketOptionX<byte[]>(ZmqSocketOptions.Identity); }
+            get { return m_socket.GetSocketOptionX<byte[]>(ZmqSocketOption.Identity); }
             [NotNull]
-            set { m_socket.SetSocketOption(ZmqSocketOptions.Identity, value); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.Identity, value); }
         }
 
         public int MulticastRate
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.Rate); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.Rate, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOption.Rate); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.Rate, value); }
         }
 
         public TimeSpan MulticastRecoveryInterval
         {
-            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOptions.ReconnectIvl); }
-            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.ReconnectIvl, value); }
+            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOption.ReconnectIvl); }
+            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOption.ReconnectIvl, value); }
         }
 
         public int SendBuffer
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.SendBuffer); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.SendBuffer, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOption.SendBuffer); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.SendBuffer, value); }
         }
 
         [Obsolete("Use ReceiveBuffer instead")]
@@ -79,8 +79,8 @@ namespace NetMQ
 
         public int ReceiveBuffer
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.ReceiveBuffer); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.ReceiveBuffer, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOption.ReceiveBuffer); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.ReceiveBuffer, value); }
         }
 
         /// <summary>
@@ -89,37 +89,37 @@ namespace NetMQ
         /// <value><c>true</c> if receive more; otherwise, <c>false</c>.</value>
         public bool ReceiveMore
         {
-            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.ReceiveMore); }
+            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOption.ReceiveMore); }
         }
 
         public TimeSpan Linger
         {
-            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOptions.Linger); }
-            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.Linger, value); }
+            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOption.Linger); }
+            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOption.Linger, value); }
         }
 
         public TimeSpan ReconnectInterval
         {
-            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOptions.ReconnectIvl); }
-            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.ReconnectIvl, value); }
+            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOption.ReconnectIvl); }
+            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOption.ReconnectIvl, value); }
         }
 
         public TimeSpan ReconnectIntervalMax
         {
-            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOptions.ReconnectIvlMax); }
-            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.ReconnectIvlMax, value); }
+            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOption.ReconnectIvlMax); }
+            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOption.ReconnectIvlMax, value); }
         }
 
         public int Backlog
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.Backlog); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.Backlog, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOption.Backlog); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.Backlog, value); }
         }
 
         public long MaxMsgSize
         {
-            get { return m_socket.GetSocketOptionLong(ZmqSocketOptions.MaxMessageSize); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.MaxMessageSize, value); }
+            get { return m_socket.GetSocketOptionLong(ZmqSocketOption.MaxMessageSize); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.MaxMessageSize, value); }
         }
 
         /// <summary>
@@ -130,8 +130,8 @@ namespace NetMQ
         /// </summary>
         public int SendHighWatermark
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.SendHighWatermark); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.SendHighWatermark, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOption.SendHighWatermark); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.SendHighWatermark, value); }
         }
 
         /// <summary>
@@ -142,33 +142,33 @@ namespace NetMQ
         /// </summary>
         public int ReceiveHighWatermark
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.ReceiveHighWatermark); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.ReceiveHighWatermark, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOption.ReceiveHighWatermark); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.ReceiveHighWatermark, value); }
         }
 
         public int MulticastHops
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.MulticastHops); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.MulticastHops, value); }
+            get { return m_socket.GetSocketOption(ZmqSocketOption.MulticastHops); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.MulticastHops, value); }
         }
 
         [Obsolete("Pass a TimeSpan value directly to socket receive methods instead.")]
         public TimeSpan ReceiveTimeout
         {
-            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOptions.ReceiveTimeout); }
-            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.ReceiveTimeout, value); }
+            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOption.ReceiveTimeout); }
+            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOption.ReceiveTimeout, value); }
         }
 
         public TimeSpan SendTimeout
         {
-            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOptions.SendTimeout); }
-            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.SendTimeout, value); }
+            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOption.SendTimeout); }
+            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOption.SendTimeout, value); }
         }
 
         public bool IPv4Only
         {
-            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.IPv4Only); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.IPv4Only, value); }
+            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOption.IPv4Only); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.IPv4Only, value); }
         }
 
         [Obsolete("Use LastEndpoint instead")]
@@ -181,71 +181,71 @@ namespace NetMQ
         [CanBeNull]
         public string LastEndpoint
         {
-            get { return m_socket.GetSocketOptionX<string>(ZmqSocketOptions.LastEndpoint); }
+            get { return m_socket.GetSocketOptionX<string>(ZmqSocketOption.LastEndpoint); }
         }
 
         public bool RouterMandatory
         {
-            set { m_socket.SetSocketOption(ZmqSocketOptions.RouterMandatory, value); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.RouterMandatory, value); }
         }
 
         public bool TcpKeepalive
         {
-            get { return m_socket.GetSocketOption(ZmqSocketOptions.TcpKeepalive) == 1; }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.TcpKeepalive, value ? 1 : 0); }
+            get { return m_socket.GetSocketOption(ZmqSocketOption.TcpKeepalive) == 1; }
+            set { m_socket.SetSocketOption(ZmqSocketOption.TcpKeepalive, value ? 1 : 0); }
         }
 
         [Obsolete("This option is not supported and has no effect")]
         public int TcpKeepaliveCnt
         {
-            set { /* m_socket.SetSocketOption(ZmqSocketOptions.TcpKeepaliveCnt, value); */ }
+            set { /* m_socket.SetSocketOption(ZmqSocketOption.TcpKeepaliveCnt, value); */ }
         }
 
         public TimeSpan TcpKeepaliveIdle
         {
-            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOptions.TcpKeepaliveIdle); }
-            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.TcpKeepaliveIdle, value); }
+            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOption.TcpKeepaliveIdle); }
+            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOption.TcpKeepaliveIdle, value); }
         }
 
         public TimeSpan TcpKeepaliveInterval
         {
-            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOptions.TcpKeepaliveIntvl); }
-            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOptions.TcpKeepaliveIntvl, value); }
+            get { return m_socket.GetSocketOptionTimeSpan(ZmqSocketOption.TcpKeepaliveIntvl); }
+            set { m_socket.SetSocketOptionTimeSpan(ZmqSocketOption.TcpKeepaliveIntvl, value); }
         }
 
         [CanBeNull]
         public string TcpAcceptFilter
         {
             // TODO the logic here doesn't really suit a setter -- set values are appended to a list, and null clear that list
-            // get { return m_socket.GetSocketOptionX<string>(ZmqSocketOptions.TcpAcceptFilter); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.TcpAcceptFilter, value); }
+            // get { return m_socket.GetSocketOptionX<string>(ZmqSocketOption.TcpAcceptFilter); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.TcpAcceptFilter, value); }
         }
 
         public bool DelayAttachOnConnect
         {
-            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOptions.DelayAttachOnConnect); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.DelayAttachOnConnect, value); }
+            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOption.DelayAttachOnConnect); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.DelayAttachOnConnect, value); }
         }
 
         public bool XPubVerbose
         {
-            set { m_socket.SetSocketOption(ZmqSocketOptions.XpubVerbose, value); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.XpubVerbose, value); }
         }
 
         public bool RouterRawSocket
         {
-            set { m_socket.SetSocketOption(ZmqSocketOptions.RouterRawSocket, value); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.RouterRawSocket, value); }
         }
 
         public Endianness Endian
         {
-            get { return m_socket.GetSocketOptionX<Endianness>(ZmqSocketOptions.Endian); }
-            set { m_socket.SetSocketOption(ZmqSocketOptions.Endian, value); }
+            get { return m_socket.GetSocketOptionX<Endianness>(ZmqSocketOption.Endian); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.Endian, value); }
         }
 
         public bool ManualPublisher
         {
-            set { m_socket.SetSocketOption(ZmqSocketOptions.XPublisherManual, value); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.XPublisherManual, value); }
         }
     }
 }

--- a/src/NetMQ/Sockets/SubscriberSocket.cs
+++ b/src/NetMQ/Sockets/SubscriberSocket.cs
@@ -37,7 +37,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">this specifies what text-prefix to subscribe to, or may be an empty-string to specify ALL</param>
         public new virtual void Subscribe(string topic)
         {
-            SetSocketOption(ZmqSocketOptions.Subscribe, topic);
+            SetSocketOption(ZmqSocketOption.Subscribe, topic);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">this specifies what byte-array prefix to subscribe to</param>
         public new virtual void Subscribe(byte[] topic)
         {
-            SetSocketOption(ZmqSocketOptions.Subscribe, topic);
+            SetSocketOption(ZmqSocketOption.Subscribe, topic);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">a string denoting which the topic to stop receiving</param>
         public new virtual void Unsubscribe(string topic)
         {
-            SetSocketOption(ZmqSocketOptions.Unsubscribe, topic);
+            SetSocketOption(ZmqSocketOption.Unsubscribe, topic);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">a byte-array denoting which the topic to stop receiving</param>
         public new virtual void Unsubscribe(byte[] topic)
         {
-            SetSocketOption(ZmqSocketOptions.Unsubscribe, topic);
+            SetSocketOption(ZmqSocketOption.Unsubscribe, topic);
         }
     }
 }

--- a/src/NetMQ/Sockets/XPublisherSocket.cs
+++ b/src/NetMQ/Sockets/XPublisherSocket.cs
@@ -25,7 +25,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">a string specifying the Topic to subscribe to</param>
         public new virtual void Subscribe(string topic)
         {
-            SetSocketOption(ZmqSocketOptions.Subscribe, topic);
+            SetSocketOption(ZmqSocketOption.Subscribe, topic);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">a byte-array specifying the Topic to subscribe to</param>
         public new virtual void Subscribe(byte[] topic)
         {
-            SetSocketOption(ZmqSocketOptions.Subscribe, topic);
+            SetSocketOption(ZmqSocketOption.Subscribe, topic);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">a string specifying the Topic to unsubscribe from</param>
         public new virtual void Unsubscribe(string topic)
         {
-            SetSocketOption(ZmqSocketOptions.Unsubscribe, topic);
+            SetSocketOption(ZmqSocketOption.Unsubscribe, topic);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">a byte-array specifying the Topic to unsubscribe from</param>
         public new virtual void Unsubscribe(byte[] topic)
         {
-            SetSocketOption(ZmqSocketOptions.Unsubscribe, topic);
+            SetSocketOption(ZmqSocketOption.Unsubscribe, topic);
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace NetMQ.Sockets
         /// </summary>
         public void ClearWelcomeMessage()
         {
-            SetSocketOption(ZmqSocketOptions.XPublisherWelcomeMessage, null);
+            SetSocketOption(ZmqSocketOption.XPublisherWelcomeMessage, null);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace NetMQ.Sockets
         /// <param name="welcomeMessage">a byte-array denoting the new value for the welcome-message</param>
         public void SetWelcomeMessage(byte[] welcomeMessage)
         {
-            SetSocketOption(ZmqSocketOptions.XPublisherWelcomeMessage, welcomeMessage);
+            SetSocketOption(ZmqSocketOption.XPublisherWelcomeMessage, welcomeMessage);
         }
     }
 }

--- a/src/NetMQ/Sockets/XSubscriberSocket.cs
+++ b/src/NetMQ/Sockets/XSubscriberSocket.cs
@@ -27,7 +27,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">this specifies what text-prefix to subscribe to, or may be an empty-string to specify ALL</param>
         public new virtual void Subscribe(string topic)
         {
-            SetSocketOption(ZmqSocketOptions.Subscribe, topic);
+            SetSocketOption(ZmqSocketOption.Subscribe, topic);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">this specifies what byte-array prefix to subscribe to</param>
         public new virtual void Subscribe(byte[] topic)
         {
-            SetSocketOption(ZmqSocketOptions.Subscribe, topic);
+            SetSocketOption(ZmqSocketOption.Subscribe, topic);
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">a string denoting which the topic to stop receiving</param>
         public new virtual void Unsubscribe(string topic)
         {
-            SetSocketOption(ZmqSocketOptions.Unsubscribe, topic);
+            SetSocketOption(ZmqSocketOption.Unsubscribe, topic);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace NetMQ.Sockets
         /// <param name="topic">a byte-array denoting which the topic to stop receiving</param>
         public new virtual void Unsubscribe(byte[] topic)
         {
-            SetSocketOption(ZmqSocketOptions.Unsubscribe, topic);
+            SetSocketOption(ZmqSocketOption.Unsubscribe, topic);
         }
     }
 }

--- a/src/NetMQ/zmq/Enums.cs
+++ b/src/NetMQ/zmq/Enums.cs
@@ -98,13 +98,9 @@ namespace NetMQ.zmq
         Rate = 8,
         RecoveryIvl = 9,
         SendBuffer = 11,
-        [Obsolete("Use ReceiveBuffer instead")]
-        ReceivevBuffer = ReceiveBuffer,
         ReceiveBuffer = 12,
         ReceiveMore = 13,
 
-        [Obsolete("Use Handle")]
-        FD = 14,
         Handle = 14,
 
         Events = 15,
@@ -128,17 +124,11 @@ namespace NetMQ.zmq
         /// </summary>
         MaxMessageSize = 22,
 
-        [Obsolete("Use MaxMessageSize instead")]
-        Maxmsgsize = 22,
-
         /// <summary>
         /// The high-water mark for message transmission, which is the number of messages that are allowed to queue up
         /// before mitigative action is taken. The default value is 1000.
         /// </summary>
         SendHighWatermark = 23,
-
-        [Obsolete("Use ReceiveHighWatermark instead")]
-        ReceivevHighWatermark = ReceiveHighWatermark,
 
         /// <summary>
         /// The high-water mark for message reception, which is the number of messages that are allowed to queue up
@@ -163,8 +153,6 @@ namespace NetMQ.zmq
         LastEndpoint = 32,
         RouterMandatory = 33,
         TcpKeepalive = 34,
-        [Obsolete("Not supported and has no effect")]
-        TcpKeepaliveCnt = 35,
         TcpKeepaliveIdle = 36,
         TcpKeepaliveIntvl = 37,
         TcpAcceptFilter = 38,
@@ -177,13 +165,7 @@ namespace NetMQ.zmq
         /// <summary>
         /// Specifies the byte-order: big-endian, vs little-endian.
         /// </summary>
-        Endian = 1000,
-
-        [Obsolete]
-        FailUnroutable = RouterMandatory,
-
-        [Obsolete]
-        RouterBehavior = RouterMandatory
+        Endian = 1000
     }
 
     /// <summary>

--- a/src/NetMQ/zmq/Enums.cs
+++ b/src/NetMQ/zmq/Enums.cs
@@ -82,7 +82,7 @@ namespace NetMQ.zmq
     /// <summary>
     /// This enum-type serves to identity a particular socket-option.
     /// </summary>
-    internal enum ZmqSocketOptions
+    internal enum ZmqSocketOption
     {
         /// <summary>
         /// The I/O-thread affinity. This is a 64-bit value used to specify  which threads from the I/O thread-pool

--- a/src/NetMQ/zmq/Enums.cs
+++ b/src/NetMQ/zmq/Enums.cs
@@ -82,7 +82,7 @@ namespace NetMQ.zmq
     /// <summary>
     /// This enum-type serves to identity a particular socket-option.
     /// </summary>
-    public enum ZmqSocketOptions
+    internal enum ZmqSocketOptions
     {
         /// <summary>
         /// The I/O-thread affinity. This is a 64-bit value used to specify  which threads from the I/O thread-pool

--- a/src/NetMQ/zmq/Options.cs
+++ b/src/NetMQ/zmq/Options.cs
@@ -276,25 +276,25 @@ namespace NetMQ.zmq
         /// <summary>
         /// Assign the given optionValue to the specified option.
         /// </summary>
-        /// <param name="option">a ZmqSocketOptions that specifies what to set</param>
+        /// <param name="option">a ZmqSocketOption that specifies what to set</param>
         /// <param name="optionValue">an Object that is the value to set that option to</param>
-        public void SetSocketOption(ZmqSocketOptions option, Object optionValue)
+        public void SetSocketOption(ZmqSocketOption option, Object optionValue)
         {
             switch (option)
             {
-                case ZmqSocketOptions.SendHighWatermark:
+                case ZmqSocketOption.SendHighWatermark:
                     SendHighWatermark = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.ReceiveHighWatermark:
+                case ZmqSocketOption.ReceiveHighWatermark:
                     ReceiveHighWatermark = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.Affinity:
+                case ZmqSocketOption.Affinity:
                     Affinity = (long)optionValue;
                     break;
 
-                case ZmqSocketOptions.Identity:
+                case ZmqSocketOption.Identity:
                     byte[] val;
 
                     if (optionValue is string)
@@ -311,87 +311,87 @@ namespace NetMQ.zmq
                     IdentitySize = (byte)Identity.Length;
                     break;
 
-                case ZmqSocketOptions.Rate:
+                case ZmqSocketOption.Rate:
                     Rate = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.RecoveryIvl:
+                case ZmqSocketOption.RecoveryIvl:
                     RecoveryIvl = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.SendBuffer:
+                case ZmqSocketOption.SendBuffer:
                     SendBuffer = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.ReceiveBuffer:
+                case ZmqSocketOption.ReceiveBuffer:
                     ReceiveBuffer = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.Linger:
+                case ZmqSocketOption.Linger:
                     Linger = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.ReconnectIvl:
+                case ZmqSocketOption.ReconnectIvl:
                     var reconnectIvl = (int)optionValue;
                     if (reconnectIvl < -1)
                         throw new InvalidException(string.Format("Options.SetSocketOption(ReconnectIvl, {0}) optionValue must be >= -1.", reconnectIvl));
                     ReconnectIvl = reconnectIvl;
                     break;
 
-                case ZmqSocketOptions.ReconnectIvlMax:
+                case ZmqSocketOption.ReconnectIvlMax:
                     var reconnectIvlMax = (int)optionValue;
                     if (reconnectIvlMax < 0)
                         throw new InvalidException(string.Format("Options.SetSocketOption(ReconnectIvlMax, {0}) optionValue must be non-negative.", reconnectIvlMax));
                     ReconnectIvlMax = reconnectIvlMax;
                     break;
 
-                case ZmqSocketOptions.Backlog:
+                case ZmqSocketOption.Backlog:
                     Backlog = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.MaxMessageSize:
+                case ZmqSocketOption.MaxMessageSize:
                     MaxMessageSize = (long)optionValue;
                     break;
 
-                case ZmqSocketOptions.MulticastHops:
+                case ZmqSocketOption.MulticastHops:
                     MulticastHops = (int)optionValue;
                     break;
 
 // disable warning about obsolete values
 #pragma warning disable 618
-                case ZmqSocketOptions.ReceiveTimeout:
+                case ZmqSocketOption.ReceiveTimeout:
                     ReceiveTimeout = (int)optionValue;
 #pragma warning restore 618
                     break;
 
-                case ZmqSocketOptions.SendTimeout:
+                case ZmqSocketOption.SendTimeout:
                     SendTimeout = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.IPv4Only:
+                case ZmqSocketOption.IPv4Only:
                     IPv4Only = (bool)optionValue;
                     break;
 
-                case ZmqSocketOptions.TcpKeepalive:
+                case ZmqSocketOption.TcpKeepalive:
                     var tcpKeepalive = (int)optionValue;
                     if (tcpKeepalive != -1 && tcpKeepalive != 0 && tcpKeepalive != 1)
                         throw new InvalidException(string.Format("Options.SetSocketOption(TcpKeepalive, {0}) optionValue is neither -1, 0, nor 1.", tcpKeepalive));
                     TcpKeepalive = tcpKeepalive;
                     break;
 
-                case ZmqSocketOptions.DelayAttachOnConnect:
+                case ZmqSocketOption.DelayAttachOnConnect:
                     DelayAttachOnConnect = (bool)optionValue;
                     break;
 
-                case ZmqSocketOptions.TcpKeepaliveIdle:
+                case ZmqSocketOption.TcpKeepaliveIdle:
                     TcpKeepaliveIdle = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.TcpKeepaliveIntvl:
+                case ZmqSocketOption.TcpKeepaliveIntvl:
                     TcpKeepaliveIntvl = (int)optionValue;
                     break;
 
-                case ZmqSocketOptions.TcpAcceptFilter:
+                case ZmqSocketOption.TcpAcceptFilter:
                     var filterStr = (string)optionValue;
                     if (filterStr == null)
                     {
@@ -409,100 +409,100 @@ namespace NetMQ.zmq
                     }
                     break;
 
-                case ZmqSocketOptions.Endian:
+                case ZmqSocketOption.Endian:
                     Endian = (Endianness)optionValue;
                     break;
 
                 default:
-                    throw new InvalidException("Options.SetSocketOption called with invalid ZmqSocketOptions of " + option);
+                    throw new InvalidException("Options.SetSocketOption called with invalid ZmqSocketOption of " + option);
             }
         }
 
         /// <summary>
         /// Get the value of the specified option.
         /// </summary>
-        /// <param name="option">a ZmqSocketOptions that specifies what to get</param>
+        /// <param name="option">a ZmqSocketOption that specifies what to get</param>
         /// <returns>an Object that is the value of that option</returns>
-        public Object GetSocketOption(ZmqSocketOptions option)
+        public Object GetSocketOption(ZmqSocketOption option)
         {
             switch (option)
             {
-                case ZmqSocketOptions.SendHighWatermark:
+                case ZmqSocketOption.SendHighWatermark:
                     return SendHighWatermark;
 
-                case ZmqSocketOptions.ReceiveHighWatermark:
+                case ZmqSocketOption.ReceiveHighWatermark:
                     return ReceiveHighWatermark;
 
-                case ZmqSocketOptions.Affinity:
+                case ZmqSocketOption.Affinity:
                     return Affinity;
 
-                case ZmqSocketOptions.Identity:
+                case ZmqSocketOption.Identity:
                     return Identity;
 
-                case ZmqSocketOptions.Rate:
+                case ZmqSocketOption.Rate:
                     return Rate;
 
-                case ZmqSocketOptions.RecoveryIvl:
+                case ZmqSocketOption.RecoveryIvl:
                     return RecoveryIvl;
 
-                case ZmqSocketOptions.SendBuffer:
+                case ZmqSocketOption.SendBuffer:
                     return SendBuffer;
 
-                case ZmqSocketOptions.ReceiveBuffer:
+                case ZmqSocketOption.ReceiveBuffer:
                     return ReceiveBuffer;
 
-                case ZmqSocketOptions.Type:
+                case ZmqSocketOption.Type:
                     return SocketType;
 
-                case ZmqSocketOptions.Linger:
+                case ZmqSocketOption.Linger:
                     return Linger;
 
-                case ZmqSocketOptions.ReconnectIvl:
+                case ZmqSocketOption.ReconnectIvl:
                     return ReconnectIvl;
 
-                case ZmqSocketOptions.ReconnectIvlMax:
+                case ZmqSocketOption.ReconnectIvlMax:
                     return ReconnectIvlMax;
 
-                case ZmqSocketOptions.Backlog:
+                case ZmqSocketOption.Backlog:
                     return Backlog;
 
-                case ZmqSocketOptions.MaxMessageSize:
+                case ZmqSocketOption.MaxMessageSize:
                     return MaxMessageSize;
 
-                case ZmqSocketOptions.MulticastHops:
+                case ZmqSocketOption.MulticastHops:
                     return MulticastHops;
 
 #pragma warning disable 618
-                case ZmqSocketOptions.ReceiveTimeout:
+                case ZmqSocketOption.ReceiveTimeout:
                     return ReceiveTimeout;
 #pragma warning restore 618
 
-                case ZmqSocketOptions.SendTimeout:
+                case ZmqSocketOption.SendTimeout:
                     return SendTimeout;
 
-                case ZmqSocketOptions.IPv4Only:
+                case ZmqSocketOption.IPv4Only:
                     return IPv4Only;
 
-                case ZmqSocketOptions.TcpKeepalive:
+                case ZmqSocketOption.TcpKeepalive:
                     return TcpKeepalive;
 
-                case ZmqSocketOptions.DelayAttachOnConnect:
+                case ZmqSocketOption.DelayAttachOnConnect:
                     return DelayAttachOnConnect;
 
-                case ZmqSocketOptions.TcpKeepaliveIdle:
+                case ZmqSocketOption.TcpKeepaliveIdle:
                     return TcpKeepaliveIdle;
 
-                case ZmqSocketOptions.TcpKeepaliveIntvl:
+                case ZmqSocketOption.TcpKeepaliveIntvl:
                     return TcpKeepaliveIntvl;
 
-                case ZmqSocketOptions.LastEndpoint:
+                case ZmqSocketOption.LastEndpoint:
                     return LastEndpoint;
 
-                case ZmqSocketOptions.Endian:
+                case ZmqSocketOption.Endian:
                     return Endian;
 
                 default:
-                    throw new InvalidException("GetSocketOption called with invalid ZmqSocketOptions of " + option);
+                    throw new InvalidException("GetSocketOption called with invalid ZmqSocketOption of " + option);
             }
         }
     }

--- a/src/NetMQ/zmq/Patterns/Router.cs
+++ b/src/NetMQ/zmq/Patterns/Router.cs
@@ -170,9 +170,9 @@ namespace NetMQ.zmq.Patterns
         }
 
 
-        protected override bool XSetSocketOption(ZmqSocketOptions option, Object optval)
+        protected override bool XSetSocketOption(ZmqSocketOption option, Object optval)
         {
-            if (option == ZmqSocketOptions.RouterRawSocket)
+            if (option == ZmqSocketOption.RouterRawSocket)
             {
                 m_rawSocket = (bool)optval;
                 if (m_rawSocket)
@@ -184,7 +184,7 @@ namespace NetMQ.zmq.Patterns
                 return true;
             }
             
-            if (option == ZmqSocketOptions.RouterMandatory)
+            if (option == ZmqSocketOption.RouterMandatory)
             {
                 m_mandatory = (bool)optval;
                 return true;

--- a/src/NetMQ/zmq/Patterns/Sub.cs
+++ b/src/NetMQ/zmq/Patterns/Sub.cs
@@ -44,9 +44,9 @@ namespace NetMQ.zmq.Patterns
             m_options.Filter = true;
         }
 
-        protected override bool XSetSocketOption(ZmqSocketOptions option, Object optionValue)
+        protected override bool XSetSocketOption(ZmqSocketOption option, Object optionValue)
         {
-            if (option != ZmqSocketOptions.Subscribe && option != ZmqSocketOptions.Unsubscribe)
+            if (option != ZmqSocketOption.Subscribe && option != ZmqSocketOption.Unsubscribe)
             {
                 return false;
             }
@@ -63,9 +63,9 @@ namespace NetMQ.zmq.Patterns
             //  Create the subscription message.
             var msg = new Msg();
             msg.InitPool(val.Length + 1);
-            if (option == ZmqSocketOptions.Subscribe)
+            if (option == ZmqSocketOption.Subscribe)
                 msg.Put(1);
-            else if (option == ZmqSocketOptions.Unsubscribe)
+            else if (option == ZmqSocketOption.Unsubscribe)
                 msg.Put(0);
             msg.Put(val, 1, val.Length);
 

--- a/src/NetMQ/zmq/Patterns/XPub.cs
+++ b/src/NetMQ/zmq/Patterns/XPub.cs
@@ -184,19 +184,19 @@ namespace NetMQ.zmq.Patterns
             m_distribution.Activated(pipe);
         }
 
-        protected override bool XSetSocketOption(ZmqSocketOptions option, Object optionValue)
+        protected override bool XSetSocketOption(ZmqSocketOption option, Object optionValue)
         {
-            if (option == ZmqSocketOptions.XpubVerbose)
+            if (option == ZmqSocketOption.XpubVerbose)
             {
                 m_verbose = (bool)optionValue;
                 return true;
             }
-            else if (option == ZmqSocketOptions.XPublisherManual)
+            else if (option == ZmqSocketOption.XPublisherManual)
             {
                 m_manual = true;
                 return true;
             }
-            else if (option == ZmqSocketOptions.Subscribe && m_manual && m_lastPipe != null)
+            else if (option == ZmqSocketOption.Subscribe && m_manual && m_lastPipe != null)
             {
                 byte[] subscription;
 
@@ -212,7 +212,7 @@ namespace NetMQ.zmq.Patterns
                 m_subscriptions.Add(subscription, 0, subscription.Length, m_lastPipe);
                 return true;
             }
-            else if (option == ZmqSocketOptions.Unsubscribe && m_manual && m_lastPipe != null)
+            else if (option == ZmqSocketOption.Unsubscribe && m_manual && m_lastPipe != null)
             {
                 byte[] subscription;
 
@@ -228,7 +228,7 @@ namespace NetMQ.zmq.Patterns
                 m_subscriptions.Remove(subscription, 0, subscription.Length, m_lastPipe);
                 return true;
             }
-            else if (option == ZmqSocketOptions.XPublisherWelcomeMessage)
+            else if (option == ZmqSocketOption.XPublisherWelcomeMessage)
             {
                 m_welcomeMessage.Close();
 

--- a/src/NetMQ/zmq/SocketBase.cs
+++ b/src/NetMQ/zmq/SocketBase.cs
@@ -255,7 +255,7 @@ namespace NetMQ.zmq
         }
 
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
-        public void SetSocketOption(ZmqSocketOptions option, Object optval)
+        public void SetSocketOption(ZmqSocketOption option, Object optval)
         {
             CheckContextTerminated();
 
@@ -269,15 +269,15 @@ namespace NetMQ.zmq
         }
 
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
-        public int GetSocketOption(ZmqSocketOptions option)
+        public int GetSocketOption(ZmqSocketOption option)
         {
             CheckContextTerminated();
 
-            if (option == ZmqSocketOptions.ReceiveMore)
+            if (option == ZmqSocketOption.ReceiveMore)
             {
                 return m_rcvMore ? 1 : 0;
             }
-            if (option == ZmqSocketOptions.Events)
+            if (option == ZmqSocketOption.Events)
             {
                 try
                 {
@@ -300,21 +300,21 @@ namespace NetMQ.zmq
         }
 
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
-        public Object GetSocketOptionX(ZmqSocketOptions option)
+        public Object GetSocketOptionX(ZmqSocketOption option)
         {
             CheckContextTerminated();
 
-            if (option == ZmqSocketOptions.ReceiveMore)
+            if (option == ZmqSocketOption.ReceiveMore)
             {
                 return m_rcvMore;
             }
 
-            if (option == ZmqSocketOptions.Handle)
+            if (option == ZmqSocketOption.Handle)
             {
                 return m_mailbox.Handle;
             }
 
-            if (option == ZmqSocketOptions.Events)
+            if (option == ZmqSocketOption.Events)
             {
                 try
                 {
@@ -1026,9 +1026,9 @@ namespace NetMQ.zmq
         /// options for the particular socket type. If not so, overload this
         /// method.
         /// </summary>
-        /// <param name="option">a ZmqSocketOptions specifying which option to set</param>
+        /// <param name="option">a ZmqSocketOption specifying which option to set</param>
         /// <param name="optionValue">an Object that is the value to set the option to</param>
-        protected virtual bool XSetSocketOption(ZmqSocketOptions option, [CanBeNull] Object optionValue)
+        protected virtual bool XSetSocketOption(ZmqSocketOption option, [CanBeNull] Object optionValue)
         {
             return false;
         }
@@ -1202,7 +1202,7 @@ namespace NetMQ.zmq
 
             try
             {
-                m_monitorSocket.SetSocketOption(ZmqSocketOptions.Linger, linger);
+                m_monitorSocket.SetSocketOption(ZmqSocketOption.Linger, linger);
             }
             catch (NetMQException)
             {

--- a/src/NetMQ/zmq/Utils/Selector.cs
+++ b/src/NetMQ/zmq/Utils/Selector.cs
@@ -141,7 +141,7 @@ namespace NetMQ.zmq.Utils
 
                     if (selectItem.Socket != null)
                     {
-                        var events = (PollEvents)selectItem.Socket.GetSocketOption(ZmqSocketOptions.Events);
+                        var events = (PollEvents)selectItem.Socket.GetSocketOption(ZmqSocketOption.Events);
 
                         if (selectItem.Event.HasIn() && events.HasIn())
                             selectItem.ResultEvent |= PollEvents.PollIn;


### PR DESCRIPTION
No public API uses this enum. Plural names are for `[Flags]` enums ([see](https://msdn.microsoft.com/en-us/library/4x252001(v=vs.71).aspx)).
