### PR TITLE
Define separate proxy control sockets for incoming and outgoing traffic

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,3 +20,4 @@ Contributors
 * Tobias Behr &mdash; [@tobi-tobsen](https://github.com/tobi-tobsen)
 * Tom Robinson &mdash; [@tjrobinson](https://github.com/tjrobinson)
 * Victor Baybekov &mdash; [@buybackoff](https://github.com/buybackoff)
+* Tobias Böhm &mdash; [@tobiasb](https://github.com/tobiasb)


### PR DESCRIPTION
In the proxy we can define a single control socket that messages are sent to. This PR lets us define separate sockets for each direction.