### PR TITLE
Throw when external Poller with Proxy used in an invalid way.

### DIFF
--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -72,7 +72,6 @@ namespace NetMQ
 
         private readonly Selector m_selector = new Selector();
 
-        #region constructors
         /// <summary>
         /// Create a new Poller object, with a default PollTimeout of 1 second.
         /// </summary>
@@ -120,46 +119,6 @@ namespace NetMQ
                 AddTimer(timer);
             }
         }
-        #endregion constructors
-
-        #region Dispose
-        /// <summary>
-        /// Perform any freeing, releasing or resetting of contained resources.
-        /// If this poller is already started, signal the polling thread to stop - and block to wait for it.
-        /// </summary>
-        /// <remarks>
-        /// Calling this again after the first time, does nothing.
-        /// </remarks>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Perform any freeing, releasing or resetting of contained resources.
-        /// If this poller is already started, signal the polling thread to stop - and block to wait for it.
-        /// </summary>
-        /// <param name="disposing">true if releasing managed resources</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposing)
-                return;
-
-            if (!m_disposed)
-            {
-                // If this poller is already started, signal the polling thread to stop
-                // and wait for it.
-                if (m_isStarted)
-                    Cancel(true);
-
-                m_disposed = true;
-                m_isStoppedEvent.Close();
-            }
-        }
-        #endregion
-
-        #region public properties
 
         /// <summary>
         /// Get whether the polling has started.
@@ -174,10 +133,6 @@ namespace NetMQ
         /// Get or set the poll timeout in milliseconds.
         /// </summary>
         public int PollTimeout { get; set; }
-
-        #endregion public properties
-
-        #region public methods
 
         /// <summary>
         /// Add the given socket and Action to this Poller's collection of socket/actions.
@@ -407,10 +362,6 @@ namespace NetMQ
         {
             Cancel(true);
         }
-
-        #endregion public methods
-
-        #region internal implementation
 
         /// <summary>
         /// Handle the EventsChanged event of any of the sockets contained within this Poller,
@@ -668,6 +619,44 @@ namespace NetMQ
             }
         }
 
-        #endregion internal implementation
+
+        #region Dispose
+        
+        /// <summary>
+        /// Perform any freeing, releasing or resetting of contained resources.
+        /// If this poller is already started, signal the polling thread to stop - and block to wait for it.
+        /// </summary>
+        /// <remarks>
+        /// Calling this again after the first time, does nothing.
+        /// </remarks>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Perform any freeing, releasing or resetting of contained resources.
+        /// If this poller is already started, signal the polling thread to stop - and block to wait for it.
+        /// </summary>
+        /// <param name="disposing">true if releasing managed resources</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing)
+                return;
+
+            if (!m_disposed)
+            {
+                // If this poller is already started, signal the polling thread to stop
+                // and wait for it.
+                if (m_isStarted)
+                    Cancel(true);
+
+                m_disposed = true;
+                m_isStoppedEvent.Close();
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -619,6 +619,13 @@ namespace NetMQ
             }
         }
 
+        /// <summary>
+        /// Gets whether <paramref name="socket"/> has been added to this <see cref="Poller"/>.
+        /// </summary>
+        public bool ContainsSocket(NetMQSocket socket)
+        {
+            return m_sockets.Contains(socket);
+        }
 
         #region Dispose
         

--- a/src/NetMQ/Proxy.cs
+++ b/src/NetMQ/Proxy.cs
@@ -38,13 +38,21 @@ namespace NetMQ
         /// <param name="backend">the socket that messages will be forwarded to</param>
         /// <param name="control">this socket will have messages also sent to it - you can set this to null if not needed</param>
         /// <param name="poller">an optional external poller to use within this proxy</param>
+        /// <exception cref="InvalidOperationException"><paramref name="poller"/> is not <c>null</c> and either <paramref name="frontend"/> or <paramref name="backend"/> are not contained within it.</exception>
         public Proxy([NotNull] NetMQSocket frontend, [NotNull] NetMQSocket backend, [CanBeNull] NetMQSocket control = null, Poller poller = null)
         {
+            if (poller != null)
+            {
+                if (!poller.ContainsSocket(backend) || !poller.ContainsSocket(frontend))
+                    throw new InvalidOperationException("When using an external poller, both the frontend and backend sockets must be added to it.");
+
+                m_externalPoller = true;
+                m_poller = poller;
+            }
+
             m_frontend = frontend;
             m_backend = backend;
             m_control = control;
-            m_externalPoller = poller != null;
-            m_poller = poller;
         }
 
         /// <summary>


### PR DESCRIPTION
After introducing support for external pollers in #239/#250 I tried to use one again today and found myself confused about their use.

This PR triggers an exception if either of the proxy's frontend or backend sockets have not been added to an external poller.