### PR TITLE
Convert Command from a class to a struct

### DIFF
--- a/src/NetMQ/Blob.cs
+++ b/src/NetMQ/Blob.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2010 250bpm s.r.o.
-    Copyright (c) 2010-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2010-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Blob.cs
+++ b/src/NetMQ/Blob.cs
@@ -108,7 +108,7 @@ namespace NetMQ
         /// </summary>
         /// <param name="t">the other object to compare against</param>
         /// <returns>true if equal</returns>
-        public override bool Equals([CanBeNull] Object t)
+        public override bool Equals([CanBeNull] object t)
         {
             var blob = t as Blob;
             if (blob != null)

--- a/src/NetMQ/Core/Address.cs
+++ b/src/NetMQ/Core/Address.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2012 Spotify AB
-    Copyright (c) 2012 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2012-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Command.cs
+++ b/src/NetMQ/Core/Command.cs
@@ -25,9 +25,9 @@ using JetBrains.Annotations;
 namespace NetMQ.Core
 {
     /// <summary>
-    /// This class defines the commands that can be sent between threads.
+    /// Defines a command sent between threads.
     /// </summary>
-    internal sealed class Command
+    internal struct Command
     {
         /// <summary>
         /// Create a new Command object for the given destination, type, and optional argument.
@@ -35,7 +35,7 @@ namespace NetMQ.Core
         /// <param name="destination">a ZObject that denotes the destination for this command</param>
         /// <param name="type">the CommandType of the new command</param>
         /// <param name="arg">an Object to comprise the argument for the command (optional)</param>
-        public Command([CanBeNull] ZObject destination, CommandType type, [CanBeNull] Object arg = null)
+        public Command([CanBeNull] ZObject destination, CommandType type, [CanBeNull] Object arg = null) : this()
         {
             Destination = destination;
             CommandType = type;

--- a/src/NetMQ/Core/Command.cs
+++ b/src/NetMQ/Core/Command.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Command.cs
+++ b/src/NetMQ/Core/Command.cs
@@ -19,7 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using System;
 using JetBrains.Annotations;
 
 namespace NetMQ.Core
@@ -35,7 +34,7 @@ namespace NetMQ.Core
         /// <param name="destination">a ZObject that denotes the destination for this command</param>
         /// <param name="type">the CommandType of the new command</param>
         /// <param name="arg">an Object to comprise the argument for the command (optional)</param>
-        public Command([CanBeNull] ZObject destination, CommandType type, [CanBeNull] Object arg = null) : this()
+        public Command([CanBeNull] ZObject destination, CommandType type, [CanBeNull] object arg = null) : this()
         {
             Destination = destination;
             CommandType = type;
@@ -53,7 +52,7 @@ namespace NetMQ.Core
         /// Get the argument to this command.
         /// </summary>
         [CanBeNull]
-        public Object Arg { get; private set; }
+        public object Arg { get; private set; }
 
         /// <summary>
         /// Override of ToString, which returns a string in the form [ command-type, destination ].

--- a/src/NetMQ/Core/CommandType.cs
+++ b/src/NetMQ/Core/CommandType.cs
@@ -9,6 +9,8 @@ namespace NetMQ.Core
     /// </remarks>
     internal enum CommandType
     {
+        None = 0,
+
         /// <summary>
         /// Sent to I/O thread to let it know that it should
         /// terminate itself.

--- a/src/NetMQ/Core/Config.cs
+++ b/src/NetMQ/Core/Config.cs
@@ -1,7 +1,7 @@
 /*  
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
     
     This file is part of 0MQ.
     

--- a/src/NetMQ/Core/Ctx.cs
+++ b/src/NetMQ/Core/Ctx.cs
@@ -242,10 +242,11 @@ namespace NetMQ.Core
                 }
 
                 // Wait till reaper thread closes all the sockets.
-                Command cmd = m_termMailbox.Recv(-1);
+                Command command;
+                var found = m_termMailbox.TryRecv(-1, out command);
 
-                Debug.Assert(cmd != null);
-                Debug.Assert(cmd.CommandType == CommandType.Done);
+                Debug.Assert(found);
+                Debug.Assert(command.CommandType == CommandType.Done);
                 Monitor.Enter(m_slotSync);
                 Debug.Assert(m_sockets.Count == 0);
             }

--- a/src/NetMQ/Core/Ctx.cs
+++ b/src/NetMQ/Core/Ctx.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/IOObject.cs
+++ b/src/NetMQ/Core/IOObject.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/IOThread.cs
+++ b/src/NetMQ/Core/IOThread.cs
@@ -91,10 +91,10 @@ namespace NetMQ.Core
         public int Load
         {
             get { return m_proactor.Load; }
-        }                  
-      
+        }
+
         protected override void ProcessStop()
-        {            
+        {
             m_proactor.Stop();
         }
 

--- a/src/NetMQ/Core/IOThread.cs
+++ b/src/NetMQ/Core/IOThread.cs
@@ -100,16 +100,10 @@ namespace NetMQ.Core
 
         public void Ready()
         {
-            while (true)
-            {
-                // Get the next command. If there is none, exit.
-                Command command;
-                if (!m_mailbox.TryRecv(out command))
-                    break;
-
-                // Process the command.
+            // Process all available commands.
+            Command command;
+            while (m_mailbox.TryRecv(out command))
                 command.Destination.ProcessCommand(command);
-            }
         }
 
 #if DEBUG

--- a/src/NetMQ/Core/IOThread.cs
+++ b/src/NetMQ/Core/IOThread.cs
@@ -24,7 +24,7 @@ using NetMQ.Core.Utils;
 
 namespace NetMQ.Core
 {
-    internal class IOThread : ZObject, IMailboxEvent
+    internal sealed class IOThread : ZObject, IMailboxEvent
     {
         /// <summary>
         /// I/O thread accesses incoming commands via this mailbox.

--- a/src/NetMQ/Core/IOThread.cs
+++ b/src/NetMQ/Core/IOThread.cs
@@ -103,12 +103,12 @@ namespace NetMQ.Core
             while (true)
             {
                 // Get the next command. If there is none, exit.
-                Command cmd = m_mailbox.Recv();
-                if (cmd == null)
+                Command command;
+                if (!m_mailbox.TryRecv(out command))
                     break;
 
                 // Process the command.
-                cmd.Destination.ProcessCommand(cmd);
+                command.Destination.ProcessCommand(command);
             }
         }
 

--- a/src/NetMQ/Core/IOThread.cs
+++ b/src/NetMQ/Core/IOThread.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/IPollEvents.cs
+++ b/src/NetMQ/Core/IPollEvents.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/IProactorEvents.cs
+++ b/src/NetMQ/Core/IProactorEvents.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Mailbox.cs
+++ b/src/NetMQ/Core/Mailbox.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2010-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Mailbox.cs
+++ b/src/NetMQ/Core/Mailbox.cs
@@ -70,7 +70,7 @@ namespace NetMQ.Core
             // polling on the associated file descriptor it will get woken up when
             // new command is posted.
             Command cmd;
-            bool ok = m_commandPipe.Read(out cmd);
+            bool ok = m_commandPipe.TryRead(out cmd);
             Debug.Assert(!ok);
 
 #if DEBUG
@@ -95,7 +95,7 @@ namespace NetMQ.Core
 
         public bool TryRecv(out Command command)
         {
-            return m_commandPipe.Read(out command);
+            return m_commandPipe.TryRead(out command);
         }
 
         public void RaiseEvent()
@@ -161,7 +161,7 @@ namespace NetMQ.Core
             // new command is posted.
 
             Command cmd;
-            bool ok = m_commandPipe.Read(out cmd);
+            bool ok = m_commandPipe.TryRead(out cmd);
 
             Debug.Assert(!ok);
 
@@ -213,7 +213,7 @@ namespace NetMQ.Core
             // Try to get the command straight away.
             if (m_active)
             {
-                if (m_commandPipe.Read(out command))
+                if (m_commandPipe.TryRead(out command))
                     return true;
 
                 // If there are no more commands available, switch into passive state.
@@ -232,7 +232,7 @@ namespace NetMQ.Core
             m_active = true;
 
             // Get a command.
-            var ok = m_commandPipe.Read(out command);
+            var ok = m_commandPipe.TryRead(out command);
             Debug.Assert(ok);
             return ok;
         }

--- a/src/NetMQ/Core/MonitorEvent.cs
+++ b/src/NetMQ/Core/MonitorEvent.cs
@@ -13,7 +13,7 @@ namespace NetMQ.Core
 
         private readonly SocketEvents m_monitorEvent;
         private readonly string m_addr;
-        [CanBeNull] private readonly Object m_arg;
+        [CanBeNull] private readonly object m_arg;
         private readonly int m_flag;
 
         private static readonly int s_sizeOfIntPtr;
@@ -41,7 +41,7 @@ namespace NetMQ.Core
         {
         }
 
-        private MonitorEvent(SocketEvents monitorEvent, [NotNull] string addr, [NotNull] Object arg)
+        private MonitorEvent(SocketEvents monitorEvent, [NotNull] string addr, [NotNull] object arg)
         {
             m_monitorEvent = monitorEvent;
             m_addr = addr;
@@ -130,7 +130,7 @@ namespace NetMQ.Core
             string addr = data.GetString(len, pos);
             pos += len;
             var flag = (int)data[pos++];
-            Object arg = null;
+            object arg = null;
 
             if (flag == ValueInteger)
             {

--- a/src/NetMQ/Core/Options.cs
+++ b/src/NetMQ/Core/Options.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
         
     This file is part of 0MQ.
             

--- a/src/NetMQ/Core/Options.cs
+++ b/src/NetMQ/Core/Options.cs
@@ -279,7 +279,7 @@ namespace NetMQ.Core
         /// <param name="option">a ZmqSocketOption that specifies what to set</param>
         /// <param name="optionValue">an Object that is the value to set that option to</param>
         /// <exception cref="InvalidException">The option and optionValue must be valid.</exception>
-        public void SetSocketOption(ZmqSocketOption option, Object optionValue)
+        public void SetSocketOption(ZmqSocketOption option, object optionValue)
         {
             switch (option)
             {
@@ -411,7 +411,7 @@ namespace NetMQ.Core
         /// <param name="option">a ZmqSocketOption that specifies what to get</param>
         /// <returns>an Object that is the value of that option</returns>
         /// <exception cref="InvalidException">A valid option must be specified.</exception>
-        public Object GetSocketOption(ZmqSocketOption option)
+        public object GetSocketOption(ZmqSocketOption option)
         {
             switch (option)
             {

--- a/src/NetMQ/Core/Options.cs
+++ b/src/NetMQ/Core/Options.cs
@@ -21,9 +21,7 @@
 */
 
 using System;
-using System.Collections.Generic;
 using System.Text;
-using NetMQ.Core.Transports.Tcp;
 
 namespace NetMQ.Core
 {

--- a/src/NetMQ/Core/Own.cs
+++ b/src/NetMQ/Core/Own.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2010-2011 250bpm s.r.o.
-    Copyright (c) 2010-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2010-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Dealer.cs
+++ b/src/NetMQ/Core/Patterns/Dealer.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Pair.cs
+++ b/src/NetMQ/Core/Patterns/Pair.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Pub.cs
+++ b/src/NetMQ/Core/Patterns/Pub.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Pull.cs
+++ b/src/NetMQ/Core/Patterns/Pull.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Push.cs
+++ b/src/NetMQ/Core/Patterns/Push.cs
@@ -1,7 +1,7 @@
 /*      
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2010 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
                 
     This file is part of 0MQ.
             

--- a/src/NetMQ/Core/Patterns/Rep.cs
+++ b/src/NetMQ/Core/Patterns/Rep.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Req.cs
+++ b/src/NetMQ/Core/Patterns/Req.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Router.cs
+++ b/src/NetMQ/Core/Patterns/Router.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
         

--- a/src/NetMQ/Core/Patterns/Stream.cs
+++ b/src/NetMQ/Core/Patterns/Stream.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
         

--- a/src/NetMQ/Core/Patterns/Sub.cs
+++ b/src/NetMQ/Core/Patterns/Sub.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Utils/Distribution.cs
+++ b/src/NetMQ/Core/Patterns/Utils/Distribution.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2011-2015 Other contributors as noted in the AUTHORS file
 
 
     This file is part of 0MQ.

--- a/src/NetMQ/Core/Patterns/Utils/FairQueueing.cs
+++ b/src/NetMQ/Core/Patterns/Utils/FairQueueing.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Utils/LoadBalancer.cs
+++ b/src/NetMQ/Core/Patterns/Utils/LoadBalancer.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2010-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
@@ -38,7 +38,7 @@ namespace NetMQ.Core.Patterns.Utils
         private int m_liveNodes;
         private MultiTrie[] m_next;
 
-        public delegate void MultiTrieDelegate([CanBeNull] Pipe pipe, [CanBeNull] byte[] data, int size, [CanBeNull] Object arg);
+        public delegate void MultiTrieDelegate([CanBeNull] Pipe pipe, [CanBeNull] byte[] data, int size, [CanBeNull] object arg);
 
         public MultiTrie()
         {
@@ -145,12 +145,12 @@ namespace NetMQ.Core.Patterns.Utils
         /// <param name="func"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        public bool RemoveHelper([NotNull] Pipe pipe, [NotNull] MultiTrieDelegate func, [CanBeNull] Object arg)
+        public bool RemoveHelper([NotNull] Pipe pipe, [NotNull] MultiTrieDelegate func, [CanBeNull] object arg)
         {
             return RemoveHelper(pipe, new byte[0], 0, 0, func, arg);
         }
 
-        private bool RemoveHelper([NotNull] Pipe pipe, [NotNull] byte[] buffer, int bufferSize, int maxBufferSize, [NotNull] MultiTrieDelegate func, [CanBeNull] Object arg)
+        private bool RemoveHelper([NotNull] Pipe pipe, [NotNull] byte[] buffer, int bufferSize, int maxBufferSize, [NotNull] MultiTrieDelegate func, [CanBeNull] object arg)
         {
             // Remove the subscription from this node.
             if (m_pipes != null && m_pipes.Remove(pipe) && m_pipes.Count == 0)
@@ -394,7 +394,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// <summary>
         /// Signal all the matching pipes.
         /// </summary>
-        public void Match([NotNull] byte[] data, int size, [NotNull] MultiTrieDelegate func, [CanBeNull] Object arg)
+        public void Match([NotNull] byte[] data, int size, [NotNull] MultiTrieDelegate func, [CanBeNull] object arg)
         {
             MultiTrie current = this;
 

--- a/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
@@ -1,10 +1,10 @@
-/*              
+/*
     Copyright (c) 2011 250bpm s.r.o.
     Copyright (c) 2011-2012 Spotify AB
-    Copyright (c) 2011 Other contributors as noted in the AUTHORS file
-                    
+    Copyright (c) 2011-2015 Other contributors as noted in the AUTHORS file
+
     This file is part of 0MQ.
-                            
+
     0MQ is free software; you can redistribute it and/or modify it under
     the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 3 of the License, or
@@ -14,7 +14,7 @@
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-                
+
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */

--- a/src/NetMQ/Core/Patterns/Utils/Trie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/Trie.cs
@@ -34,7 +34,7 @@ namespace NetMQ.Core.Patterns.Utils
         private short m_count;
         private short m_liveNodes;
 
-        public delegate void TrieDelegate([NotNull] byte[] data, int size, [CanBeNull] Object arg);
+        public delegate void TrieDelegate([NotNull] byte[] data, int size, [CanBeNull] object arg);
 
         private Trie[] m_next;
 
@@ -274,12 +274,12 @@ namespace NetMQ.Core.Patterns.Utils
         }
 
         // Apply the function supplied to each subscription in the trie.
-        public void Apply([NotNull] TrieDelegate func, [CanBeNull] Object arg)
+        public void Apply([NotNull] TrieDelegate func, [CanBeNull] object arg)
         {
             ApplyHelper(null, 0, 0, func, arg);
         }
 
-        private void ApplyHelper([NotNull] byte[] buffer, int bufferSize, int maxBufferSize, [NotNull] TrieDelegate func, [CanBeNull] Object arg)
+        private void ApplyHelper([NotNull] byte[] buffer, int bufferSize, int maxBufferSize, [NotNull] TrieDelegate func, [CanBeNull] object arg)
         {
             // If this node is a subscription, apply the function.
             if (m_referenceCount > 0)

--- a/src/NetMQ/Core/Patterns/Utils/Trie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/Trie.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2011-2012 Spotify AB
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/XPub.cs
+++ b/src/NetMQ/Core/Patterns/XPub.cs
@@ -1,7 +1,7 @@
 /*      
     Copyright (c) 2010-2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2010-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2010-2015 Other contributors as noted in the AUTHORS file
         
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Patterns/XSub.cs
+++ b/src/NetMQ/Core/Patterns/XSub.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2010-2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2010-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2010-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Pipe.cs
+++ b/src/NetMQ/Core/Pipe.cs
@@ -249,7 +249,7 @@ namespace NetMQ.Core
             if (m_inboundPipe.Probe().IsDelimiter)
             {
                 var msg = new Msg();
-                bool ok = m_inboundPipe.Read(out msg);
+                bool ok = m_inboundPipe.TryRead(out msg);
                 Debug.Assert(ok);
                 Delimit();
                 return false;
@@ -267,7 +267,7 @@ namespace NetMQ.Core
             if (!m_inActive || (m_state != State.Active && m_state != State.Pending))
                 return false;
 
-            if (!m_inboundPipe.Read(out msg))
+            if (!m_inboundPipe.TryRead(out msg))
             {
                 m_inActive = false;
                 return false;
@@ -393,7 +393,7 @@ namespace NetMQ.Core
             Debug.Assert(m_outboundPipe != null);
             m_outboundPipe.Flush();
             var msg = new Msg();
-            while (m_outboundPipe.Read(out msg))
+            while (m_outboundPipe.TryRead(out msg))
             {
                 msg.Close();
             }
@@ -480,7 +480,7 @@ namespace NetMQ.Core
             // hand because msg_t doesn't have automatic destructor. Then deallocate
             // the ypipe itself.
             var msg = new Msg();
-            while (m_inboundPipe.Read(out msg))
+            while (m_inboundPipe.TryRead(out msg))
             {
                 msg.Close();
             }

--- a/src/NetMQ/Core/Pipe.cs
+++ b/src/NetMQ/Core/Pipe.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Reaper.cs
+++ b/src/NetMQ/Core/Reaper.cs
@@ -1,9 +1,9 @@
-/*  
+/*
     Copyright (c) 2011 250bpm s.r.o.
     Copyright (c) 2011 Other contributors as noted in the AUTHORS file
-          
+
     This file is part of 0MQ.
-       
+
     0MQ is free software; you can redistribute it and/or modify it under
     the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 3 of the License, or
@@ -68,7 +68,7 @@ namespace NetMQ.Core
         {
             m_sockets = 0;
             m_terminating = false;
-            
+
             string name = "reaper-" + threadId;
             m_poller = new Utils.Poller(name);
 

--- a/src/NetMQ/Core/Reaper.cs
+++ b/src/NetMQ/Core/Reaper.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2011 250bpm s.r.o.
-    Copyright (c) 2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2011-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Reaper.cs
+++ b/src/NetMQ/Core/Reaper.cs
@@ -123,12 +123,12 @@ namespace NetMQ.Core
             while (true)
             {
                 // Get the next command. If there is none, exit.
-                Command cmd = m_mailbox.Recv(0);
-                if (cmd == null)
+                Command command;
+                if (!m_mailbox.TryRecv(0, out command))
                     break;
 
                 // Process the command.
-                cmd.Destination.ProcessCommand(cmd);
+                command.Destination.ProcessCommand(command);
             }
         }
 

--- a/src/NetMQ/Core/SessionBase.cs
+++ b/src/NetMQ/Core/SessionBase.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
         

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -38,7 +38,7 @@ namespace NetMQ.Core
 {
     internal abstract class SocketBase : Own, IPollEvents, Pipe.IPipeEvents
     {
-        [NotNull] private readonly Dictionary<String, Own> m_endpoints = new Dictionary<string, Own>();
+        [NotNull] private readonly Dictionary<string, Own> m_endpoints = new Dictionary<string, Own>();
 
         [NotNull] private readonly Dictionary<string, Pipe> m_inprocs = new Dictionary<string, Pipe>();
 
@@ -281,7 +281,7 @@ namespace NetMQ.Core
         /// <param name="option">which option to set</param>
         /// <param name="optionValue">the value to set the option to</param>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
-        public void SetSocketOption(ZmqSocketOption option, Object optionValue)
+        public void SetSocketOption(ZmqSocketOption option, object optionValue)
         {
             CheckContextTerminated();
 
@@ -347,7 +347,7 @@ namespace NetMQ.Core
         /// If the Events option is specified, then process any outstanding commands, and return -1 if that throws a TerminatingException.
         ///     then return a PollEvents that is the bitwise-OR of the PollEvents.PollOut and PollEvents.PollIn flags.
         /// </remarks>
-        public Object GetSocketOptionX(ZmqSocketOption option)
+        public object GetSocketOptionX(ZmqSocketOption option)
         {
             CheckContextTerminated();
 

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -453,7 +453,7 @@ namespace NetMQ.Core
             {
                 case Address.TcpProtocol:
                     {
-                        var listener = new Transports.Tcp.TcpListener(ioThread, this, m_options);
+                        var listener = new TcpListener(ioThread, this, m_options);
 
                         try
                         {

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -1,4 +1,4 @@
-/*      
+/*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2011 VMware, Inc.
@@ -15,7 +15,7 @@
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -116,7 +116,7 @@ namespace NetMQ.Core
         /// <param name="pipe">the Pipe that is being removed</param>
         protected abstract void XTerminated([NotNull] Pipe pipe);
 
-        /// <summary>Throw <see cref="ObjectDisposedException"/> if this socket is already disposed.</summary>  
+        /// <summary>Throw <see cref="ObjectDisposedException"/> if this socket is already disposed.</summary>
         /// <exception cref="ObjectDisposedException">This object is already disposed.</exception>
         public void CheckDisposed()
         {
@@ -461,8 +461,8 @@ namespace NetMQ.Core
                             m_port = listener.Port;
 
                             // Recreate the address string (localhost:1234) in case the port was system-assigned
-                            addr = string.Format("tcp://{0}:{1}", 
-                                address.Substring(0, address.IndexOf(':')), 
+                            addr = string.Format("tcp://{0}:{1}",
+                                address.Substring(0, address.IndexOf(':')),
                                 m_port);
                         }
                         catch (NetMQException ex)
@@ -583,11 +583,11 @@ namespace NetMQ.Core
 
                 // The total HWM for an inproc connection should be the sum of
                 // the binder's HWM and the connector's HWM.
-                var sndhwm = m_options.SendHighWatermark != 0 && peer.Options.ReceiveHighWatermark != 0 
+                var sndhwm = m_options.SendHighWatermark != 0 && peer.Options.ReceiveHighWatermark != 0
                     ? m_options.SendHighWatermark + peer.Options.ReceiveHighWatermark
                     : 0;
 
-                var rcvhwm = m_options.ReceiveHighWatermark != 0 && peer.Options.SendHighWatermark != 0 
+                var rcvhwm = m_options.ReceiveHighWatermark != 0 && peer.Options.SendHighWatermark != 0
                     ? m_options.ReceiveHighWatermark + peer.Options.SendHighWatermark
                     : 0;
 
@@ -643,7 +643,7 @@ namespace NetMQ.Core
 
             if (ioThread == null)
                 throw NetMQException.Create(ErrorCode.EmptyThread);
-            
+
             var paddr = new Address(protocol, address);
 
             // Resolve address (if needed by the protocol)
@@ -761,7 +761,7 @@ namespace NetMQ.Core
             {
                 if (UnregisterEndpoint(addr, this))
                     return;
-                
+
                 Pipe pipe;
                 if (!m_inprocs.TryGetValue(addr, out pipe))
                     throw new EndpointNotFoundException("Endpoint was not found and cannot be disconnected");
@@ -814,12 +814,12 @@ namespace NetMQ.Core
             if (isMessageSent)
                 return true;
 
-            // In case of non-blocking send we'll simply return false            
+            // In case of non-blocking send we'll simply return false
             if (timeout == TimeSpan.Zero)
                 return false;
 
             // Compute the time when the timeout should occur.
-            // If the timeout is infinite, don't care. 
+            // If the timeout is infinite, don't care.
             int timeoutMillis = (int)timeout.TotalMilliseconds;
             long end = timeoutMillis < 0 ? 0 : (Clock.NowMs() + timeoutMillis);
 
@@ -831,7 +831,7 @@ namespace NetMQ.Core
                 ProcessCommands(timeoutMillis, false);
 
                 isMessageSent = XSend(ref msg);
-                
+
                 if (isMessageSent)
                     break;
 
@@ -839,7 +839,7 @@ namespace NetMQ.Core
                     continue;
 
                 timeoutMillis = (int)(end - Clock.NowMs());
-                    
+
                 if (timeoutMillis <= 0)
                     return false;
             }
@@ -860,11 +860,11 @@ namespace NetMQ.Core
         ///   <item>Positive - return <c>false</c> after the corresponding duration if no message has become available</item>
         ///   <item>Negative - wait indefinitely, always returning <c>true</c></item>
         /// </list>
-        /// </remarks>        
+        /// </remarks>
         /// <exception cref="FaultException">the Msg must already have been uninitialised</exception>
         /// <exception cref="TerminatingException">The socket must not already be stopped.</exception>
         public bool TryRecv(ref Msg msg, TimeSpan timeout)
-        {            
+        {
             CheckContextTerminated();
 
             // Check whether message passed to the function is valid.
@@ -905,7 +905,7 @@ namespace NetMQ.Core
                 m_ticks = 0;
 
                 isMessageAvailable = XRecv(ref msg);
-                
+
                 if (!isMessageAvailable)
                     return false;
 
@@ -914,7 +914,7 @@ namespace NetMQ.Core
             }
 
             // Compute the time when the timeout should occur.
-            // If the timeout is infinite (negative), don't care. 
+            // If the timeout is infinite (negative), don't care.
             int timeoutMillis = (int)timeout.TotalMilliseconds;
             long end = timeoutMillis < 0 ? 0L : Clock.NowMs() + timeoutMillis;
 
@@ -1018,7 +1018,7 @@ namespace NetMQ.Core
                 // If we are asked not to wait, check whether we haven't processed
                 // commands recently, so that we can throttle the new commands.
 
-                // Get the CPU's tick counter. If 0, the counter is not available.								
+                // Get the CPU's tick counter. If 0, the counter is not available.
                 long tsc = Clock.Rdtsc();
 
                 // Optimised version of command processing - it doesn't have to check

--- a/src/NetMQ/Core/Transports/DecoderBase.cs
+++ b/src/NetMQ/Core/Transports/DecoderBase.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/EncoderBase.cs
+++ b/src/NetMQ/Core/Transports/EncoderBase.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/IEngine.cs
+++ b/src/NetMQ/Core/Transports/IEngine.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/Ipc/IpcAddress.cs
+++ b/src/NetMQ/Core/Transports/Ipc/IpcAddress.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2011 250bpm s.r.o.
-    Copyright (c) 2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2011-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/Ipc/IpcConnector.cs
+++ b/src/NetMQ/Core/Transports/Ipc/IpcConnector.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2011 250bpm s.r.o.
-    Copyright (c) 2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2011-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/Ipc/IpcListener.cs
+++ b/src/NetMQ/Core/Transports/Ipc/IpcListener.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2011 250bpm s.r.o.
-    Copyright (c) 2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2011-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/Pgm/PgmSocket.cs
+++ b/src/NetMQ/Core/Transports/Pgm/PgmSocket.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Net.Sockets;
 using System.Text;
 using AsyncIO;

--- a/src/NetMQ/Core/Transports/StreamEngine.cs
+++ b/src/NetMQ/Core/Transports/StreamEngine.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/Tcp/TcpConnector.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpConnector.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2010 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/V1Decoder.cs
+++ b/src/NetMQ/Core/Transports/V1Decoder.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Transports/V1Encoder.cs
+++ b/src/NetMQ/Core/Transports/V1Encoder.cs
@@ -2,7 +2,7 @@
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2011 VMware, Inc.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Utils/ByteArrayEqualityComparer.cs
+++ b/src/NetMQ/Core/Utils/ByteArrayEqualityComparer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace NetMQ.Core.Utils
 {
@@ -90,7 +89,7 @@ namespace NetMQ.Core.Utils
                     hash ^= k;
                 }
 
-                hash ^= (UInt32)data.Length;
+                hash ^= (uint)data.Length;
                 hash ^= hash >> 16;
                 hash *= 0x85ebca6b;
                 hash ^= hash >> 13;

--- a/src/NetMQ/Core/Utils/Clock.cs
+++ b/src/NetMQ/Core/Utils/Clock.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2010-2011 250bpm s.r.o.
-    Copyright (c) 2010-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2010-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Utils/Poller.cs
+++ b/src/NetMQ/Core/Utils/Poller.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Utils/PollerBase.cs
+++ b/src/NetMQ/Core/Utils/PollerBase.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2010-2011 250bpm s.r.o.
-    Copyright (c) 2010-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2010-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Utils/Selector.cs
+++ b/src/NetMQ/Core/Utils/Selector.cs
@@ -88,9 +88,9 @@ namespace NetMQ.Core.Utils
                     {
                         currentTimeoutMicroSeconds = 0;
                     }
-                    else if (currentTimeoutMicroSeconds > Int32.MaxValue)
+                    else if (currentTimeoutMicroSeconds > int.MaxValue)
                     {
-                        currentTimeoutMicroSeconds = Int32.MaxValue;
+                        currentTimeoutMicroSeconds = int.MaxValue;
                     }
                 }
 

--- a/src/NetMQ/Core/Utils/Selector.cs
+++ b/src/NetMQ/Core/Utils/Selector.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Sockets;
-using System.Threading;
 using JetBrains.Annotations;
 
 namespace NetMQ.Core.Utils

--- a/src/NetMQ/Core/Utils/Signaler.cs
+++ b/src/NetMQ/Core/Utils/Signaler.cs
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2010-2011 250bpm s.r.o.
-    Copyright (c) 2010-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2010-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/Utils/SocketUtility.cs
+++ b/src/NetMQ/Core/Utils/SocketUtility.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Net.Sockets;
 using JetBrains.Annotations;
 

--- a/src/NetMQ/Core/Utils/YQueue.cs
+++ b/src/NetMQ/Core/Utils/YQueue.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/YPipe.cs
+++ b/src/NetMQ/Core/YPipe.cs
@@ -1,4 +1,4 @@
-/*  
+/*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
@@ -32,24 +32,24 @@ namespace NetMQ.Core
         /// Front of the queue points to the first prefetched item, back of
         /// the pipe points to last un-flushed item. Front is used only by
         /// reader thread, while back is used only by writer thread.
-        /// </summary> 
+        /// </summary>
         private readonly YQueue<T> m_queue;
 
         /// <summary>
         /// Points to the first un-flushed item. This variable is used
         /// exclusively by writer thread.
-        /// </summary> 
+        /// </summary>
         private int m_flushFromIndex;
 
         /// <summary>
         /// Points to the first un-prefetched item. This variable is used
         /// exclusively by reader thread.
-        /// </summary> 
+        /// </summary>
         private int m_readToIndex;
 
         /// <summary>
         /// Points to the first item to be flushed in the future.
-        /// </summary> 
+        /// </summary>
         private int m_flushToIndex;
 
 #if DEBUG
@@ -61,7 +61,7 @@ namespace NetMQ.Core
         /// Points past the last flushed item. If it is NULL,
         /// reader is asleep. This pointer should be always accessed using
         /// atomic operations.
-        /// </summary> 
+        /// </summary>
         private int m_lastAllowedToReadIndex;
 
         public YPipe(int qsize, string name)
@@ -78,7 +78,7 @@ namespace NetMQ.Core
         /// set to true the item is assumed to be continued by items
         /// subsequently written to the pipe. Incomplete items are never
         /// flushed down the stream.
-        /// </summary> 
+        /// </summary>
         public void Write(ref T value, bool incomplete)
         {
             // Place the value to the queue, add new terminator element.
@@ -93,8 +93,8 @@ namespace NetMQ.Core
 
         /// <summary>
         /// Pop an incomplete item from the pipe.
-        /// </summary> 
-        /// <returns>the element revoked if such item exists, <c>null</c> otherwise.</returns>  
+        /// </summary>
+        /// <returns>the element revoked if such item exists, <c>null</c> otherwise.</returns>
         public bool Unwrite(ref T value)
         {
             if (m_flushToIndex == m_queue.BackPos)
@@ -139,7 +139,7 @@ namespace NetMQ.Core
 
         /// <summary>
         /// Check whether item is available for reading.
-        /// </summary> 
+        /// </summary>
         public bool CheckRead()
         {
             // Was the value prefetched already? If so, return.
@@ -176,7 +176,7 @@ namespace NetMQ.Core
         /// <summary>
         /// Reads an item from the pipe. Returns false if there is no value.
         /// available.
-        /// </summary> 
+        /// </summary>
         public bool Read(out T value)
         {
             // Try to prefetch a value.

--- a/src/NetMQ/Core/YPipe.cs
+++ b/src/NetMQ/Core/YPipe.cs
@@ -174,10 +174,10 @@ namespace NetMQ.Core
 
 
         /// <summary>
-        /// Reads an item from the pipe. Returns false if there is no value.
-        /// available.
+        /// Attempts to read an item from the pipe.
         /// </summary>
-        public bool Read(out T value)
+        /// <returns><c>true</c> if the read succeeded, otherwise <c>false</c>.</returns>
+        public bool TryRead(out T value)
         {
             // Try to prefetch a value.
             if (!CheckRead())

--- a/src/NetMQ/Core/YPipe.cs
+++ b/src/NetMQ/Core/YPipe.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/ZObject.cs
+++ b/src/NetMQ/Core/ZObject.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2009-2011 250bpm s.r.o.
     Copyright (c) 2007-2009 iMatix Corporation
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
     
     This file is part of 0MQ.
 

--- a/src/NetMQ/Core/ZObject.cs
+++ b/src/NetMQ/Core/ZObject.cs
@@ -187,7 +187,7 @@ namespace NetMQ.Core
             SendCommand(new Command(destination, CommandType.ActivateWrite, msgsRead));
         }
 
-        protected void SendHiccup([NotNull] Pipe destination, [NotNull] Object pipe)
+        protected void SendHiccup([NotNull] Pipe destination, [NotNull] object pipe)
         {
             SendCommand(new Command(destination, CommandType.Hiccup, pipe));
         }
@@ -383,7 +383,7 @@ namespace NetMQ.Core
         /// is no longer available for writing to.
         /// </remarks>
         /// <exception cref="NotSupportedException">No supported on the ZObject class.</exception>
-        protected virtual void ProcessHiccup([NotNull] Object pipe)
+        protected virtual void ProcessHiccup([NotNull] object pipe)
         {
             throw new NotSupportedException();
         }

--- a/src/NetMQ/Msg.cs
+++ b/src/NetMQ/Msg.cs
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
-    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 

--- a/src/NetMQ/NetMQContext.cs
+++ b/src/NetMQ/NetMQContext.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Threading;
 using JetBrains.Annotations;
+using NetMQ.Core;
 using NetMQ.Monitoring;
 using NetMQ.Sockets;
-using NetMQ.Core;
 
 namespace NetMQ
 {

--- a/src/NetMQ/OutgoingSocketExtensions.cs
+++ b/src/NetMQ/OutgoingSocketExtensions.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
 using System.Text;
 using JetBrains.Annotations;
-using System.Diagnostics;
 
 namespace NetMQ
 {

--- a/src/NetMQ/Security/CipherSuite.cs
+++ b/src/NetMQ/Security/CipherSuite.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 
-
 namespace NetMQ.Security
 {
     /// <summary>

--- a/src/RouterPerformance/Program.cs
+++ b/src/RouterPerformance/Program.cs
@@ -11,7 +11,10 @@ namespace RouterPerformance
     {
         private static void Main()
         {
-            const int count = 1000000;
+            const int messageCount = 1000000;
+            const int dealerCount = 100;
+
+            Console.WriteLine("Sending {0} messages to {1} dealers", messageCount, dealerCount);
 
             //BufferPool.SetBufferManagerBufferPool(1024 * 1024 * 10, 1024);
 
@@ -23,11 +26,10 @@ namespace RouterPerformance
 
                 var dealers = new List<DealerSocket>();
                 var identities = new List<byte[]>();
-
                 var random = new Random();
-
                 var identity = new byte[50];
-                for (int i = 0; i < 100; i++)
+
+                for (var i = 0; i < dealerCount; i++)
                 {
                     var dealer = context.CreateDealerSocket();
 
@@ -41,24 +43,24 @@ namespace RouterPerformance
                     identities.Add(identity);
                 }
 
-                Thread.Sleep(1000);
+                Thread.Sleep(500);
 
-                Stopwatch stopwatch = Stopwatch.StartNew();
-
-                for (int i = 0; i < count; i++)
+                while (!Console.KeyAvailable)
                 {
-                    router.SendMore(identities[i%identities.Count]).Send("E");
+                    Thread.Sleep(500);
+
+                    var stopwatch = Stopwatch.StartNew();
+
+                    for (var i = 0; i < messageCount; i++)
+                        router.SendMoreFrame(identities[i%identities.Count]).SendFrame("E");
+
+                    stopwatch.Stop();
+
+                    Console.WriteLine("{0:N1} messages sent per second", messageCount/stopwatch.Elapsed.TotalSeconds);
                 }
-
-                stopwatch.Stop();
-
-                Console.WriteLine("{0:N1} in second", count/stopwatch.Elapsed.TotalSeconds);
-                Console.ReadLine();
 
                 foreach (var dealerSocket in dealers)
-                {
                     dealerSocket.Dispose();
-                }
             }
         }
     }


### PR DESCRIPTION
Following some [discussion on the mailing list](https://groups.google.com/forum/#!topic/netmq-dev/sDuyucNPd2Y) in which brunobodin discovered allocations of `Command` objects when sending, I ran this experimental branch which converts `Command` to a value type, avoiding the heap allocation.

The change was fairly straightforward and completely within internal code, so no public API changes occurred.

I ran the `Performance\NetMQ.SimpleTests` project before and after this change, and the results look promising in terms of throughout and latency. See this screenshot of a diff.

![image](https://cloud.githubusercontent.com/assets/350947/8909505/8dc6dff0-3479-11e5-8b7f-755698b0f278.png)

Latencies and throughput are improved where message sizes are small. In some cases values are slightly worse, though I feel that's within the measurement error/uncertainty, so I'm not too concerned. Would be good to have someone else test this too.