### PR TITLE
Fixed invalid TimeSpan values which cause infinite timeout for polling t...

### DIFF
--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -887,14 +887,14 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="msg">the <c>Msg</c> to read the received message into</param>
         /// <remarks>
-        /// This calls <c>Recv(Msg, TimeSpan)</c> with a TimeSpan value of <c>TimeSpan.MinValue</c>.
+        /// This calls <c>Recv(Msg, TimeSpan)</c> with a TimeSpan value of -1 (ms).
         /// </remarks>
         /// <exception cref="AgainException">if there is no message ready to be received, this exception is thrown if DontWait is set or no receive-timeout is specified</exception>
         /// <exception cref="FaultException">the Msg must already have been uninitialised</exception>
         /// <exception cref="TerminatingException">The socket must not already be stopped.</exception>
         public void Recv(ref Msg msg)
         {
-            var res = Recv(ref msg, TimeSpan.MinValue);
+            var res = Recv(ref msg, TimeSpan.FromMilliseconds(-1));
 
             Debug.Assert(res);
         }

--- a/src/NetMQ/ReceivingSocketExtensions.cs
+++ b/src/NetMQ/ReceivingSocketExtensions.cs
@@ -24,7 +24,7 @@ namespace NetMQ
         public static readonly Encoding DefaultEncoding = Encoding.UTF8;
 
         /// <summary>Indicates an infinite timeout for receive operations.</summary>
-        public static readonly TimeSpan InfiniteTimeout = TimeSpan.FromTicks(-1);
+        public static readonly TimeSpan InfiniteTimeout = TimeSpan.FromMilliseconds(-1);
 
         /// <summary>
         /// Block until the next message arrives, then make the message's data available via <paramref name="msg"/>.


### PR DESCRIPTION
Fixed invalid TimeSpan values which cause infinite timeout for polling to become 0 or not -1 as expected with high cpu and memory pressure as side effect.
In one case FromTicks(-1) was used which didn't work properly as code down the callstack was using timeout.TotalMilliseconds with result of 0. In other case TimeSpan.MinValue was used with similar outcome but on Socket.Select or Socket.Poll methods. This problem is not going to be evident unless monitoring cpu usage or memory allocations, as no noticable functional issues seem to occur.
Issue was noticed on a single socket service with cpu spikes and 10mb/s memory allocs after updating to sought after implementation of TryRecieve methods.