### PR TITLE
Changed lists to use Count instead of Any

### DIFF
--- a/src/NetMQ/Core/Utils/PollerBase.cs
+++ b/src/NetMQ/Core/Utils/PollerBase.cs
@@ -178,7 +178,7 @@ namespace NetMQ.Core.Utils
         protected int ExecuteTimers()
         {
             // Immediately return 0 if there are no timers.
-            if (!m_timers.Any())
+            if (m_timers.Count == 0)
                 return 0;
 
             // Get the current time.

--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -558,7 +558,7 @@ namespace NetMQ
                         }
                     }
 
-                    if (m_zombies.Any())
+                    if (m_zombies.Count > 0)
                     {
                         // Now handle any timer zombies
                         // This is going to be slow if we have many zombies


### PR DESCRIPTION
While doing profiling usage of Any() surfaced as memory footprint in #Gen0. Since the support of explicit Count property is there it should be used instead.