### PR TITLE
Found that when running pub/sub sockets on a Raspberry PI subscription requests were never processed.

### DIFF
--- a/src/NetMQ/Core/Utils/Clock.cs
+++ b/src/NetMQ/Core/Utils/Clock.cs
@@ -23,90 +23,89 @@ using System.Diagnostics;
 
 namespace NetMQ.Core.Utils
 {
-    /// <summary>
-    /// The Clock class provides properties for getting timer-counts in either milliseconds or microseconds,
-    /// and the CPU's timestamp-counter if available.
-    /// </summary>
-    internal static class Clock
-    {
-        /// <summary>
-        /// TSC timestamp of when last time measurement was made.
-        /// </summary>
-        private static long s_lastTsc;
+	/// <summary>
+	/// The Clock class provides properties for getting timer-counts in either milliseconds or microseconds,
+	/// and the CPU's timestamp-counter if available.
+	/// </summary>
+	internal static class Clock
+	{
+		/// <summary>
+		/// TSC timestamp of when last time measurement was made.
+		/// </summary>
+		private static long s_lastTsc;
 
-        /// <summary>
-        /// Physical time corresponding to the TSC above (in milliseconds).
-        /// </summary>
-        private static long s_lastTime;
+		/// <summary>
+		/// Physical time corresponding to the TSC above (in milliseconds).
+		/// </summary>
+		private static long s_lastTime;
 
-        /// <summary>
-        /// This flag indicates whether the rdtsc instruction is supported on this platform.
-        /// </summary>
-        private static readonly bool s_rdtscSupported;
+		/// <summary>
+		/// This flag indicates whether the rdtsc instruction is supported on this platform.
+		/// </summary>
+		private static readonly bool s_rdtscSupported;
 
-        static Clock()
-        {
-            try
-            {
-                if (Environment.OSVersion.Platform == PlatformID.Win32NT ||
-                    Environment.OSVersion.Platform == PlatformID.Unix ||
-                    Environment.OSVersion.Platform == (PlatformID)128)
-                {
-                    Opcode.Open();
-                    s_rdtscSupported = true;
-                }
-                else
-                {
-                    s_rdtscSupported = false;
-                }
-            }
-            catch (Exception)
-            {
-                s_rdtscSupported = false;
-            }
-        }
+		static Clock()
+		{
+			try
+			{
+				if (Environment.OSVersion.Platform == PlatformID.Win32NT ||
+					Environment.OSVersion.Platform == PlatformID.Unix ||
+					Environment.OSVersion.Platform == (PlatformID)128)
+				{
+					s_rdtscSupported = Opcode.Open();
+				}
+				else
+				{
+					s_rdtscSupported = false;
+				}
+			}
+			catch (Exception)
+			{
+				s_rdtscSupported = false;
+			}
+		}
 
-        /// <summary>
-        /// Return the High-Precision timestamp, as a 64-bit integer that denotes microseconds.
-        /// </summary>
-        public static long NowUs()
-        {
-            long ticksPerSecond = Stopwatch.Frequency;
-            long tickCount = Stopwatch.GetTimestamp();
+		/// <summary>
+		/// Return the High-Precision timestamp, as a 64-bit integer that denotes microseconds.
+		/// </summary>
+		public static long NowUs()
+		{
+			long ticksPerSecond = Stopwatch.Frequency;
+			long tickCount = Stopwatch.GetTimestamp();
 
-            double ticksPerMicrosecond = ticksPerSecond / 1000000.0;
-            return (long)(tickCount / ticksPerMicrosecond);
-        }
+			double ticksPerMicrosecond = ticksPerSecond / 1000000.0;
+			return (long)(tickCount / ticksPerMicrosecond);
+		}
 
-        /// <summary>
-        /// Return the Low-Precision timestamp, as a 64-bit integer denoting milliseconds.
-        /// In tight loops generating it can be 10 to 100 times faster than the High-Precision timestamp.
-        /// </summary>
-        public static long NowMs()
-        {
-            long tsc = Rdtsc();
+		/// <summary>
+		/// Return the Low-Precision timestamp, as a 64-bit integer denoting milliseconds.
+		/// In tight loops generating it can be 10 to 100 times faster than the High-Precision timestamp.
+		/// </summary>
+		public static long NowMs()
+		{
+			long tsc = Rdtsc();
 
-            if (tsc == 0)
-            {
-                return NowUs() / 1000;
-            }
+			if (tsc == 0)
+			{
+				return NowUs() / 1000;
+			}
 
-            if (tsc - s_lastTsc <= Config.ClockPrecision / 2 && tsc >= s_lastTsc)
-            {
-                return s_lastTime;
-            }
+			if (tsc - s_lastTsc <= Config.ClockPrecision / 2 && tsc >= s_lastTsc)
+			{
+				return s_lastTime;
+			}
 
-            s_lastTsc = tsc;
-            s_lastTime = NowUs() / 1000;
-            return s_lastTime;
-        }
+			s_lastTsc = tsc;
+			s_lastTime = NowUs() / 1000;
+			return s_lastTime;
+		}
 
-        /// <summary>
-        /// Return the CPU's timestamp counter, or 0 if it's not available.
-        /// </summary>
-        public static long Rdtsc()
-        {
-            return s_rdtscSupported ? (long)Opcode.Rdtsc() : 0;
-        }
-    }
+		/// <summary>
+		/// Return the CPU's timestamp counter, or 0 if it's not available.
+		/// </summary>
+		public static long Rdtsc()
+		{
+			return s_rdtscSupported ? (long)Opcode.Rdtsc() : 0;
+		}
+	}
 }

--- a/src/NetMQ/Core/Utils/OpCode.cs
+++ b/src/NetMQ/Core/Utils/OpCode.cs
@@ -5,183 +5,173 @@ using JetBrains.Annotations;
 
 namespace NetMQ.Core.Utils
 {
-    internal static class Opcode
-    {
-        private static IntPtr s_codeBuffer;
-        private static ulong s_size;
-        private static bool s_isArm;
+	internal static class Opcode
+	{
+		private static IntPtr s_codeBuffer;
+		private static ulong s_size;
 
-        public static void Open()
-        {
-            var p = (int)Environment.OSVersion.Platform;
+		public static bool Open()
+		{
+			var p = (int)Environment.OSVersion.Platform;
 
-            byte[] rdtscCode = IntPtr.Size == 4 ? RDTSC_32 : RDTSC_64;
+			byte[] rdtscCode = IntPtr.Size == 4 ? RDTSC_32 : RDTSC_64;
 
-            s_size = (ulong)(rdtscCode.Length);
+			s_size = (ulong)(rdtscCode.Length);
 
-            if ((p == 4) || (p == 128))
-            {
-                // Unix
-                s_isArm = IsARMArchitecture();
-                if (s_isArm)
-                {
-                    Rdtsc = RdtscOnArm;
-                    return;
-                }
-                Assembly assembly = Assembly.Load("Mono.Posix");
+			if ((p == 4) || (p == 128))
+			{
+				// Unix
+				if (IsARMArchitecture()) return false;
 
-                Type syscall = assembly.GetType("Mono.Unix.Native.Syscall");
-                MethodInfo mmap = syscall.GetMethod("mmap");
+				Assembly assembly = Assembly.Load("Mono.Posix");
 
-                Type mmapProts = assembly.GetType("Mono.Unix.Native.MmapProts");
-                object mmapProtsParam = Enum.ToObject(mmapProts,
-                    (int)mmapProts.GetField("PROT_READ").GetValue(null) |
-                    (int)mmapProts.GetField("PROT_WRITE").GetValue(null) |
-                    (int)mmapProts.GetField("PROT_EXEC").GetValue(null));
+				Type syscall = assembly.GetType("Mono.Unix.Native.Syscall");
+				MethodInfo mmap = syscall.GetMethod("mmap");
 
-                Type mmapFlags = assembly.GetType("Mono.Unix.Native.MmapFlags");
-                object mmapFlagsParam = Enum.ToObject(mmapFlags,
-                    (int)mmapFlags.GetField("MAP_ANONYMOUS").GetValue(null) |
-                    (int)mmapFlags.GetField("MAP_PRIVATE").GetValue(null));
+				Type mmapProts = assembly.GetType("Mono.Unix.Native.MmapProts");
+				object mmapProtsParam = Enum.ToObject(mmapProts,
+					(int)mmapProts.GetField("PROT_READ").GetValue(null) |
+					(int)mmapProts.GetField("PROT_WRITE").GetValue(null) |
+					(int)mmapProts.GetField("PROT_EXEC").GetValue(null));
 
-                s_codeBuffer = (IntPtr)mmap.Invoke(null,
-                    new[] { IntPtr.Zero, s_size, mmapProtsParam, mmapFlagsParam, -1, 0 });
+				Type mmapFlags = assembly.GetType("Mono.Unix.Native.MmapFlags");
+				object mmapFlagsParam = Enum.ToObject(mmapFlags,
+					(int)mmapFlags.GetField("MAP_ANONYMOUS").GetValue(null) |
+					(int)mmapFlags.GetField("MAP_PRIVATE").GetValue(null));
 
-                if (s_codeBuffer == IntPtr.Zero || s_codeBuffer == (IntPtr)(-1))
-                {
-                    throw new InvalidOperationException("Mmap failed");
-                }
-            }
-            else
-            {
-                // Windows
-                s_codeBuffer = NativeMethods.VirtualAlloc(IntPtr.Zero,
-                    (UIntPtr)s_size, AllocationType.COMMIT | AllocationType.RESERVE,
-                    MemoryProtection.EXECUTE_READWRITE);
-            }
+				s_codeBuffer = (IntPtr)mmap.Invoke(null,
+					new[] { IntPtr.Zero, s_size, mmapProtsParam, mmapFlagsParam, -1, 0 });
 
-            Marshal.Copy(rdtscCode, 0, s_codeBuffer, rdtscCode.Length);
+				if (s_codeBuffer == IntPtr.Zero || s_codeBuffer == (IntPtr)(-1))
+				{
+					throw new InvalidOperationException("Mmap failed");
+				}
+			}
+			else
+			{
+				// Windows
+				s_codeBuffer = NativeMethods.VirtualAlloc(IntPtr.Zero,
+					(UIntPtr)s_size, AllocationType.COMMIT | AllocationType.RESERVE,
+					MemoryProtection.EXECUTE_READWRITE);
+			}
 
-            Rdtsc = Marshal.GetDelegateForFunctionPointer(
-                s_codeBuffer, typeof(RdtscDelegate)) as RdtscDelegate;
-        }
+			Marshal.Copy(rdtscCode, 0, s_codeBuffer, rdtscCode.Length);
 
-        private static bool IsARMArchitecture()
-        {
-            // force to load from mono gac
-            Assembly currentAssembly = Assembly.Load("Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756");
-            Type syscall = currentAssembly.GetType("Mono.Unix.Native.Syscall");
-            Type utsname = currentAssembly.GetType("Mono.Unix.Native.Utsname");
-            MethodInfo uname = syscall.GetMethod("uname");
-            object[] parameters = { null };
+			Rdtsc = Marshal.GetDelegateForFunctionPointer(s_codeBuffer, typeof(RdtscDelegate)) as RdtscDelegate;
 
-            var invokeResult = (int)uname.Invoke(null, parameters);
+			return true;
+		}
 
-            if (invokeResult != 0)
-                return false;
+		private static bool IsARMArchitecture()
+		{
+			// force to load from mono gac
+			Assembly currentAssembly = Assembly.Load("Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756");
+			Type syscall = currentAssembly.GetType("Mono.Unix.Native.Syscall");
+			Type utsname = currentAssembly.GetType("Mono.Unix.Native.Utsname");
+			MethodInfo uname = syscall.GetMethod("uname");
+			object[] parameters = { null };
 
-            var currentValues = parameters[0];
-            var machineValue = (string)utsname.GetField("machine").GetValue(currentValues);
-            return machineValue.ToLower().Contains("arm");
-        }
+			var invokeResult = (int)uname.Invoke(null, parameters);
 
-        public static void Close()
-        {
-            Rdtsc = null;
+			if (invokeResult != 0)
+				return false;
 
-            var p = (int)Environment.OSVersion.Platform;
-            if ((p == 4) || (p == 128))
-            { 
-                // Unix
-                Assembly assembly =
-                    Assembly.Load("Mono.Posix, Version=2.0.0.0, Culture=neutral, " +
-                    "PublicKeyToken=0738eb9f132ed756");
+			var currentValues = parameters[0];
+			var machineValue = (string)utsname.GetField("machine").GetValue(currentValues);
+			return machineValue.ToLower().Contains("arm");
+		}
 
-                Type syscall = assembly.GetType("Mono.Unix.Native.Syscall");
-                MethodInfo munmap = syscall.GetMethod("munmap");
-                munmap.Invoke(null, new object[] { s_codeBuffer, s_size });
+		public static void Close()
+		{
+			Rdtsc = null;
 
-            }
-            else
-            { 
-                // Windows
-                NativeMethods.VirtualFree(s_codeBuffer, UIntPtr.Zero, FreeType.RELEASE);
-            }
-        }
+			var p = (int)Environment.OSVersion.Platform;
+			if ((p == 4) || (p == 128))
+			{
+				// Unix
+				Assembly assembly =
+					Assembly.Load("Mono.Posix, Version=2.0.0.0, Culture=neutral, " +
+					"PublicKeyToken=0738eb9f132ed756");
 
-        private static ulong RdtscOnArm()
-        {
-            return (ulong)Environment.TickCount;
-        }
+				Type syscall = assembly.GetType("Mono.Unix.Native.Syscall");
+				MethodInfo munmap = syscall.GetMethod("munmap");
+				munmap.Invoke(null, new object[] { s_codeBuffer, s_size });
+			}
+			else
+			{
+				// Windows
+				NativeMethods.VirtualFree(s_codeBuffer, UIntPtr.Zero, FreeType.RELEASE);
+			}
+		}
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        public delegate ulong RdtscDelegate();
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		public delegate ulong RdtscDelegate();
 
-        [CanBeNull]
-        public static RdtscDelegate Rdtsc { get; private set; }
+		[CanBeNull]
+		public static RdtscDelegate Rdtsc { get; private set; }
 
-        // unsigned __int64 __stdcall rdtsc() {
-        //   return __rdtsc();
-        // }
+		// unsigned __int64 __stdcall rdtsc() {
+		//   return __rdtsc();
+		// }
 
-        private static readonly byte[] RDTSC_32 = {
+		private static readonly byte[] RDTSC_32 = {
             0x0F, 0x31,                     // rdtsc
             0xC3                            // ret
         };
 
-        private static readonly byte[] RDTSC_64 = {
+		private static readonly byte[] RDTSC_64 = {
             0x0F, 0x31,                     // rdtsc
             0x48, 0xC1, 0xE2, 0x20,         // shl rdx, 20h
             0x48, 0x0B, 0xC2,               // or rax, rdx
             0xC3                            // ret
         };
 
-        [Flags]
-        public enum AllocationType : uint
-        {
-            COMMIT = 0x1000,
-            RESERVE = 0x2000,
-            RESET = 0x80000,
-            LARGE_PAGES = 0x20000000,
-            PHYSICAL = 0x400000,
-            TOP_DOWN = 0x100000,
-            WRITE_WATCH = 0x200000
-        }
+		[Flags]
+		public enum AllocationType : uint
+		{
+			COMMIT = 0x1000,
+			RESERVE = 0x2000,
+			RESET = 0x80000,
+			LARGE_PAGES = 0x20000000,
+			PHYSICAL = 0x400000,
+			TOP_DOWN = 0x100000,
+			WRITE_WATCH = 0x200000
+		}
 
-        [Flags]
-        public enum MemoryProtection : uint
-        {
-            EXECUTE = 0x10,
-            EXECUTE_READ = 0x20,
-            EXECUTE_READWRITE = 0x40,
-            EXECUTE_WRITECOPY = 0x80,
-            NOACCESS = 0x01,
-            READONLY = 0x02,
-            READWRITE = 0x04,
-            WRITECOPY = 0x08,
-            GUARD = 0x100,
-            NOCACHE = 0x200,
-            WRITECOMBINE = 0x400
-        }
+		[Flags]
+		public enum MemoryProtection : uint
+		{
+			EXECUTE = 0x10,
+			EXECUTE_READ = 0x20,
+			EXECUTE_READWRITE = 0x40,
+			EXECUTE_WRITECOPY = 0x80,
+			NOACCESS = 0x01,
+			READONLY = 0x02,
+			READWRITE = 0x04,
+			WRITECOPY = 0x08,
+			GUARD = 0x100,
+			NOCACHE = 0x200,
+			WRITECOMBINE = 0x400
+		}
 
-        [Flags]
-        public enum FreeType
-        {
-            DECOMMIT = 0x4000,
-            RELEASE = 0x8000
-        }
+		[Flags]
+		public enum FreeType
+		{
+			DECOMMIT = 0x4000,
+			RELEASE = 0x8000
+		}
 
-        private static class NativeMethods
-        {
-            private const string Kernel = "kernel32.dll";
+		private static class NativeMethods
+		{
+			private const string Kernel = "kernel32.dll";
 
-            [DllImport(Kernel, CallingConvention = CallingConvention.Winapi)]
-            public static extern IntPtr VirtualAlloc(IntPtr lpAddress, UIntPtr dwSize,
-                AllocationType flAllocationType, MemoryProtection flProtect);
+			[DllImport(Kernel, CallingConvention = CallingConvention.Winapi)]
+			public static extern IntPtr VirtualAlloc(IntPtr lpAddress, UIntPtr dwSize,
+				AllocationType flAllocationType, MemoryProtection flProtect);
 
-            [DllImport(Kernel, CallingConvention = CallingConvention.Winapi)]
-            public static extern bool VirtualFree(IntPtr lpAddress, UIntPtr dwSize,
-                FreeType dwFreeType);
-        }
-    }
+			[DllImport(Kernel, CallingConvention = CallingConvention.Winapi)]
+			public static extern bool VirtualFree(IntPtr lpAddress, UIntPtr dwSize,
+				FreeType dwFreeType);
+		}
+	}
 }


### PR DESCRIPTION
Found that when running pub/sub sockets on a Raspberry PI subscription requests were never processed.

The root cause was that RdtscOnArm was returning tick counts (milliseconds) and the throttling code was expecting high-resolution CPU timings. This caused the socket to be throttled virtually indefinitely (MaxCommandDelay = 3000000 milliseconds).

Simplified the ARM detection code to instead just set s_rdtscSupported = false which disables the throttle checking for ARM processors and removed associated code that was no longer used.