### PR TITLE
Bug fixes in use of EventDelegatorHelper<TArgs>

### DIFF
--- a/src/NetMQ.Tests/EventDelegatorTests.cs
+++ b/src/NetMQ.Tests/EventDelegatorTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace NetMQ.Tests
+{
+    [TestFixture]
+    public class EventDelegatorTests
+    {
+        private class Args<T> : EventArgs
+        {
+            public Args(T value)
+            {
+                Value = value;
+            }
+
+            public T Value { get; private set; }
+        }
+
+        private event EventHandler<Args<int>> Source;
+
+        [Test]
+        public void Basics()
+        {
+            EventHandler<Args<int>> sourceHandler = null;
+
+            var delegator = new EventDelegator<Args<double>>(
+                () => Source += sourceHandler,
+                () => Source -= sourceHandler);
+
+            sourceHandler = (sender, args) => delegator.Fire(this, new Args<double>(args.Value / 2.0));
+
+            Assert.IsNull(Source);
+
+            var value = 0.0;
+            var callCount = 0;
+
+            EventHandler<Args<double>> delegatorHandler
+                = (sender, args) =>
+                {
+                    value = args.Value;
+                    callCount++;
+                };
+
+            delegator.Event += delegatorHandler;
+
+            Assert.IsNotNull(Source);
+
+            Assert.AreEqual(0, callCount);
+
+            Source(this, new Args<int>(5));
+            Assert.AreEqual(2.5, value);
+            Assert.AreEqual(1, callCount);
+
+            Source(this, new Args<int>(12));
+            Assert.AreEqual(6.0, value);
+            Assert.AreEqual(2, callCount);
+
+            delegator.Event -= delegatorHandler;
+
+            Assert.IsNull(Source);
+        }
+    }
+}

--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ActorTests.cs" />
     <Compile Include="BeaconTests.cs" />
     <Compile Include="ByteArraySegmentTests.cs" />
+    <Compile Include="EventDelegatorTests.cs" />
     <Compile Include="ExceptionTests.cs" />
     <Compile Include="InProcActors\AccountJSON\Account.cs" />
     <Compile Include="InProcActors\AccountJSON\AccountAction.cs" />

--- a/src/NetMQ.Tests/NetMQ3.5.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ3.5.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="BeaconTests.cs" />
     <Compile Include="ByteArraySegmentTests.cs" />
     <Compile Include="Core\YQueueTests.cs" />
+    <Compile Include="EventDelegatorTests.cs" />
     <Compile Include="ExceptionTests.cs" />
     <Compile Include="MockBufferPool.cs" />
     <Compile Include="MsgTests.cs" />

--- a/src/NetMQ/EventDelegator.cs
+++ b/src/NetMQ/EventDelegator.cs
@@ -5,10 +5,13 @@ using JetBrains.Annotations;
 namespace NetMQ
 {
     /// <summary>
-    /// EventDelegator is an internal utility-class that, for a given EventArgs type,
-    /// registers two Actions for it - one to execute when the first handler is added, and the other when the last handler is removed.
+    /// Facilitates a pattern whereby an event may be decorated with logic that transforms its arguments.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <remarks>
+    /// Use of this class requires providing actions that register and unregister a handler of the source
+    /// event that calls <see cref="Fire"/> with updated arguments in response.
+    /// </remarks>
+    /// <typeparam name="T">Argument type of the decorated event.</typeparam>
     internal class EventDelegator<T> where T : EventArgs
     {
         private readonly Action m_registerToEvent;

--- a/src/NetMQ/EventDelegator.cs
+++ b/src/NetMQ/EventDelegator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using JetBrains.Annotations;
 
 namespace NetMQ
 {
@@ -20,7 +21,7 @@ namespace NetMQ
         /// </summary>
         /// <param name="registerToEvent">an Action to perform when the first handler is registered for the event</param>
         /// <param name="unregisterFromEvent">an Action to perform when the last handler is unregistered from the event</param>
-        public EventDelegator(Action registerToEvent, Action unregisterFromEvent)
+        public EventDelegator([NotNull] Action registerToEvent, [NotNull] Action unregisterFromEvent)
         {
             m_registerToEvent = registerToEvent;
             m_unregisterFromEvent = unregisterFromEvent;
@@ -49,7 +50,7 @@ namespace NetMQ
         /// </summary>
         /// <param name="sender">the sender that the event-handler that gets notified of this event will receive</param>
         /// <param name="args">the subclass of EventArgs that the event-handler will receive</param>
-        public void Fire(object sender, T args)
+        public void Fire([NotNull] object sender, [NotNull] T args)
         {
             var temp = m_event;
             if (temp != null)

--- a/src/NetMQ/EventDelegator.cs
+++ b/src/NetMQ/EventDelegator.cs
@@ -4,11 +4,11 @@ using System.Threading;
 namespace NetMQ
 {
     /// <summary>
-    /// EventDelegatorHelper is an internal utility-class that, for a given EventArgs type,
+    /// EventDelegator is an internal utility-class that, for a given EventArgs type,
     /// registers two Actions for it - one to execute when the first handler is added, and the other when the last handler is removed.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal class EventDelegatorHelper<T> where T : EventArgs
+    internal class EventDelegator<T> where T : EventArgs
     {
         private readonly Action m_registerToEvent;
         private readonly Action m_unregisterFromEvent;
@@ -16,11 +16,11 @@ namespace NetMQ
         private int m_counter;
 
         /// <summary>
-        /// Create a new EventDelegatorHelper with the given Actions.
+        /// Initialises a new instance.
         /// </summary>
         /// <param name="registerToEvent">an Action to perform when the first handler is registered for the event</param>
         /// <param name="unregisterFromEvent">an Action to perform when the last handler is unregistered from the event</param>
-        public EventDelegatorHelper(Action registerToEvent, Action unregisterFromEvent)
+        public EventDelegator(Action registerToEvent, Action unregisterFromEvent)
         {
             m_registerToEvent = registerToEvent;
             m_unregisterFromEvent = unregisterFromEvent;

--- a/src/NetMQ/EventDelegator.cs
+++ b/src/NetMQ/EventDelegator.cs
@@ -12,7 +12,7 @@ namespace NetMQ
     /// event that calls <see cref="Fire"/> with updated arguments in response.
     /// </remarks>
     /// <typeparam name="T">Argument type of the decorated event.</typeparam>
-    internal class EventDelegator<T> where T : EventArgs
+    internal class EventDelegator<T> : IDisposable where T : EventArgs
     {
         private readonly Action m_registerToEvent;
         private readonly Action m_unregisterFromEvent;
@@ -59,6 +59,15 @@ namespace NetMQ
             if (temp != null)
             {
                 temp(sender, args);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (m_counter != 0)
+            {
+                m_unregisterFromEvent();
+                m_counter = 0;
             }
         }
     }

--- a/src/NetMQ/EventDelegator.cs
+++ b/src/NetMQ/EventDelegator.cs
@@ -42,7 +42,7 @@ namespace NetMQ
             {
                 m_event -= value;
 
-                m_counter++;
+                m_counter--;
 
                 if (m_counter == 0)
                 {

--- a/src/NetMQ/EventDelegator.cs
+++ b/src/NetMQ/EventDelegator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace NetMQ
 {
@@ -31,23 +32,15 @@ namespace NetMQ
             {
                 m_event += value;
 
-                if (m_counter == 0)
-                {
+                if (Interlocked.Increment(ref m_counter) == 1)
                     m_registerToEvent();
-                }
-
-                m_counter++;
             }
             remove
             {
                 m_event -= value;
 
-                m_counter--;
-
-                if (m_counter == 0)
-                {
+                if (Interlocked.Decrement(ref m_counter) == 0)
                     m_unregisterFromEvent();
-                }
             }
         }
 

--- a/src/NetMQ/InProcActors/Actor.cs
+++ b/src/NetMQ/InProcActors/Actor.cs
@@ -199,6 +199,8 @@ namespace NetMQ.Actors
 
             m_shimTask.Wait();
             m_self.Dispose();
+            m_sendEvent.Dispose();
+            m_receiveEvent.Dispose();
         }
 
         #region IOutgoingSocket

--- a/src/NetMQ/InProcActors/Actor.cs
+++ b/src/NetMQ/InProcActors/Actor.cs
@@ -65,13 +65,19 @@ namespace NetMQ.Actors
             m_self.Options.SendHighWatermark = 1000;
             m_self.Options.SendHighWatermark = 1000;
 
+            EventHandler<NetMQSocketEventArgs> onReceive = (sender, e) =>
+                m_receiveEvent.Fire(this, new NetMQActorEventArgs<T>(this));
+
+            EventHandler<NetMQSocketEventArgs> onSend = (sender, e) =>
+                m_sendEvent.Fire(this, new NetMQActorEventArgs<T>(this));
+
             m_receiveEvent = new EventDelegator<NetMQActorEventArgs<T>>(
-                () => m_self.ReceiveReady += OnReceive,
-                () => m_self.ReceiveReady -= OnReceive);
+                () => m_self.ReceiveReady += onReceive,
+                () => m_self.ReceiveReady -= onReceive);
 
             m_sendEvent = new EventDelegator<NetMQActorEventArgs<T>>(
-                () => m_self.SendReady += OnSend,
-                () => m_self.SendReady -= OnSend);
+                () => m_self.SendReady += onSend,
+                () => m_self.SendReady -= onSend);
 
             //now binding and connect pipe ends
             string endPoint = string.Empty;
@@ -142,16 +148,6 @@ namespace NetMQ.Actors
         NetMQSocket ISocketPollable.Socket
         {
             get { return m_self; }
-        }
-
-        private void OnReceive(object sender, NetMQSocketEventArgs e)
-        {
-            m_receiveEvent.Fire(this, new NetMQActorEventArgs<T>(this));
-        }
-
-        private void OnSend(object sender, NetMQSocketEventArgs e)
-        {
-            m_sendEvent.Fire(this, new NetMQActorEventArgs<T>(this));
         }
 
         private void CreateShimThread()

--- a/src/NetMQ/InProcActors/Actor.cs
+++ b/src/NetMQ/InProcActors/Actor.cs
@@ -42,8 +42,8 @@ namespace NetMQ.Actors
         private readonly PairSocket m_self;
         private readonly Shim<T> m_shim;
         private Task m_shimTask;
-        private readonly EventDelegatorHelper<NetMQActorEventArgs<T>> m_receiveEventDelegatorHelper;
-        private readonly EventDelegatorHelper<NetMQActorEventArgs<T>> m_sendEventDelegatorHelper;
+        private readonly EventDelegator<NetMQActorEventArgs<T>> m_receiveEvent;
+        private readonly EventDelegator<NetMQActorEventArgs<T>> m_sendEvent;
 
         [NotNull]
         private static string GetEndPointName()
@@ -65,11 +65,11 @@ namespace NetMQ.Actors
             m_self.Options.SendHighWatermark = 1000;
             m_self.Options.SendHighWatermark = 1000;
 
-            m_receiveEventDelegatorHelper = new EventDelegatorHelper<NetMQActorEventArgs<T>>(
+            m_receiveEvent = new EventDelegator<NetMQActorEventArgs<T>>(
                 () => m_self.ReceiveReady += OnReceive,
                 () => m_self.ReceiveReady -= OnReceive);
 
-            m_sendEventDelegatorHelper = new EventDelegatorHelper<NetMQActorEventArgs<T>>(
+            m_sendEvent = new EventDelegator<NetMQActorEventArgs<T>>(
                 () => m_self.SendReady += OnSend,
                 () => m_self.SendReady -= OnSend);
 
@@ -126,8 +126,8 @@ namespace NetMQ.Actors
         /// </summary>
         public event EventHandler<NetMQActorEventArgs<T>> ReceiveReady
         {
-            add { m_receiveEventDelegatorHelper.Event += value; }
-            remove { m_receiveEventDelegatorHelper.Event -= value; }
+            add { m_receiveEvent.Event += value; }
+            remove { m_receiveEvent.Event -= value; }
         }
 
         /// <summary>
@@ -135,8 +135,8 @@ namespace NetMQ.Actors
         /// </summary>
         public event EventHandler<NetMQActorEventArgs<T>> SendReady
         {
-            add { m_sendEventDelegatorHelper.Event += value; }
-            remove { m_sendEventDelegatorHelper.Event -= value; }
+            add { m_sendEvent.Event += value; }
+            remove { m_sendEvent.Event -= value; }
         }
 
         NetMQSocket ISocketPollable.Socket
@@ -146,12 +146,12 @@ namespace NetMQ.Actors
 
         private void OnReceive(object sender, NetMQSocketEventArgs e)
         {
-            m_receiveEventDelegatorHelper.Fire(this, new NetMQActorEventArgs<T>(this));
+            m_receiveEvent.Fire(this, new NetMQActorEventArgs<T>(this));
         }
 
         private void OnSend(object sender, NetMQSocketEventArgs e)
         {
-            m_sendEventDelegatorHelper.Fire(this, new NetMQActorEventArgs<T>(this));
+            m_sendEvent.Fire(this, new NetMQActorEventArgs<T>(this));
         }
 
         private void CreateShimThread()

--- a/src/NetMQ/InProcActors/Actor.cs
+++ b/src/NetMQ/InProcActors/Actor.cs
@@ -67,10 +67,11 @@ namespace NetMQ.Actors
 
             m_receiveEventDelegatorHelper = new EventDelegatorHelper<NetMQActorEventArgs<T>>(
                 () => m_self.ReceiveReady += OnReceive,
-                () => m_self.ReceiveReady += OnReceive);
+                () => m_self.ReceiveReady -= OnReceive);
+
             m_sendEventDelegatorHelper = new EventDelegatorHelper<NetMQActorEventArgs<T>>(
-                () => m_self.SendReady += OnReceive,
-                () => m_self.SendReady += OnSend);
+                () => m_self.SendReady += OnSend,
+                () => m_self.SendReady -= OnSend);
 
             //now binding and connect pipe ends
             string endPoint = string.Empty;

--- a/src/NetMQ/NetMQActor.cs
+++ b/src/NetMQ/NetMQActor.cs
@@ -139,11 +139,11 @@ namespace NetMQ
 
             m_receiveEventDelegatorHelper = new EventDelegatorHelper<NetMQActorEventArgs>(
                 () => m_self.ReceiveReady += OnReceive,
-                () => m_self.ReceiveReady += OnReceive);
+                () => m_self.ReceiveReady -= OnReceive);
 
             m_sendEventDelegatorHelper = new EventDelegatorHelper<NetMQActorEventArgs>(
-                () => m_self.SendReady += OnReceive,
-                () => m_self.SendReady += OnSend);
+                () => m_self.SendReady += OnSend,
+                () => m_self.SendReady -= OnSend);
 
             var random = new Random();
 

--- a/src/NetMQ/NetMQActor.cs
+++ b/src/NetMQ/NetMQActor.cs
@@ -137,13 +137,19 @@ namespace NetMQ
             m_self = context.CreatePairSocket();
             m_shim = context.CreatePairSocket();
 
+            EventHandler<NetMQSocketEventArgs> onReceive = (sender, e) =>
+                m_receiveEvent.Fire(this, new NetMQActorEventArgs(this));
+
+            EventHandler<NetMQSocketEventArgs> onSend = (sender, e) =>
+                m_sendEvent.Fire(this, new NetMQActorEventArgs(this));
+
             m_receiveEvent = new EventDelegator<NetMQActorEventArgs>(
-                () => m_self.ReceiveReady += OnReceive,
-                () => m_self.ReceiveReady -= OnReceive);
+                () => m_self.ReceiveReady += onReceive,
+                () => m_self.ReceiveReady -= onReceive);
 
             m_sendEvent = new EventDelegator<NetMQActorEventArgs>(
-                () => m_self.SendReady += OnSend,
-                () => m_self.SendReady -= OnSend);
+                () => m_self.SendReady += onSend,
+                () => m_self.SendReady -= onSend);
 
             var random = new Random();
 
@@ -296,16 +302,6 @@ namespace NetMQ
         NetMQSocket ISocketPollable.Socket
         {
             get { return m_self; }
-        }
-
-        private void OnReceive(object sender, NetMQSocketEventArgs e)
-        {
-            m_receiveEvent.Fire(this, new NetMQActorEventArgs(this));
-        }
-
-        private void OnSend(object sender, NetMQSocketEventArgs e)
-        {
-            m_sendEvent.Fire(this, new NetMQActorEventArgs(this));
         }
 
         #endregion

--- a/src/NetMQ/NetMQActor.cs
+++ b/src/NetMQ/NetMQActor.cs
@@ -342,6 +342,8 @@ namespace NetMQ
 
             m_shimThread.Join();
             m_self.Dispose();
+            m_sendEvent.Dispose();
+            m_receiveEvent.Dispose();
         }
 
         #endregion

--- a/src/NetMQ/NetMQActor.cs
+++ b/src/NetMQ/NetMQActor.cs
@@ -125,8 +125,8 @@ namespace NetMQ
         private readonly Thread m_shimThread;
         private readonly IShimHandler m_shimHandler;
 
-        private readonly EventDelegatorHelper<NetMQActorEventArgs> m_receiveEventDelegatorHelper;
-        private readonly EventDelegatorHelper<NetMQActorEventArgs> m_sendEventDelegatorHelper;
+        private readonly EventDelegator<NetMQActorEventArgs> m_receiveEvent;
+        private readonly EventDelegator<NetMQActorEventArgs> m_sendEvent;
 
         #region Creating Actor
 
@@ -137,11 +137,11 @@ namespace NetMQ
             m_self = context.CreatePairSocket();
             m_shim = context.CreatePairSocket();
 
-            m_receiveEventDelegatorHelper = new EventDelegatorHelper<NetMQActorEventArgs>(
+            m_receiveEvent = new EventDelegator<NetMQActorEventArgs>(
                 () => m_self.ReceiveReady += OnReceive,
                 () => m_self.ReceiveReady -= OnReceive);
 
-            m_sendEventDelegatorHelper = new EventDelegatorHelper<NetMQActorEventArgs>(
+            m_sendEvent = new EventDelegator<NetMQActorEventArgs>(
                 () => m_self.SendReady += OnSend,
                 () => m_self.SendReady -= OnSend);
 
@@ -280,8 +280,8 @@ namespace NetMQ
         /// </summary>
         public event EventHandler<NetMQActorEventArgs> ReceiveReady
         {
-            add { m_receiveEventDelegatorHelper.Event += value; }
-            remove { m_receiveEventDelegatorHelper.Event -= value; }
+            add { m_receiveEvent.Event += value; }
+            remove { m_receiveEvent.Event -= value; }
         }
 
         /// <summary>
@@ -289,8 +289,8 @@ namespace NetMQ
         /// </summary>
         public event EventHandler<NetMQActorEventArgs> SendReady
         {
-            add { m_sendEventDelegatorHelper.Event += value; }
-            remove { m_sendEventDelegatorHelper.Event -= value; }
+            add { m_sendEvent.Event += value; }
+            remove { m_sendEvent.Event -= value; }
         }
 
         NetMQSocket ISocketPollable.Socket
@@ -300,12 +300,12 @@ namespace NetMQ
 
         private void OnReceive(object sender, NetMQSocketEventArgs e)
         {
-            m_receiveEventDelegatorHelper.Fire(this, new NetMQActorEventArgs(this));
+            m_receiveEvent.Fire(this, new NetMQActorEventArgs(this));
         }
 
         private void OnSend(object sender, NetMQSocketEventArgs e)
         {
-            m_sendEventDelegatorHelper.Fire(this, new NetMQActorEventArgs(this));
+            m_sendEvent.Fire(this, new NetMQActorEventArgs(this));
         }
 
         #endregion

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -480,6 +480,7 @@ namespace NetMQ
                 return;
 
             m_actor.Dispose();
+            m_receiveEvent.Dispose();
         }
     }
 }

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -264,7 +264,7 @@ namespace NetMQ
 
         private readonly NetMQActor m_actor;
 
-        private readonly EventDelegatorHelper<NetMQBeaconEventArgs> m_receiveEventHelper;
+        private readonly EventDelegator<NetMQBeaconEventArgs> m_receiveEvent;
 
         /// <summary>
         /// Create a new NetMQBeacon, contained within the given context.
@@ -274,7 +274,7 @@ namespace NetMQ
         {
             m_actor = NetMQActor.Create(context, new Shim());
 
-            m_receiveEventHelper = new EventDelegatorHelper<NetMQBeaconEventArgs>(
+            m_receiveEvent = new EventDelegator<NetMQBeaconEventArgs>(
                 () => m_actor.ReceiveReady += OnReceiveReady,
                 () => m_actor.ReceiveReady -= OnReceiveReady);
         }
@@ -297,13 +297,13 @@ namespace NetMQ
         /// </summary>
         public event EventHandler<NetMQBeaconEventArgs> ReceiveReady
         {
-            add { m_receiveEventHelper.Event += value; }
-            remove { m_receiveEventHelper.Event -= value; }
+            add { m_receiveEvent.Event += value; }
+            remove { m_receiveEvent.Event -= value; }
         }
 
         private void OnReceiveReady(object sender, NetMQActorEventArgs args)
         {
-            m_receiveEventHelper.Fire(this, new NetMQBeaconEventArgs(this));
+            m_receiveEvent.Fire(this, new NetMQBeaconEventArgs(this));
         }
 
         /// <summary>

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -274,9 +274,12 @@ namespace NetMQ
         {
             m_actor = NetMQActor.Create(context, new Shim());
 
+            EventHandler<NetMQActorEventArgs> onReceive = (sender, e) =>
+                m_receiveEvent.Fire(this, new NetMQBeaconEventArgs(this));
+
             m_receiveEvent = new EventDelegator<NetMQBeaconEventArgs>(
-                () => m_actor.ReceiveReady += OnReceiveReady,
-                () => m_actor.ReceiveReady -= OnReceiveReady);
+                () => m_actor.ReceiveReady += onReceive,
+                () => m_actor.ReceiveReady -= onReceive);
         }
 
         /// <summary>
@@ -299,11 +302,6 @@ namespace NetMQ
         {
             add { m_receiveEvent.Event += value; }
             remove { m_receiveEvent.Event -= value; }
-        }
-
-        private void OnReceiveReady(object sender, NetMQActorEventArgs args)
-        {
-            m_receiveEvent.Fire(this, new NetMQBeaconEventArgs(this));
         }
 
         /// <summary>


### PR DESCRIPTION
Following #344, here are some fixes to the use of internal `EventDelegatorHelper`.

1. Use correct events in all places
2. Fix resubscribe in place of unsubscribe
3. Fix bug in reference counting that prevents unsubscribe

In #344 we discussed removing `EventDelegatorHelper`. Looking at it a little further, it possibly makes a difference in [`NetMQSocket:275`](https://github.com/zeromq/netmq/blob/master/src/NetMQ/NetMQSocket.cs#L275) where the absence of a receive handler excludes the `PollEvents.PollIn` flag from being set.

@somdoron, if you still feel like removing this class, I will put together another PR. At least it seems that bugs are now fixed.