### PR TITLE
Fixed timeout overflows on Selector and moved sleep to Poller.

### DIFF
--- a/src/NetMQ.Tests/BeaconTests.cs
+++ b/src/NetMQ.Tests/BeaconTests.cs
@@ -74,7 +74,7 @@ namespace NetMQ.Tests
 
                 // this should send one broadcast message and stop
                 speaker.Publish("Hello", s_publishInterval);
-
+                Thread.Sleep(10);
                 listener.Unsubscribe();
 
                 string peerName;

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -254,7 +254,7 @@ namespace NetMQ
         {
             SelectItem[] items = { new SelectItem(SocketHandle, pollEvents) };
 
-            m_selector.Select(items, 1, (int)timeout.TotalMilliseconds);
+            m_selector.Select(items, 1, (long)timeout.TotalMilliseconds);
             return items[0].ResultEvent;
         }
 


### PR DESCRIPTION
Fix for issue #319.
Changed parameter of Selector.Select to long so it is not that easy to overflow and now TimeSpan.MinValue and TimeSpan.MaxValue can be safely used, even for Ticks property. This can be further improved by normalizing all inputs to ticks (1 tick is 10 micros I think). This will remove the reason of overflow during multiplication by 1000 (numbers are not realistic though), but it could also allow to go below 1 ms min.

* Negative values are considered to be infinite (-1 for socket api).
* If for some reason a unusual large timeout value is used function will do its work in chunks of Int32.MaxValue microseconds (~35min) and not break prematurely.
* Sleep was moved to poller, it seems like the only reason for it was to make sure timers fire as scheduled without spinning if there are no sockets. Selector should not be making decision to sleep based on other type needs and only be concerned whether sockets to work with are available.