### PR TITLE
C# 6

### DIFF
--- a/src/NetMQ.Tests/EventDelegatorTests.cs
+++ b/src/NetMQ.Tests/EventDelegatorTests.cs
@@ -13,7 +13,7 @@ namespace NetMQ.Tests
                 Value = value;
             }
 
-            public T Value { get; private set; }
+            public T Value { get; }
         }
 
         private event EventHandler<Args<int>> Source;

--- a/src/NetMQ.Tests/InProcActors/AccountJSON/AccountShimHandler.cs
+++ b/src/NetMQ.Tests/InProcActors/AccountJSON/AccountShimHandler.cs
@@ -65,7 +65,7 @@ namespace NetMQ.Tests.InProcActors.AccountJSON
                 // demonstration purposes only, any unhandled fault will bubble up to caller's code.
                 catch (Exception e)
                 {
-                    shim.SendFrame(string.Format("Error: Exception occurred {0}", e.Message));
+                    shim.SendFrame($"Error: Exception occurred {e.Message}");
                 }
             }
         }

--- a/src/NetMQ.Tests/InProcActors/Echo/EchoActorTests.cs
+++ b/src/NetMQ.Tests/InProcActors/Echo/EchoActorTests.cs
@@ -17,7 +17,7 @@ namespace NetMQ.Tests.InProcActors.Echo
                 actor.SendFrame(actorMessage);
 
                 Assert.AreEqual(
-                    string.Format("ECHO BACK : {0}", actorMessage),
+                    $"ECHO BACK : {actorMessage}",
                     actor.ReceiveFrameString());
             }
         }

--- a/src/NetMQ.Tests/InProcActors/Echo/EchoShimHandler.cs
+++ b/src/NetMQ.Tests/InProcActors/Echo/EchoShimHandler.cs
@@ -46,7 +46,7 @@ namespace NetMQ.Tests.InProcActors.Echo
 
                     if (command == "ECHO")
                     {
-                        shim.SendFrame(string.Format("ECHO BACK : {0}", msg[1].ConvertToString()));
+                        shim.SendFrame($"ECHO BACK : {msg[1].ConvertToString()}");
                     }
                     else
                     {
@@ -57,7 +57,7 @@ namespace NetMQ.Tests.InProcActors.Echo
                 // demonstration purposes only, any unhandled fault will bubble up to caller's code
                 catch (Exception e)
                 {
-                    shim.SendFrame(string.Format("Error: Exception occurred {0}", e.Message));
+                    shim.SendFrame($"Error: Exception occurred {e.Message}");
                 }
             }
         }

--- a/src/NetMQ.Tests/InProcActors/ExceptionShimExample/ExceptionShimHandler.cs
+++ b/src/NetMQ.Tests/InProcActors/ExceptionShimExample/ExceptionShimHandler.cs
@@ -46,7 +46,7 @@ namespace NetMQ.Tests.InProcActors.ExceptionShimExample
                 //demonstration purposes only, any unhandled fault will bubble up to caller's code
                 catch (InvalidOperationException e)
                 {
-                    shim.SendFrame(string.Format("Error: Exception occurred {0}", e.Message));
+                    shim.SendFrame($"Error: Exception occurred {e.Message}");
                 }
             }
         }

--- a/src/NetMQ.Tests/MockBufferPool.cs
+++ b/src/NetMQ.Tests/MockBufferPool.cs
@@ -6,10 +6,10 @@ namespace NetMQ.Tests
     public class MockBufferPool : IBufferPool
     {
         public int TakeCallCount { get; private set; }
-        public List<int> TakeSize { get; private set; }
+        public List<int> TakeSize { get; }
         
         public int ReturnCallCount { get; private set; }
-        public List<byte[]> ReturnBuffer { get; private set; }
+        public List<byte[]> ReturnBuffer { get; }
 
         public MockBufferPool()
         {

--- a/src/NetMQ.Tests/PgmTests.cs
+++ b/src/NetMQ.Tests/PgmTests.cs
@@ -93,8 +93,8 @@ namespace NetMQ.Tests
             using (var pub = context.CreatePublisherSocket())
             using (var sub = context.CreateSubscriberSocket())
             {
-                pub.Connect(string.Format("pgm://{0};224.0.0.1:5555", ip));
-                sub.Bind(string.Format("pgm://{0};224.0.0.1:5555", ip));
+                pub.Connect($"pgm://{ip};224.0.0.1:5555");
+                sub.Bind($"pgm://{ip};224.0.0.1:5555");
 
                 sub.Subscribe("");
 

--- a/src/NetMQ.Tests/SocketTests.cs
+++ b/src/NetMQ.Tests/SocketTests.cs
@@ -303,7 +303,7 @@ namespace NetMQ.Tests
                 using (var connectingDealer = context.CreateDealerSocket())
                 {
                     var port = localDealer.BindRandomPort("tcp://*");
-                    connectingDealer.Connect(string.Format("tcp://{0}:{1}", alias, port));
+                    connectingDealer.Connect($"tcp://{alias}:{port}");
 
                     localDealer.SendFrame("test");
 
@@ -323,7 +323,7 @@ namespace NetMQ.Tests
                 localDealer.Options.IPv4Only = false;
                 var port = localDealer.BindRandomPort(string.Format("tcp://*"));
 
-                connectingDealer.Connect(string.Format("tcp://{0}:{1}", IPAddress.Loopback, port));
+                connectingDealer.Connect($"tcp://{IPAddress.Loopback}:{port}");
 
                 connectingDealer.SendFrame("test");
 
@@ -342,7 +342,7 @@ namespace NetMQ.Tests
                 var port = localDealer.BindRandomPort(string.Format("tcp://*"));
 
                 connectingDealer.Options.IPv4Only = false;
-                connectingDealer.Connect(string.Format("tcp://{0}:{1}", IPAddress.IPv6Loopback, port));
+                connectingDealer.Connect($"tcp://{IPAddress.IPv6Loopback}:{port}");
 
                 connectingDealer.SendFrame("test");
 

--- a/src/NetMQ/Blob.cs
+++ b/src/NetMQ/Blob.cs
@@ -89,19 +89,13 @@ namespace NetMQ
         /// <summary>
         /// Get the length of the data-buffer (the number of bytes in the array).
         /// </summary>
-        public int Size
-        {
-            get { return m_buffer.Length; }
-        }
+        public int Size => m_buffer.Length;
 
         /// <summary>
         /// Get the data buffer contained by this Blob, as a byte-array.
         /// </summary>
         [NotNull]
-        public byte[] Data
-        {
-            get { return m_buffer; }
-        }
+        public byte[] Data => m_buffer;
 
         /// <summary>
         /// Return true if this Blob is equal to the given object.

--- a/src/NetMQ/BufferPool.cs
+++ b/src/NetMQ/BufferPool.cs
@@ -184,8 +184,7 @@ namespace NetMQ
         {
             var prior = Interlocked.Exchange(ref s_bufferPool, bufferPool);
 
-            if (prior != null)
-                prior.Dispose();
+            prior?.Dispose();
         }
 
         /// <summary>

--- a/src/NetMQ/Core/Address.cs
+++ b/src/NetMQ/Core/Address.cs
@@ -128,10 +128,10 @@ namespace NetMQ.Core
         }
 
         [NotNull]
-        public string Protocol { get; private set; }
+        public string Protocol { get; }
 
         [NotNull]
-        public string AddressString { get; private set; }
+        public string AddressString { get; }
 
         [CanBeNull]
         public IZAddress Resolved { get; set; }

--- a/src/NetMQ/Core/Command.cs
+++ b/src/NetMQ/Core/Command.cs
@@ -43,10 +43,10 @@ namespace NetMQ.Core
 
         /// <summary>The destination to which the command should be applied.</summary>
         [CanBeNull]
-        public ZObject Destination { get; private set; }
+        public ZObject Destination { get; }
 
         /// <summary>The type of this command.</summary>
-        public CommandType CommandType { get; private set; }
+        public CommandType CommandType { get; }
 
         /// <summary>
         /// Get the argument to this command.

--- a/src/NetMQ/Core/Ctx.cs
+++ b/src/NetMQ/Core/Ctx.cs
@@ -261,7 +261,7 @@ namespace NetMQ.Core
             set
             {
                 if (value < 0)
-                    throw new ArgumentOutOfRangeException("value", value, "Must be zero or greater");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "Must be zero or greater");
                 lock (m_optSync)
                     m_ioThreadCount = value;
             }
@@ -273,7 +273,7 @@ namespace NetMQ.Core
             set
             {
                 if (value <= 0)
-                    throw new ArgumentOutOfRangeException("value", value, "Must be greater than zero");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "Must be greater than zero");
                 lock (m_optSync)
                     m_maxSockets = value;
             }

--- a/src/NetMQ/Core/Ctx.cs
+++ b/src/NetMQ/Core/Ctx.cs
@@ -63,7 +63,7 @@ namespace NetMQ.Core
             /// Get the socket associated with this Endpoint.
             /// </summary>
             [NotNull]
-            public SocketBase Socket { get; private set; }
+            public SocketBase Socket { get; }
 
             /// <summary>
             /// Get the Options of this Endpoint.

--- a/src/NetMQ/Core/Ctx.cs
+++ b/src/NetMQ/Core/Ctx.cs
@@ -184,8 +184,7 @@ namespace NetMQ.Core
             foreach (IOThread it in m_ioThreads)
                 it.Destroy();
 
-            if (m_reaper != null)
-                m_reaper.Destroy();
+            m_reaper?.Destroy();
 
             m_termMailbox.Close();
 

--- a/src/NetMQ/Core/Ctx.cs
+++ b/src/NetMQ/Core/Ctx.cs
@@ -340,7 +340,7 @@ namespace NetMQ.Core
                 // Once zmq_term() was called, we can't create new sockets.
                 if (m_terminating)
                 {
-                    string xMsg = string.Format("Ctx.CreateSocket({0}), cannot create new socket while terminating.", type);
+                    string xMsg = $"Ctx.CreateSocket({type}), cannot create new socket while terminating.";
                     throw new TerminatingException(innerException: null, message: xMsg);
                 }
 
@@ -348,7 +348,7 @@ namespace NetMQ.Core
                 if (m_emptySlots.Count == 0)
                 {
 #if DEBUG
-                    string xMsg = string.Format("Ctx.CreateSocket({0}), max number of sockets {1} reached.", type, m_maxSockets);
+                    string xMsg = $"Ctx.CreateSocket({type}), max number of sockets {m_maxSockets} reached.";
                     throw NetMQException.Create(xMsg, ErrorCode.TooManyOpenSockets);
 #else
                     throw NetMQException.Create(ErrorCode.TooManyOpenSockets);

--- a/src/NetMQ/Core/IOThread.cs
+++ b/src/NetMQ/Core/IOThread.cs
@@ -61,10 +61,7 @@ namespace NetMQ.Core
         }
 
         [NotNull]
-        internal Proactor Proactor
-        {
-            get { return m_proactor; }
-        }
+        internal Proactor Proactor => m_proactor;
 
         public void Start()
         {
@@ -83,15 +80,9 @@ namespace NetMQ.Core
         }
 
         [NotNull]
-        public IMailbox Mailbox
-        {
-            get { return m_mailbox; }
-        }
+        public IMailbox Mailbox => m_mailbox;
 
-        public int Load
-        {
-            get { return m_proactor.Load; }
-        }
+        public int Load => m_proactor.Load;
 
         protected override void ProcessStop()
         {

--- a/src/NetMQ/Core/Mailbox.cs
+++ b/src/NetMQ/Core/Mailbox.cs
@@ -176,10 +176,7 @@ namespace NetMQ.Core
         /// Get the socket-handle contained by the Signaler.
         /// </summary>
         [NotNull]
-        public Socket Handle
-        {
-            get { return m_signaler.Handle; }
-        }
+        public Socket Handle => m_signaler.Handle;
 
         /// <summary>
         /// Send the given Command out accross the command-pipe.

--- a/src/NetMQ/Core/MonitorEvent.cs
+++ b/src/NetMQ/Core/MonitorEvent.cs
@@ -56,21 +56,12 @@ namespace NetMQ.Core
         }
 
         [NotNull]
-        public string Addr
-        {
-            get { return m_addr; }
-        }
+        public string Addr => m_addr;
 
         [NotNull]
-        public object Arg
-        {
-            get { return m_arg; }
-        }
+        public object Arg => m_arg;
 
-        public SocketEvents Event
-        {
-            get { return m_monitorEvent; }
-        }
+        public SocketEvents Event => m_monitorEvent;
 
         public void Write([NotNull] SocketBase s)
         {

--- a/src/NetMQ/Core/Options.cs
+++ b/src/NetMQ/Core/Options.cs
@@ -301,10 +301,10 @@ namespace NetMQ.Core
                     else if (optionValue is byte[])
                         val = (byte[])optionValue;
                     else
-                        throw new InvalidException(string.Format("In Options.SetSocketOption(Identity, {0}) optionValue must be a string or byte-array.", optionValue == null ? "null" : optionValue.ToString()));
+                        throw new InvalidException($"In Options.SetSocketOption(Identity, {(optionValue == null ? "null" : optionValue.ToString())}) optionValue must be a string or byte-array.");
 
                     if (val.Length == 0 || val.Length > 255)
-                        throw new InvalidException(string.Format("In Options.SetSocketOption(Identity,) optionValue yielded a byte-array of length {0}, should be 1..255.", val.Length));
+                        throw new InvalidException($"In Options.SetSocketOption(Identity,) optionValue yielded a byte-array of length {val.Length}, should be 1..255.");
                     Identity = new byte[val.Length];
                     val.CopyTo(Identity, 0);
                     IdentitySize = (byte)Identity.Length;
@@ -333,14 +333,14 @@ namespace NetMQ.Core
                 case ZmqSocketOption.ReconnectIvl:
                     var reconnectIvl = (int)optionValue;
                     if (reconnectIvl < -1)
-                        throw new InvalidException(string.Format("Options.SetSocketOption(ReconnectIvl, {0}) optionValue must be >= -1.", reconnectIvl));
+                        throw new InvalidException($"Options.SetSocketOption(ReconnectIvl, {reconnectIvl}) optionValue must be >= -1.");
                     ReconnectIvl = reconnectIvl;
                     break;
 
                 case ZmqSocketOption.ReconnectIvlMax:
                     var reconnectIvlMax = (int)optionValue;
                     if (reconnectIvlMax < 0)
-                        throw new InvalidException(string.Format("Options.SetSocketOption(ReconnectIvlMax, {0}) optionValue must be non-negative.", reconnectIvlMax));
+                        throw new InvalidException($"Options.SetSocketOption(ReconnectIvlMax, {reconnectIvlMax}) optionValue must be non-negative.");
                     ReconnectIvlMax = reconnectIvlMax;
                     break;
 
@@ -374,7 +374,7 @@ namespace NetMQ.Core
                 case ZmqSocketOption.TcpKeepalive:
                     var tcpKeepalive = (int)optionValue;
                     if (tcpKeepalive != -1 && tcpKeepalive != 0 && tcpKeepalive != 1)
-                        throw new InvalidException(string.Format("Options.SetSocketOption(TcpKeepalive, {0}) optionValue is neither -1, 0, nor 1.", tcpKeepalive));
+                        throw new InvalidException($"Options.SetSocketOption(TcpKeepalive, {tcpKeepalive}) optionValue is neither -1, 0, nor 1.");
                     TcpKeepalive = tcpKeepalive;
                     break;
 

--- a/src/NetMQ/Core/Own.cs
+++ b/src/NetMQ/Core/Own.cs
@@ -249,7 +249,7 @@ namespace NetMQ.Core
         /// <summary>
         /// Returns true if the object is in process of termination.
         /// </summary>
-        protected bool IsTerminating { get { return m_terminating; } }
+        protected bool IsTerminating => m_terminating;
 
         /// <summary>
         /// Send termination requests to all of the owned objects, and then runs the termination process.

--- a/src/NetMQ/Core/Patterns/Router.cs
+++ b/src/NetMQ/Core/Patterns/Router.cs
@@ -55,7 +55,7 @@ namespace NetMQ.Core.Patterns
             }
 
             [NotNull]
-            public Pipe Pipe { get; private set; }
+            public Pipe Pipe { get; }
 
             public bool Active;
         };

--- a/src/NetMQ/Core/Patterns/Stream.cs
+++ b/src/NetMQ/Core/Patterns/Stream.cs
@@ -49,7 +49,7 @@ namespace NetMQ.Core.Patterns
             }
 
             [NotNull]
-            public Pipe Pipe { get; private set; }
+            public Pipe Pipe { get; }
 
             public bool Active;
         }

--- a/src/NetMQ/Core/Patterns/Sub.cs
+++ b/src/NetMQ/Core/Patterns/Sub.cs
@@ -63,7 +63,7 @@ namespace NetMQ.Core.Patterns
             else if (optionValue is byte[])
                 topic = (byte[])optionValue;
             else
-                throw new InvalidException(string.Format("In Sub.XSetSocketOption({0},{1}), optionValue must be either a string or a byte-array.", option, (optionValue == null ? "null" : optionValue.ToString())));
+                throw new InvalidException($"In Sub.XSetSocketOption({option},{(optionValue == null ? "null" : optionValue.ToString())}), optionValue must be either a string or a byte-array.");
 
             // Create the subscription message.
             var msg = new Msg();
@@ -78,7 +78,7 @@ namespace NetMQ.Core.Patterns
 
                 if (!isMessageSent)
                 {
-                    string xMsg = string.Format("in Sub.XSetSocketOption({0}, {1}), XSend returned false.", option, optionValue);
+                    string xMsg = $"in Sub.XSetSocketOption({option}, {optionValue}), XSend returned false.";
                     // TODO: should we change the excepion that is thrown here as AgainException is obsolete?
 #pragma warning disable 618                    
                     throw new AgainException(innerException: null, message: xMsg);

--- a/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
@@ -441,9 +441,6 @@ namespace NetMQ.Core.Patterns.Utils
             }
         }
 
-        private bool IsRedundant
-        {
-            get { return m_pipes == null && m_liveNodes == 0; }
-        }
+        private bool IsRedundant => m_pipes == null && m_liveNodes == 0;
     }
 }

--- a/src/NetMQ/Core/Patterns/XPub.cs
+++ b/src/NetMQ/Core/Patterns/XPub.cs
@@ -248,7 +248,7 @@ namespace NetMQ.Core.Patterns
                     {
                         var bytes = optionValue as byte[];
                         if (bytes == null)
-                            throw new InvalidException(string.Format("In XPub.XSetSocketOption({0},{1}), optionValue must be a byte-array.", option, optionValue));
+                            throw new InvalidException($"In XPub.XSetSocketOption({option},{optionValue}), optionValue must be a byte-array.");
                         var welcomeBytes = new byte[bytes.Length];
                         bytes.CopyTo(welcomeBytes, 0);
                         m_welcomeMessage.InitGC(welcomeBytes, welcomeBytes.Length);

--- a/src/NetMQ/Core/Reaper.cs
+++ b/src/NetMQ/Core/Reaper.cs
@@ -92,10 +92,7 @@ namespace NetMQ.Core
         /// Get the Mailbox that this Reaper uses for communication with the rest of the message-queueing subsystem.
         /// </summary>
         [NotNull]
-        public Mailbox Mailbox
-        {
-            get { return m_mailbox; }
-        }
+        public Mailbox Mailbox => m_mailbox;
 
         /// <summary>
         /// Start the contained Poller to begin polling.

--- a/src/NetMQ/Core/SessionBase.cs
+++ b/src/NetMQ/Core/SessionBase.cs
@@ -196,8 +196,7 @@ namespace NetMQ.Core
             }
 
             // Close the engine.
-            if (m_engine != null)
-                m_engine.Terminate();
+            m_engine?.Terminate();
         }
 
         /// <summary>
@@ -295,8 +294,7 @@ namespace NetMQ.Core
         /// </summary>
         public void Flush()
         {
-            if (m_pipe != null)
-                m_pipe.Flush();
+            m_pipe?.Flush();
         }
 
         /// <summary>
@@ -390,8 +388,7 @@ namespace NetMQ.Core
                 return;
             }
 
-            if (m_engine != null)
-                m_engine.ActivateIn();
+            m_engine?.ActivateIn();
         }
 
         public void Hiccuped(Pipe pipe)
@@ -467,8 +464,7 @@ namespace NetMQ.Core
             Detached();
 
             // Just in case there's only a delimiter in the pipe.
-            if (m_pipe != null)
-                m_pipe.CheckRead();
+            m_pipe?.CheckRead();
         }
 
         /// <summary>

--- a/src/NetMQ/Core/SessionBase.cs
+++ b/src/NetMQ/Core/SessionBase.cs
@@ -405,10 +405,7 @@ namespace NetMQ.Core
         /// Get the contained socket.
         /// </summary>
         [NotNull]
-        public SocketBase Socket
-        {
-            get { return m_socket; }
-        }
+        public SocketBase Socket => m_socket;
 
         /// <summary>
         /// Process the Plug-request by setting this SessionBase as teh handler for the io-object

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -420,7 +420,7 @@ namespace NetMQ.Core
                         bool addressRegistered = RegisterEndpoint(addr, endpoint);
 
                         if (!addressRegistered)
-                            throw new AddressAlreadyInUseException(string.Format("Cannot bind address ( {0} ) - already in use.", addr));
+                            throw new AddressAlreadyInUseException($"Cannot bind address ( {addr} ) - already in use.");
 
                         m_options.LastEndpoint = addr;
                         return;
@@ -458,9 +458,7 @@ namespace NetMQ.Core
                             m_port = listener.Port;
 
                             // Recreate the address string (localhost:1234) in case the port was system-assigned
-                            addr = string.Format("tcp://{0}:{1}",
-                                address.Substring(0, address.IndexOf(':')),
-                                m_port);
+                            addr = $"tcp://{address.Substring(0, address.IndexOf(':'))}:{m_port}";
                         }
                         catch (NetMQException ex)
                         {
@@ -515,7 +513,7 @@ namespace NetMQ.Core
                     }
                 default:
                     {
-                        throw new ArgumentException(string.Format("Address {0} has unsupported protocol: {1}", addr, protocol), nameof(addr));
+                        throw new ArgumentException($"Address {addr} has unsupported protocol: {protocol}", nameof(addr));
                     }
             }
         }
@@ -1337,7 +1335,7 @@ namespace NetMQ.Core
 
             // Event notification only supported over inproc://
             if (protocol != Address.InProcProtocol)
-                throw new ProtocolNotSupportedException(string.Format("In SocketBase.Monitor({0},), protocol must be inproc", addr));
+                throw new ProtocolNotSupportedException($"In SocketBase.Monitor({addr},), protocol must be inproc");
 
             // Register events to monitor
             m_monitorEvents = events;

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -191,10 +191,7 @@ namespace NetMQ.Core
         /// Return the Mailbox associated with this socket.
         /// </summary>
         [NotNull]
-        public Mailbox Mailbox
-        {
-            get { return m_mailbox; }
-        }
+        public Mailbox Mailbox => m_mailbox;
 
         /// <summary>
         /// Interrupt a blocking call if the socket is stuck in one.
@@ -1490,10 +1487,7 @@ namespace NetMQ.Core
         /// Get the Socket (Handle) - which is actually the Handle of the contained mailbox.
         /// </summary>
         [NotNull]
-        public Socket Handle
-        {
-            get { return m_mailbox.Handle; }
-        }
+        public Socket Handle => m_mailbox.Handle;
 
         /// <summary>
         /// Return a short bit of text that denotes the SocketType of this socket.

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -515,7 +515,7 @@ namespace NetMQ.Core
                     }
                 default:
                     {
-                        throw new ArgumentException(string.Format("Address {0} has unsupported protocol: {1}", addr, protocol), "addr");
+                        throw new ArgumentException(string.Format("Address {0} has unsupported protocol: {1}", addr, protocol), nameof(addr));
                     }
             }
         }
@@ -741,7 +741,7 @@ namespace NetMQ.Core
 
             // Check whether endpoint address passed to the function is valid.
             if (addr == null)
-                throw new ArgumentNullException("addr");
+                throw new ArgumentNullException(nameof(addr));
 
             // Process pending commands, if any, since there could be pending unprocessed process_own()'s
             //  (from launch_child() for example) we're asked to terminate now.

--- a/src/NetMQ/Core/Transports/ByteArraySegment.cs
+++ b/src/NetMQ/Core/Transports/ByteArraySegment.cs
@@ -58,10 +58,7 @@ namespace NetMQ.Core.Transports
         /// <summary>
         /// Get the number of bytes within the buffer that is past the Offset (ie, buffer-length minus offset).
         /// </summary>
-        public int Size
-        {
-            get { return m_innerBuffer.Length - Offset; }
-        }
+        public int Size => m_innerBuffer.Length - Offset;
 
         /// <summary>
         /// Add the given value to the offset.

--- a/src/NetMQ/Core/Transports/Ipc/IpcAddress.cs
+++ b/src/NetMQ/Core/Transports/Ipc/IpcAddress.cs
@@ -49,9 +49,6 @@ namespace NetMQ.Core.Transports.Ipc
 
         public IPEndPoint Address { get; private set; }
 
-        public string Protocol
-        {
-            get { return Core.Address.IpcProtocol; }
-        }
+        public string Protocol => Core.Address.IpcProtocol;
     }
 }

--- a/src/NetMQ/Core/Transports/Ipc/IpcListener.cs
+++ b/src/NetMQ/Core/Transports/Ipc/IpcListener.cs
@@ -45,10 +45,7 @@ namespace NetMQ.Core.Transports.Ipc
         /// <summary>
         /// Get the bound address for use with wildcards
         /// </summary>
-        public override string Address
-        {
-            get { return m_address.ToString(); }
-        }
+        public override string Address => m_address.ToString();
 
         /// <summary>
         /// Set address to listen on.

--- a/src/NetMQ/Core/Transports/Pgm/PgmAddress.cs
+++ b/src/NetMQ/Core/Transports/Pgm/PgmAddress.cs
@@ -90,9 +90,6 @@ namespace NetMQ.Core.Transports.Pgm
                 : Protocol + "://" + endpoint.Address + ":" + endpoint.Port;
         }
 
-        public string Protocol
-        {
-            get { return Core.Address.PgmProtocol; }
-        }
+        public string Protocol => Core.Address.PgmProtocol;
     }
 }

--- a/src/NetMQ/Core/Transports/Pgm/PgmAddress.cs
+++ b/src/NetMQ/Core/Transports/Pgm/PgmAddress.cs
@@ -23,7 +23,7 @@ namespace NetMQ.Core.Transports.Pgm
             int delimiter = name.LastIndexOf(':');
             if (delimiter < 0)
             {
-                throw new InvalidException(string.Format("In PgmAddress.Resolve({0},{1}), delimiter ({2}) must be non-negative.", name, ip4Only, delimiter));
+                throw new InvalidException($"In PgmAddress.Resolve({name},{ip4Only}), delimiter ({delimiter}) must be non-negative.");
             }
 
             // Separate the address/port.
@@ -60,7 +60,7 @@ namespace NetMQ.Core.Transports.Pgm
                 port = Convert.ToInt32(portStr);
                 
                 if (port == 0)
-                    throw new InvalidException(string.Format("In PgmAddress.Resolve({0},{1}), portStr ({2}) must denote a valid nonzero integer.", name, ip4Only, portStr));
+                    throw new InvalidException($"In PgmAddress.Resolve({name},{ip4Only}), portStr ({portStr}) must denote a valid nonzero integer.");
             }
 
             if (addrStr == "*")
@@ -68,7 +68,7 @@ namespace NetMQ.Core.Transports.Pgm
 
             IPAddress ipAddress;
             if (!IPAddress.TryParse(addrStr, out ipAddress))
-                throw new InvalidException(string.Format("In PgmAddress.Resolve({0},{1}), addrStr ({2}) must be a valid IPAddress.", name, ip4Only, addrStr));
+                throw new InvalidException($"In PgmAddress.Resolve({name},{ip4Only}), addrStr ({addrStr}) must be a valid IPAddress.");
 
             Address = new IPEndPoint(ipAddress, port);
         }

--- a/src/NetMQ/Core/Transports/Pgm/PgmSession.cs
+++ b/src/NetMQ/Core/Transports/Pgm/PgmSession.cs
@@ -169,8 +169,7 @@ namespace NetMQ.Core.Transports.Pgm
             m_ioObject.Unplug();
 
             // Disconnect from session object.
-            if (m_decoder != null)
-                m_decoder.SetMsgSink(null);
+            m_decoder?.SetMsgSink(null);
 
             m_session = null;
 

--- a/src/NetMQ/Core/Transports/Pgm/PgmSocket.cs
+++ b/src/NetMQ/Core/Transports/Pgm/PgmSocket.cs
@@ -93,7 +93,7 @@ namespace NetMQ.Core.Transports.Pgm
             }
             catch (SocketException x)
             {
-                string xMsg = string.Format("SocketException with ErrorCode={0}, SocketErrorCode={1}, Message={2}, in PgmSocket.Init, within AsyncSocket.Create(AddressFamily.InterNetwork, SocketType.Rdm, PGM_PROTOCOL_TYPE), {3}", x.ErrorCode, x.SocketErrorCode, x.Message, this);
+                string xMsg = $"SocketException with ErrorCode={x.ErrorCode}, SocketErrorCode={x.SocketErrorCode}, Message={x.Message}, in PgmSocket.Init, within AsyncSocket.Create(AddressFamily.InterNetwork, SocketType.Rdm, PGM_PROTOCOL_TYPE), {this}";
                 Debug.WriteLine(xMsg);
                 // If running on Microsoft Windows, suggest to the developer that he may need to install MSMQ in order to get PGM socket support.
                 PlatformID p = Environment.OSVersion.Platform;

--- a/src/NetMQ/Core/Transports/StreamEngine.cs
+++ b/src/NetMQ/Core/Transports/StreamEngine.cs
@@ -39,11 +39,11 @@ namespace NetMQ.Core.Transports
                 BytesTransferred = bytesTransferred;
             }
 
-            public Action Action { get; private set; }
+            public Action Action { get; }
 
-            public SocketError SocketError { get; private set; }
+            public SocketError SocketError { get; }
 
-            public int BytesTransferred { get; private set; }
+            public int BytesTransferred { get; }
         }
 
         /// <summary>

--- a/src/NetMQ/Core/Transports/StreamEngine.cs
+++ b/src/NetMQ/Core/Transports/StreamEngine.cs
@@ -239,10 +239,8 @@ namespace NetMQ.Core.Transports
             m_state = State.Closed;
 
             // Disconnect from session object.
-            if (m_encoder != null)
-                m_encoder.SetMsgSource(null);
-            if (m_decoder != null)
-                m_decoder.SetMsgSink(null);
+            m_encoder?.SetMsgSource(null);
+            m_decoder?.SetMsgSink(null);
             m_session = null;
         }
 

--- a/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
@@ -63,7 +63,7 @@ namespace NetMQ.Core.Transports.Tcp
             // Find the ':' at end that separates address from the port number.
             int delimiter = name.LastIndexOf(':');
             if (delimiter < 0)
-                throw new InvalidException(string.Format("TcpAddress.Resolve, delimiter ({0}) must be non-negative.", delimiter));
+                throw new InvalidException($"TcpAddress.Resolve, delimiter ({delimiter}) must be non-negative.");
 
             // Separate the address/port.
             string addrStr = name.Substring(0, delimiter);
@@ -87,7 +87,7 @@ namespace NetMQ.Core.Transports.Tcp
                 port = Convert.ToInt32(portStr);
                 if (port == 0)
                 {
-                    throw new InvalidException(string.Format("TcpAddress.Resolve, port ({0}) must be a valid nonzero integer.", portStr));
+                    throw new InvalidException($"TcpAddress.Resolve, port ({portStr}) must be a valid nonzero integer.");
                 }
             }
 
@@ -111,7 +111,7 @@ namespace NetMQ.Core.Transports.Tcp
                               ip.AddressFamily == AddressFamily.InterNetworkV6);
 
                 if (ipAddress == null)
-                    throw new InvalidException(string.Format("TcpAddress.Resolve, unable to find an IP address for {0}", name));
+                    throw new InvalidException($"TcpAddress.Resolve, unable to find an IP address for {name}");
             }
 
             Address = new IPEndPoint(ipAddress, port);             

--- a/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
@@ -127,9 +127,6 @@ namespace NetMQ.Core.Transports.Tcp
         /// Get the textual-representation of the communication protocol implied by this TcpAddress,
         /// which here is simply "tcp".
         /// </summary>
-        public string Protocol
-        {
-            get { return Core.Address.TcpProtocol; }
-        }
+        public string Protocol => Core.Address.TcpProtocol;
     }
 }

--- a/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
@@ -280,18 +280,12 @@ namespace NetMQ.Core.Transports.Tcp
         /// Get the bound address for use with wildcards
         /// </summary>
         [NotNull]
-        public virtual string Address
-        {
-            get { return m_address.ToString(); }
-        }
+        public virtual string Address => m_address.ToString();
 
         /// <summary>
         /// Get the port-number to listen on.
         /// </summary>
-        public virtual int Port
-        {
-            get { return m_port; }
-        }
+        public virtual int Port => m_port;
 
         /// <summary>
         /// This method would be called when a message Send operation has been completed - except in this case it simply throws a NotImplementedException.

--- a/src/NetMQ/Core/Utils/Poller.cs
+++ b/src/NetMQ/Core/Utils/Poller.cs
@@ -40,13 +40,13 @@ namespace NetMQ.Core.Utils
             /// Get the Socket that this PollSet contains.
             /// </summary>
             [NotNull]
-            public Socket Socket { get; private set; }
+            public Socket Socket { get; }
 
             /// <summary>
             /// Get the IPollEvents object that has methods to signal when ready for reading or writing.
             /// </summary>
             [NotNull]
-            public IPollEvents Handler { get; private set; }
+            public IPollEvents Handler { get; }
 
             /// <summary>
             /// Get or set whether this PollSet is cancelled.

--- a/src/NetMQ/Core/Utils/PollerBase.cs
+++ b/src/NetMQ/Core/Utils/PollerBase.cs
@@ -58,12 +58,12 @@ namespace NetMQ.Core.Utils
             /// Get the ITimerEvent that serves as the event-sink.
             /// </summary>
             [NotNull]
-            public ITimerEvent Sink { get; private set; }
+            public ITimerEvent Sink { get; }
 
             /// <summary>
             /// Get the integer Id of this TimerInfo.
             /// </summary>
-            public int Id { get; private set; }
+            public int Id { get; }
         }
 
         /// <summary>

--- a/src/NetMQ/Core/Utils/Proactor.cs
+++ b/src/NetMQ/Core/Utils/Proactor.cs
@@ -27,7 +27,7 @@ namespace NetMQ.Core.Utils
             }
 
             [NotNull] 
-            public IProactorEvents ProactorEvents { get; private set; }
+            public IProactorEvents ProactorEvents { get; }
             public bool Cancelled { get; set; }
         }
 

--- a/src/NetMQ/Core/Utils/Selector.cs
+++ b/src/NetMQ/Core/Utils/Selector.cs
@@ -54,7 +54,7 @@ namespace NetMQ.Core.Utils
         public bool Select([NotNull] SelectItem[] items, int itemsCount, long timeout)
         {
             if (items == null)
-                throw new ArgumentNullException("items");
+                throw new ArgumentNullException(nameof(items));
 
             if (itemsCount == 0)
             {

--- a/src/NetMQ/Core/Utils/Selector.cs
+++ b/src/NetMQ/Core/Utils/Selector.cs
@@ -23,11 +23,11 @@ namespace NetMQ.Core.Utils
             Event = @event;
         }
 
-        public Socket FileDescriptor { get; private set; }
+        public Socket FileDescriptor { get; }
 
-        public SocketBase Socket { get; private set; }
+        public SocketBase Socket { get; }
 
-        public PollEvents Event { get; private set; }
+        public PollEvents Event { get; }
 
         public PollEvents ResultEvent { get; set; }
     }

--- a/src/NetMQ/Core/Utils/Selector.cs
+++ b/src/NetMQ/Core/Utils/Selector.cs
@@ -126,7 +126,7 @@ namespace NetMQ.Core.Utils
                     string textOfListRead = StringLib.AsString(m_checkRead);
                     string textOfListWrite = StringLib.AsString(m_checkWrite);
                     string textOfListError = StringLib.AsString(m_checkError);
-                    string xMsg = string.Format("In Selector.Select, Socket.Select({0}, {1}, {2}, {3}) threw a SocketException: {4}", textOfListRead, textOfListWrite, textOfListError, currentTimeoutMicroSeconds, x.Message);
+                    string xMsg = $"In Selector.Select, Socket.Select({textOfListRead}, {textOfListWrite}, {textOfListError}, {currentTimeoutMicroSeconds}) threw a SocketException: {x.Message}";
                     Debug.WriteLine(xMsg);
                     throw new FaultException(innerException: x, message: xMsg);
 #else

--- a/src/NetMQ/Core/Utils/Signaler.cs
+++ b/src/NetMQ/Core/Utils/Signaler.cs
@@ -91,10 +91,7 @@ namespace NetMQ.Core.Utils
         // to pass the signals.
 
         [NotNull]
-        public Socket Handle
-        {
-            get { return m_readSocket; }
-        }
+        public Socket Handle => m_readSocket;
 
         public void Send()
         {

--- a/src/NetMQ/Core/Utils/YQueue.cs
+++ b/src/NetMQ/Core/Utils/YQueue.cs
@@ -109,16 +109,16 @@ namespace NetMQ.Core.Utils
         /// <summary>Gets the index of the front element of the queue.</summary>
         /// <value>The index of the front element of the queue.</value>
         /// <remarks>If the queue is empty, it should be equal to <see cref="BackPos"/>.</remarks>
-        public int FrontPos { get { return m_beginChunk.GlobalOffset + m_beginPositionInChunk; } }
+        public int FrontPos => m_beginChunk.GlobalOffset + m_beginPositionInChunk;
 
         /// <summary>Gets the front element of the queue. If the queue is empty, behaviour is undefined.</summary>
         /// <value>The front element of the queue.</value>
-        public T Front { get { return m_beginChunk.Values[m_beginPositionInChunk]; } }
+        public T Front => m_beginChunk.Values[m_beginPositionInChunk];
 
         /// <summary>Gets the index of the back element of the queue.</summary>
         /// <value>The index of the back element of the queue.</value>
         /// <remarks>If the queue is empty, it should be equal to <see cref="FrontPos"/>.</remarks>
-        public int BackPos { get { return m_backChunk.GlobalOffset + m_backPositionInChunk; } }
+        public int BackPos => m_backChunk.GlobalOffset + m_backPositionInChunk;
 
         /// <summary>Retrieves the element at the front of the queue.</summary>
         /// <returns>The element taken from queue.</returns>

--- a/src/NetMQ/Core/Utils/YQueue.cs
+++ b/src/NetMQ/Core/Utils/YQueue.cs
@@ -94,7 +94,7 @@ namespace NetMQ.Core.Utils
         public YQueue(int chunkSize)
         {
             if (chunkSize < 2)
-                throw new ArgumentOutOfRangeException("chunkSize", "Should be no less than 2");
+                throw new ArgumentOutOfRangeException(nameof(chunkSize), "Should be no less than 2");
 
             m_chunkSize = chunkSize;
 

--- a/src/NetMQ/Core/Utils/YQueue.cs
+++ b/src/NetMQ/Core/Utils/YQueue.cs
@@ -53,10 +53,10 @@ namespace NetMQ.Core.Utils
             }
 
             [NotNull]
-            public T[] Values { get; private set; }
+            public T[] Values { get; }
 
             /// <summary>Contains global index positions of elements in the chunk.</summary>
-            public int GlobalOffset { get; private set; }
+            public int GlobalOffset { get; }
 
             /// <summary>Optional link to the previous <see cref="Chunk"/>.</summary>
             [CanBeNull]

--- a/src/NetMQ/Core/ZObject.cs
+++ b/src/NetMQ/Core/ZObject.cs
@@ -62,19 +62,13 @@ namespace NetMQ.Core
         /// <summary>
         /// Get the id of the thread that this object belongs to.
         /// </summary>
-        public int ThreadId
-        {
-            get { return m_threadId; }
-        }
+        public int ThreadId => m_threadId;
 
         /// <summary>
         /// Get the context that provides access to the global state.
         /// </summary>
         [NotNull]
-        protected Ctx Ctx
-        {
-            get { return m_ctx; }
-        }
+        protected Ctx Ctx => m_ctx;
 
         protected bool RegisterEndpoint([NotNull] string addr, [NotNull] Ctx.Endpoint endpoint)
         {

--- a/src/NetMQ/Devices/DeviceBase.cs
+++ b/src/NetMQ/Devices/DeviceBase.cs
@@ -85,10 +85,10 @@ namespace NetMQ.Devices
             m_isInitialized = false;
 
             if (frontendSocket == null)
-                throw new ArgumentNullException("frontendSocket");
+                throw new ArgumentNullException(nameof(frontendSocket));
 
             if (backendSocket == null)
-                throw new ArgumentNullException("backendSocket");
+                throw new ArgumentNullException(nameof(backendSocket));
 
             FrontendSocket = frontendSocket;
             BackendSocket = backendSocket;

--- a/src/NetMQ/Devices/DeviceBase.cs
+++ b/src/NetMQ/Devices/DeviceBase.cs
@@ -44,12 +44,12 @@ namespace NetMQ.Devices
         /// <summary>
         /// Get a <see cref="DeviceSocketSetup"/> for configuring the frontend socket.
         /// </summary>
-        public DeviceSocketSetup FrontendSetup { get; private set; }
+        public DeviceSocketSetup FrontendSetup { get; }
 
         /// <summary>
         /// Get a <see cref="DeviceSocketSetup"/> for configuring the backend socket.
         /// </summary>
-        public DeviceSocketSetup BackendSetup { get; private set; }
+        public DeviceSocketSetup BackendSetup { get; }
 
         /// <summary>
         /// Create a new instance of the <see cref="DeviceBase"/> class.

--- a/src/NetMQ/Devices/DeviceSocketSetup.cs
+++ b/src/NetMQ/Devices/DeviceSocketSetup.cs
@@ -47,7 +47,7 @@ namespace NetMQ.Devices
         internal DeviceSocketSetup([NotNull] NetMQSocket socket)
         {
             if (socket == null)
-                throw new ArgumentNullException("socket");
+                throw new ArgumentNullException(nameof(socket));
 
             m_socket = socket;
             m_socketInitializers = new List<Action<NetMQSocket>>();
@@ -65,7 +65,7 @@ namespace NetMQ.Devices
         public DeviceSocketSetup Bind([NotNull] string endpoint)
         {
             if (endpoint == null)
-                throw new ArgumentNullException("endpoint");
+                throw new ArgumentNullException(nameof(endpoint));
 
             m_bindings.Add(endpoint);
             return this;
@@ -81,7 +81,7 @@ namespace NetMQ.Devices
         public DeviceSocketSetup Connect([NotNull] string endpoint)
         {
             if (endpoint == null)
-                throw new ArgumentNullException("endpoint");
+                throw new ArgumentNullException(nameof(endpoint));
 
             m_connections.Add(endpoint);
             return this;

--- a/src/NetMQ/Devices/DeviceSocketSetup.cs
+++ b/src/NetMQ/Devices/DeviceSocketSetup.cs
@@ -135,7 +135,7 @@ namespace NetMQ.Devices
 
                 if (sck == null)
                 {
-                    string xMsg = string.Format("DeviceSocketSetup.Subscribe, this socket type {0} does not support Subscription.", s.GetType());
+                    string xMsg = $"DeviceSocketSetup.Subscribe, this socket type {s.GetType()} does not support Subscription.";
                     throw new InvalidException(xMsg);
                 }
 
@@ -157,7 +157,7 @@ namespace NetMQ.Devices
 
                 if (sck == null)
                 {
-                    string xMsg = string.Format("DeviceSocketSetup.Subscribe, this socket type {0} does not support Subscription.", s.GetType());
+                    string xMsg = $"DeviceSocketSetup.Subscribe, this socket type {s.GetType()} does not support Subscription.";
                     throw new ArgumentException(xMsg);
                 }
 

--- a/src/NetMQ/EventDelegator.cs
+++ b/src/NetMQ/EventDelegator.cs
@@ -55,11 +55,7 @@ namespace NetMQ
         /// <param name="args">the subclass of EventArgs that the event-handler will receive</param>
         public void Fire([NotNull] object sender, [NotNull] T args)
         {
-            var temp = m_event;
-            if (temp != null)
-            {
-                temp(sender, args);
-            }
+            m_event?.Invoke(sender, args);
         }
 
         public void Dispose()

--- a/src/NetMQ/InProcActors/Actor.cs
+++ b/src/NetMQ/InProcActors/Actor.cs
@@ -48,8 +48,7 @@ namespace NetMQ.Actors
         [NotNull]
         private static string GetEndPointName()
         {
-            return string.Format("inproc://zactor-{0}-{1}",
-                s_rand.Next(0, 10000), s_rand.Next(0, 10000));
+            return $"inproc://zactor-{s_rand.Next(0, 10000)}-{s_rand.Next(0, 10000)}";
         }
 
         /// <summary>

--- a/src/NetMQ/InProcActors/Actor.cs
+++ b/src/NetMQ/InProcActors/Actor.cs
@@ -145,10 +145,7 @@ namespace NetMQ.Actors
             remove { m_sendEvent.Event -= value; }
         }
 
-        NetMQSocket ISocketPollable.Socket
-        {
-            get { return m_self; }
-        }
+        NetMQSocket ISocketPollable.Socket => m_self;
 
         private void CreateShimThread()
         {

--- a/src/NetMQ/Monitoring/NetMQMonitor.cs
+++ b/src/NetMQ/Monitoring/NetMQMonitor.cs
@@ -194,13 +194,8 @@ namespace NetMQ.Monitoring
 
         private void InvokeEvent<T>(EventHandler<T> handler, T args) where T : NetMQMonitorEventArgs
         {
-            var t1 = EventReceived;
-            if (t1 != null)
-                t1(this, args);
-
-            var t2 = handler;
-            if (t2 != null)
-                t2(this, args);
+            EventReceived?.Invoke(this, args);
+            handler?.Invoke(this, args);
         }
 
         private void InternalStart()

--- a/src/NetMQ/Monitoring/NetMQMonitor.cs
+++ b/src/NetMQ/Monitoring/NetMQMonitor.cs
@@ -72,7 +72,7 @@ namespace NetMQ.Monitoring
         /// <summary>
         /// The monitoring address.
         /// </summary>
-        public string Endpoint { get; private set; }
+        public string Endpoint { get; }
 
         /// <summary>
         /// Get whether this monitor is currently running.

--- a/src/NetMQ/Msg.cs
+++ b/src/NetMQ/Msg.cs
@@ -108,20 +108,14 @@ namespace NetMQ
         /// which would indicate that this message is intended for use simply to mark a boundary
         /// between other parts of some unit of communication.
         /// </summary>
-        public bool IsDelimiter
-        {
-            get { return MsgType == MsgType.Delimiter; }
-        }
+        public bool IsDelimiter => MsgType == MsgType.Delimiter;
 
         /// <summary>Get whether this <see cref="Msg"/> is initialised and ready for use.</summary>
         /// <remarks>A newly constructed <see cref="Msg"/> is uninitialised, and can be initialised via one
         /// of <see cref="InitEmpty"/>, <see cref="InitDelimiter"/>, <see cref="InitGC"/>, or <see cref="InitPool"/>. 
         /// Calling <see cref="Close"/> will cause the <see cref="Msg"/> to become uninitialised again.</remarks>
         /// <returns><c>true</c> if the <see cref="Msg"/> is initialised, otherwise <c>false</c>.</returns>
-        public bool IsInitialised
-        {
-            get { return MsgType != MsgType.Uninitialised; }
-        }
+        public bool IsInitialised => MsgType != MsgType.Uninitialised;
 
         #endregion
 
@@ -135,27 +129,18 @@ namespace NetMQ
         /// <summary>
         /// Get the "Has-More" flag, which when set on a message-queue frame indicates that there are more frames to follow.
         /// </summary>
-        public bool HasMore
-        {
-            get { return (Flags & MsgFlags.More) == MsgFlags.More; }
-        }
+        public bool HasMore => (Flags & MsgFlags.More) == MsgFlags.More;
 
         /// <summary>
         /// Get whether the <see cref="Data"/> buffer of this <see cref="Msg"/> is shared with another instance.
         /// Only applies to pooled message types.
         /// </summary>
-        public bool IsShared
-        {
-            get { return (Flags & MsgFlags.Shared) != 0; }
-        }
+        public bool IsShared => (Flags & MsgFlags.Shared) != 0;
 
         /// <summary>
         /// Get whether the Identity bit is set on the Flags property.
         /// </summary>
-        public bool IsIdentity
-        {
-            get { return (Flags & MsgFlags.Identity) != 0; }
-        }
+        public bool IsIdentity => (Flags & MsgFlags.Identity) != 0;
 
         /// <summary>
         /// Set the indicated Flags bits.

--- a/src/NetMQ/NetMQActor.cs
+++ b/src/NetMQ/NetMQActor.cs
@@ -309,10 +309,7 @@ namespace NetMQ
             remove { m_sendEvent.Event -= value; }
         }
 
-        NetMQSocket ISocketPollable.Socket
-        {
-            get { return m_self; }
-        }
+        NetMQSocket ISocketPollable.Socket => m_self;
 
         #endregion
 

--- a/src/NetMQ/NetMQActor.cs
+++ b/src/NetMQ/NetMQActor.cs
@@ -159,7 +159,7 @@ namespace NetMQ
             {
                 try
                 {
-                    endPoint = string.Format("inproc://NetMQActor-{0}-{1}", random.Next(0, 10000), random.Next(0, 10000));
+                    endPoint = $"inproc://NetMQActor-{random.Next(0, 10000)}-{random.Next(0, 10000)}";
                     m_self.Bind(endPoint);
                     break;
                 }

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -290,10 +290,7 @@ namespace NetMQ
         /// <summary>
         /// Get the socket of the contained actor.
         /// </summary>
-        NetMQSocket ISocketPollable.Socket
-        {
-            get { return ((ISocketPollable)m_actor).Socket; }
-        }
+        NetMQSocket ISocketPollable.Socket => ((ISocketPollable)m_actor).Socket;
 
         /// <summary>
         /// This event occurs when at least one message may be received from the socket without blocking.

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -160,10 +160,7 @@ namespace NetMQ
                 m_poller.PollTillCancelled();
 
                 // the beacon might never been configured
-                if (m_udpSocket != null)
-                {
-                    m_udpSocket.Close();
-                }
+                m_udpSocket?.Close();
             }
 
             private void PingElapsed(object sender, NetMQTimerEventArgs e)
@@ -177,14 +174,7 @@ namespace NetMQ
                 var frame = ReceiveUdpFrame(out peerName);
 
                 // If filter is set, check that beacon matches it
-                bool isValid = false;
-                if (m_filter != null)
-                {
-                    if (frame.MessageSize >= m_filter.MessageSize && Compare(frame, m_filter, m_filter.MessageSize))
-                    {
-                        isValid = true;
-                    }
-                }
+                var isValid = frame.MessageSize >= m_filter?.MessageSize && Compare(frame, m_filter, m_filter.MessageSize);
 
                 // If valid, discard our own broadcasts, which UDP echoes to us
                 if (isValid && m_transmit != null)

--- a/src/NetMQ/NetMQContext.cs
+++ b/src/NetMQ/NetMQContext.cs
@@ -117,7 +117,7 @@ namespace NetMQ
                 case ZmqSocketType.Stream:
                     return new StreamSocket(socketHandle);
                 default:
-                    throw new ArgumentOutOfRangeException("socketType");
+                    throw new ArgumentOutOfRangeException(nameof(socketType));
             }
         }
 
@@ -253,12 +253,12 @@ namespace NetMQ
         {
             if (endpoint == null)
             {
-                throw new ArgumentNullException("endpoint");
+                throw new ArgumentNullException(nameof(endpoint));
             }
 
             if (endpoint == string.Empty)
             {
-                throw new ArgumentException("Unable to monitor to an empty endpoint.", "endpoint");
+                throw new ArgumentException("Unable to monitor to an empty endpoint.", nameof(endpoint));
             }
 
             return new NetMQMonitor(CreatePairSocket(), endpoint, ownsSocket: true);

--- a/src/NetMQ/NetMQException.cs
+++ b/src/NetMQ/NetMQException.cs
@@ -13,7 +13,7 @@ namespace NetMQ
     [Serializable]
     public class NetMQException : Exception
     {
-        public ErrorCode ErrorCode { get; private set; }
+        public ErrorCode ErrorCode { get; }
 
         #region Exception contract & serialisation
 

--- a/src/NetMQ/NetMQException.cs
+++ b/src/NetMQ/NetMQException.cs
@@ -83,7 +83,7 @@ namespace NetMQ
 #if DEBUG
             if (errorCode == 0)
             {
-                var s = string.Format("(And within NetMQException.Create: Unanticipated error-code: {0})", error.ToString());
+                var s = $"(And within NetMQException.Create: Unanticipated error-code: {error.ToString()})";
                 return Create(errorCode: errorCode, message: s, innerException: innerException);
             }
 #endif

--- a/src/NetMQ/NetMQFrame.cs
+++ b/src/NetMQ/NetMQFrame.cs
@@ -208,10 +208,7 @@ namespace NetMQ
         /// <returns></returns>
         public bool Equals([CanBeNull] byte[] other)
         {
-            if (other == null)
-                return false;
-
-            if (other.Length != MessageSize)
+            if (other?.Length != MessageSize)
                 return false;
 
             if (ReferenceEquals(Buffer, other))

--- a/src/NetMQ/NetMQFrame.cs
+++ b/src/NetMQ/NetMQFrame.cs
@@ -92,7 +92,7 @@ namespace NetMQ
         /// Get the underlying frame-data buffer, which is an array of bytes.
         /// </summary>       
         [NotNull]
-        public byte[] Buffer { get; private set; }
+        public byte[] Buffer { get; }
 
         /// <summary>
         /// Get the maximum size of the frame-data buffer (ie, the number of bytes of the array).

--- a/src/NetMQ/NetMQFrame.cs
+++ b/src/NetMQ/NetMQFrame.cs
@@ -63,7 +63,7 @@ namespace NetMQ
         {
             if (length < 0)
             {
-                throw new ArgumentOutOfRangeException("length", "A non-negative value is expected.");
+                throw new ArgumentOutOfRangeException(nameof(length), "A non-negative value is expected.");
             }
 
             Buffer = new byte[length];
@@ -81,7 +81,7 @@ namespace NetMQ
             {
                 if (value < 0 || value > BufferSize)
                 {
-                    throw new ArgumentOutOfRangeException("value", "Expecting a non-negative value less than or equal to the buffer size.");
+                    throw new ArgumentOutOfRangeException(nameof(value), "Expecting a non-negative value less than or equal to the buffer size.");
                 }
 
                 m_messageSize = value;
@@ -120,7 +120,7 @@ namespace NetMQ
         {
             if (buffer == null)
             {
-                throw new ArgumentNullException("buffer");
+                throw new ArgumentNullException(nameof(buffer));
             }
 
             var copy = new NetMQFrame(buffer.Length);
@@ -180,7 +180,7 @@ namespace NetMQ
         {
             if (frame == null)
             {
-                throw new ArgumentNullException("frame");
+                throw new ArgumentNullException(nameof(frame));
             }
 
             var copy = new NetMQFrame(new byte[frame.BufferSize]);

--- a/src/NetMQ/NetMQFrame.cs
+++ b/src/NetMQ/NetMQFrame.cs
@@ -97,26 +97,17 @@ namespace NetMQ
         /// <summary>
         /// Get the maximum size of the frame-data buffer (ie, the number of bytes of the array).
         /// </summary>
-        public int BufferSize
-        {
-            get { return Buffer.Length; }
-        }
+        public int BufferSize => Buffer.Length;
 
         /// <summary>
         /// Get a new empty <see cref="NetMQFrame"/> that may be used as message separators.
         /// </summary>
-        public static NetMQFrame Empty
-        {
-            get { return new NetMQFrame(0); }
-        }
+        public static NetMQFrame Empty => new NetMQFrame(0);
 
         /// <summary>
         /// Get whether this NetMQFrame is empty - that is, has a Buffer of zero-length.
         /// </summary>
-        public bool IsEmpty
-        {
-            get { return MessageSize == 0; }
-        }
+        public bool IsEmpty => MessageSize == 0;
 
         /// <summary>
         /// Create and return a new NetMQFrame with a copy of the supplied byte-array buffer.

--- a/src/NetMQ/NetMQMessage.cs
+++ b/src/NetMQ/NetMQMessage.cs
@@ -75,35 +75,23 @@ namespace NetMQ
         /// Gets the first frame in the current message.
         /// </summary>
         [NotNull]
-        public NetMQFrame First
-        {
-            get { return m_frames[0]; }
-        }
+        public NetMQFrame First => m_frames[0];
 
         /// <summary>
         /// Gets the last frame in the current message.
         /// </summary>
         [NotNull]
-        public NetMQFrame Last
-        {
-            get { return m_frames[m_frames.Count - 1]; }
-        }
+        public NetMQFrame Last => m_frames[m_frames.Count - 1];
 
         /// <summary>
         /// Gets a value indicating whether the current message is empty.
         /// </summary>
-        public bool IsEmpty
-        {
-            get { return m_frames.Count == 0; }
-        }
+        public bool IsEmpty => m_frames.Count == 0;
 
         /// <summary>
         /// Gets the number of <see cref="NetMQFrame"/> objects contained by this message.
         /// </summary>
-        public int FrameCount
-        {
-            get { return m_frames.Count; }
-        }
+        public int FrameCount => m_frames.Count;
 
         /// <summary>
         /// Gets the <see cref="NetMQFrame"/> at the specified index.
@@ -114,10 +102,7 @@ namespace NetMQ
         /// <paramref name="index"/>is less than 0 -or- <paramref name="index"/> is equal to or greater than <see cref="FrameCount"/>.
         /// </exception>
         [NotNull]
-        public NetMQFrame this[int index]
-        {
-            get { return m_frames[index]; }
-        }
+        public NetMQFrame this[int index] => m_frames[index];
 
         #endregion
 

--- a/src/NetMQ/NetMQMessage.cs
+++ b/src/NetMQ/NetMQMessage.cs
@@ -49,7 +49,7 @@ namespace NetMQ
         public NetMQMessage([NotNull] IEnumerable<NetMQFrame> frames)
         {
             if (frames == null)
-                throw new ArgumentNullException("frames");
+                throw new ArgumentNullException(nameof(frames));
 
             m_frames = new List<NetMQFrame>(frames);
         }
@@ -62,7 +62,7 @@ namespace NetMQ
         public NetMQMessage([NotNull] IEnumerable<byte[]> buffers)
         {
             if (buffers == null)
-                throw new ArgumentNullException("buffers");
+                throw new ArgumentNullException(nameof(buffers));
 
             m_frames = buffers.Select(buf => new NetMQFrame(buf)).ToList();
         }

--- a/src/NetMQ/NetMQScheduler.cs
+++ b/src/NetMQ/NetMQScheduler.cs
@@ -54,7 +54,7 @@ namespace NetMQ
 
             var schedulerId = Interlocked.Increment(ref s_schedulerCounter);
 
-            var address = string.Format("{0}://scheduler-{1}", Address.InProcProtocol, schedulerId);
+            var address = $"{Address.InProcProtocol}://scheduler-{schedulerId}";
 
             m_serverSocket = context.CreatePullSocket();
             m_serverSocket.Options.Linger = TimeSpan.Zero;

--- a/src/NetMQ/NetMQScheduler.cs
+++ b/src/NetMQ/NetMQScheduler.cs
@@ -126,10 +126,7 @@ namespace NetMQ
         /// }
         /// </code>
         /// </example>
-        public bool CanExecuteTaskInline
-        {
-            get { return m_schedulerThread.Value; }
-        }
+        public bool CanExecuteTaskInline => m_schedulerThread.Value;
 
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {
@@ -140,10 +137,7 @@ namespace NetMQ
         /// Get the maximum level of concurrency used in the scheduling.
         /// This is simply the value 1, and is not presently used anywhere within NetMQ.
         /// </summary>
-        public override int MaximumConcurrencyLevel
-        {
-            get { return 1; }
-        }
+        public override int MaximumConcurrencyLevel => 1;
 
         /// <summary>
         /// Release any contained resources.

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -104,7 +104,7 @@ namespace NetMQ
         /// <summary>
         /// Get the <see cref="SocketOptions"/> of this socket.
         /// </summary>
-        public SocketOptions Options { get; private set; }
+        public SocketOptions Options { get; }
 
         /// <summary>
         /// Get the underlying <see cref="SocketBase"/>.

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -109,15 +109,9 @@ namespace NetMQ
         /// <summary>
         /// Get the underlying <see cref="SocketBase"/>.
         /// </summary>
-        internal SocketBase SocketHandle
-        {
-            get { return m_socketHandle; }
-        }
+        internal SocketBase SocketHandle => m_socketHandle;
 
-        NetMQSocket ISocketPollable.Socket
-        {
-            get { return this; }
-        }
+        NetMQSocket ISocketPollable.Socket => this;
 
         #region Bind, Unbind, Connect, Disconnect, Close
 
@@ -505,10 +499,7 @@ namespace NetMQ
         /// Get whether a message is waiting to be picked up (<c>true</c> if there is, <c>false</c> if there is none).
         /// </summary>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
-        public bool HasIn
-        {
-            get { return GetSocketOptionX<PollEvents>(ZmqSocketOption.Events).HasIn(); }
-        }
+        public bool HasIn => GetSocketOptionX<PollEvents>(ZmqSocketOption.Events).HasIn();
 
         /// <summary>
         /// Get whether a message is waiting to be sent.
@@ -517,10 +508,7 @@ namespace NetMQ
         /// This is <c>true</c> if at least one message is waiting to be sent, <c>false</c> if there is none.
         /// </remarks>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
-        public bool HasOut
-        {
-            get { return GetSocketOptionX<PollEvents>(ZmqSocketOption.Events).HasOut(); }
-        }
+        public bool HasOut => GetSocketOptionX<PollEvents>(ZmqSocketOption.Events).HasOut();
 
         /// <summary>
         /// Get the integer-value of the specified <see cref="ZmqSocketOption"/>.

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -287,18 +287,10 @@ namespace NetMQ
             m_socketEventArgs.Init(events);
 
             if (events.HasIn())
-            {
-                var temp = m_receiveReady;
-                if (temp != null)
-                    temp(sender, m_socketEventArgs);
-            }
+                m_receiveReady?.Invoke(sender, m_socketEventArgs);
 
             if (events.HasOut())
-            {
-                var temp = m_sendReady;
-                if (temp != null)
-                    temp(sender, m_socketEventArgs);
-            }
+                m_sendReady?.Invoke(sender, m_socketEventArgs);
         }
 
         #endregion

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -476,9 +476,9 @@ namespace NetMQ
         public void Monitor([NotNull] string endpoint, SocketEvents events = SocketEvents.All)
         {
             if (endpoint == null)
-                throw new ArgumentNullException("endpoint");
+                throw new ArgumentNullException(nameof(endpoint));
             if (string.IsNullOrEmpty(endpoint))
-                throw new ArgumentException("Cannot be empty.", "endpoint");
+                throw new ArgumentException("Cannot be empty.", nameof(endpoint));
 
             m_socketHandle.CheckDisposed();
 

--- a/src/NetMQ/NetMQTimer.cs
+++ b/src/NetMQ/NetMQTimer.cs
@@ -125,9 +125,7 @@ namespace NetMQ
         /// <param name="sender">the sender to include within the event's event-args</param>
         internal void InvokeElapsed(object sender)
         {
-            var temp = Elapsed;
-            if (temp != null)
-                temp(sender, m_timerEventArgs);
+            Elapsed?.Invoke(sender, m_timerEventArgs);
         }
     }
 }

--- a/src/NetMQ/OutgoingSocketExtensions.cs
+++ b/src/NetMQ/OutgoingSocketExtensions.cs
@@ -291,7 +291,7 @@ namespace NetMQ
                 // move to the first emlement, if false frames is empty
                 if (!enumerator.MoveNext())
                 {
-                    throw new ArgumentException("frames is empty", "frames");
+                    throw new ArgumentException("frames is empty", nameof(frames));
                 }
 
                 var current = enumerator.Current;
@@ -346,7 +346,7 @@ namespace NetMQ
                 // move to the first emlement, if false frames is empty
                 if (!enumerator.MoveNext())
                 {
-                    throw new ArgumentException("frames is empty", "frames");
+                    throw new ArgumentException("frames is empty", nameof(frames));
                 }
 
                 var current = enumerator.Current;
@@ -629,7 +629,7 @@ namespace NetMQ
         public static void SendMultipartMessage([NotNull] this IOutgoingSocket socket, [NotNull] NetMQMessage message)
         {
             if (message.FrameCount == 0)
-                throw new ArgumentException("message is empty", "message");
+                throw new ArgumentException("message is empty", nameof(message));
 
             for (int i = 0; i < message.FrameCount - 1; i++)
             {
@@ -652,7 +652,7 @@ namespace NetMQ
         public static bool TrySendMultipartMessage([NotNull] this IOutgoingSocket socket, TimeSpan timeout, [NotNull] NetMQMessage message)
         {
             if (message.FrameCount == 0)
-                throw new ArgumentException("message is empty", "message");
+                throw new ArgumentException("message is empty", nameof(message));
             else if (message.FrameCount == 1)
             {
                 return TrySendFrame(socket, timeout, message[0].Buffer, message[0].MessageSize);

--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -92,7 +92,7 @@ namespace NetMQ
         {
             if (sockets == null)
             {
-                throw new ArgumentNullException("sockets");
+                throw new ArgumentNullException(nameof(sockets));
             }
 
             foreach (var socket in sockets)
@@ -111,7 +111,7 @@ namespace NetMQ
         {
             if (timers == null)
             {
-                throw new ArgumentNullException("timers");
+                throw new ArgumentNullException(nameof(timers));
             }
 
             foreach (var timer in timers)
@@ -143,12 +143,12 @@ namespace NetMQ
         {
             if (socket == null)
             {
-                throw new ArgumentNullException("socket");
+                throw new ArgumentNullException(nameof(socket));
             }
 
             if (callback == null)
             {
-                throw new ArgumentNullException("callback");
+                throw new ArgumentNullException(nameof(callback));
             }
 
             if (m_pollinSockets.ContainsKey(socket))
@@ -176,7 +176,7 @@ namespace NetMQ
         {
             if (socket == null)
             {
-                throw new ArgumentNullException("socket");
+                throw new ArgumentNullException(nameof(socket));
             }
 
             if (m_disposed)
@@ -200,7 +200,7 @@ namespace NetMQ
         {
             if (socket == null)
             {
-                throw new ArgumentNullException("socket");
+                throw new ArgumentNullException(nameof(socket));
             }
 
             if (m_sockets.Contains(socket.Socket))
@@ -230,7 +230,7 @@ namespace NetMQ
         {
             if (socket == null)
             {
-                throw new ArgumentNullException("socket");
+                throw new ArgumentNullException(nameof(socket));
             }
 
             if (m_disposed)
@@ -254,7 +254,7 @@ namespace NetMQ
         {
             if (timer == null)
             {
-                throw new ArgumentNullException("timer");
+                throw new ArgumentNullException(nameof(timer));
             }
 
             if (m_disposed)
@@ -275,7 +275,7 @@ namespace NetMQ
         {
             if (timer == null)
             {
-                throw new ArgumentNullException("timer");
+                throw new ArgumentNullException(nameof(timer));
             }
 
             if (m_disposed)

--- a/src/NetMQ/Poller.cs
+++ b/src/NetMQ/Poller.cs
@@ -124,10 +124,7 @@ namespace NetMQ
         /// Get whether the polling has started.
         /// This is set true at the beginning of the Start method, and cleared in the Stop method.
         /// </summary>
-        public bool IsStarted
-        {
-            get { return m_isStarted; }
-        }
+        public bool IsStarted => m_isStarted;
 
         /// <summary>
         /// Get or set the poll timeout in milliseconds.

--- a/src/NetMQ/ReceivingSocketExtensions.cs
+++ b/src/NetMQ/ReceivingSocketExtensions.cs
@@ -650,7 +650,7 @@ namespace NetMQ
         public static string ReceiveString([NotNull] this IReceivingSocket socket, [NotNull] Encoding encoding, SendReceiveOptions options, out bool hasMore)
         {
             if (encoding == null)
-                throw new ArgumentNullException("encoding");
+                throw new ArgumentNullException(nameof(encoding));
 
             var msg = new Msg();
             msg.InitEmpty();

--- a/src/NetMQ/Security/V0_1/HandshakeLayer.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeLayer.cs
@@ -552,7 +552,7 @@ namespace NetMQ.Security.V0_1
                     SecurityParameters.RecordIVLength = 16;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException("cipher");
+                    throw new ArgumentOutOfRangeException(nameof(cipher));
             }
 
             switch (cipher)
@@ -577,7 +577,7 @@ namespace NetMQ.Security.V0_1
                     SecurityParameters.MACLength = 32;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException("cipher");
+                    throw new ArgumentOutOfRangeException(nameof(cipher));
             }
         }
 

--- a/src/NetMQ/Security/V0_1/HandshakeLayer.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeLayer.cs
@@ -105,7 +105,7 @@ namespace NetMQ.Security.V0_1
             VerifyCertificate = c => c.Verify();
         }
 
-        public SecurityParameters SecurityParameters { get; private set; }
+        public SecurityParameters SecurityParameters { get; }
 
         /// <summary>
         /// Get or set the array of allowed cipher-suites.

--- a/src/NetMQ/Security/V0_1/HandshakeLayer.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeLayer.cs
@@ -586,11 +586,7 @@ namespace NetMQ.Security.V0_1
         /// </summary>
         private void InvokeChangeCipherSuite()
         {
-            EventHandler temp = CipherSuiteChange;
-            if (temp != null)
-            {
-                temp(this, EventArgs.Empty);
-            }
+            CipherSuiteChange?.Invoke(this, EventArgs.Empty);
         }
 
         private void GenerateMasterSecret(byte[] preMasterSecret)

--- a/src/NetMQ/Security/V0_1/HandshakeLayer.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeLayer.cs
@@ -125,10 +125,7 @@ namespace NetMQ.Security.V0_1
         /// <summary>
         /// Get the Pseudo-Random number generating-Function (PRF) that is being used.
         /// </summary>
-        public IPRF PRF
-        {
-            get { return m_prf; }
-        }
+        public IPRF PRF => m_prf;
 
         /// <summary>
         /// This event signals a change to the cipher-suite.

--- a/src/NetMQ/Security/V0_1/HandshakeMessages/CertificateMessage.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeMessages/CertificateMessage.cs
@@ -13,10 +13,7 @@ namespace NetMQ.Security.V0_1.HandshakeMessages
         /// Get the part of the handshake-protocol that this HandshakeMessage represents
         /// - in this case a Certificate.
         /// </summary>
-        public override HandshakeType HandshakeType
-        {
-            get { return HandshakeType.Certificate; }
-        }
+        public override HandshakeType HandshakeType => HandshakeType.Certificate;
 
         /// <summary>
         /// Get or set the X.509 Digital Certificate that this message contains.

--- a/src/NetMQ/Security/V0_1/HandshakeMessages/ClientHelloMessage.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeMessages/ClientHelloMessage.cs
@@ -19,10 +19,7 @@ namespace NetMQ.Security.V0_1.HandshakeMessages
         /// Get the part of the handshake-protocol that this HandshakeMessage represents
         /// - in this case a ClientHello.
         /// </summary>
-        public override HandshakeType HandshakeType
-        {
-            get { return HandshakeType.ClientHello; }
-        }
+        public override HandshakeType HandshakeType => HandshakeType.ClientHello;
 
         /// <summary>
         /// Get or set the list of CipherSuites that are indicated as being available in this phase of the handshake-protocol.

--- a/src/NetMQ/Security/V0_1/HandshakeMessages/ClientKeyExchangeMessage.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeMessages/ClientKeyExchangeMessage.cs
@@ -17,10 +17,7 @@
         /// Get the part of the handshake-protocol that this HandshakeMessage represents
         /// - in this case a ClientKeyExchange.
         /// </summary>
-        public override HandshakeType HandshakeType
-        {
-            get { return HandshakeType.ClientKeyExchange; }
-        }
+        public override HandshakeType HandshakeType => HandshakeType.ClientKeyExchange;
 
         /// <summary>
         /// Get or set the 48-byte array that is the encrypted pre-master secret.

--- a/src/NetMQ/Security/V0_1/HandshakeMessages/FinishedMessage.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeMessages/FinishedMessage.cs
@@ -15,10 +15,7 @@
         /// Get the part of the handshake-protocol that this HandshakeMessage represents
         /// - in this case, Finished.
         /// </summary>
-        public override HandshakeType HandshakeType
-        {
-            get { return HandshakeType.Finished; }
-        }
+        public override HandshakeType HandshakeType => HandshakeType.Finished;
 
         /// <summary>
         /// Get or set a byte-array that contains the verification data that is part of the finished-message.

--- a/src/NetMQ/Security/V0_1/HandshakeMessages/ServerHelloDoneMessage.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeMessages/ServerHelloDoneMessage.cs
@@ -9,10 +9,7 @@
         /// Get the part of the handshake-protocol that this HandshakeMessage represents
         /// - in this case, ServerHelloDone.
         /// </summary>
-        public override HandshakeType HandshakeType
-        {
-            get { return HandshakeType.ServerHelloDone; }
-        }
+        public override HandshakeType HandshakeType => HandshakeType.ServerHelloDone;
 
         /// <summary>
         /// Remove the one frame from the given NetMQMessage, which shall contain one byte with the HandshakeType,

--- a/src/NetMQ/Security/V0_1/HandshakeMessages/ServerHelloMessage.cs
+++ b/src/NetMQ/Security/V0_1/HandshakeMessages/ServerHelloMessage.cs
@@ -11,10 +11,7 @@
         /// Get the part of the handshake-protocol that this HandshakeMessage represents
         /// - in this case, ServerHello.
         /// </summary>
-        public override HandshakeType HandshakeType
-        {
-            get { return HandshakeType.ServerHello; }
-        }
+        public override HandshakeType HandshakeType => HandshakeType.ServerHello;
 
         /// <summary>
         /// Get or set the Random-Number that is a part of the handshake-protocol, as a byte-array.

--- a/src/NetMQ/Security/V0_1/OutgoingMessageBag.cs
+++ b/src/NetMQ/Security/V0_1/OutgoingMessageBag.cs
@@ -24,10 +24,7 @@ namespace NetMQ.Security.V0_1
         /// <summary>
         /// Get the list of NetMQMessages that this OutgoingMessageBag is holding.
         /// </summary>
-        public IEnumerable<NetMQMessage> Messages
-        {
-            get { return m_messages; }
-        }
+        public IEnumerable<NetMQMessage> Messages => m_messages;
 
         /// <summary>
         /// Add the given NetMQMessage to the list that this object holds, using the SecureChannel to

--- a/src/NetMQ/Security/V0_1/SecureChannel.cs
+++ b/src/NetMQ/Security/V0_1/SecureChannel.cs
@@ -189,7 +189,7 @@ namespace NetMQ.Security.V0_1
 
             if (plainMessage == null)
             {
-                throw new ArgumentNullException("plainMessage");
+                throw new ArgumentNullException(nameof(plainMessage));
             }
 
             return InternalEncryptAndWrapMessage(ContentType.ApplicationData, plainMessage);
@@ -214,7 +214,7 @@ namespace NetMQ.Security.V0_1
 
             if (cipherMessage == null)
             {
-                throw new ArgumentNullException("cipherMessage");
+                throw new ArgumentNullException(nameof(cipherMessage));
             }
 
             if (cipherMessage.FrameCount < 2)

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -113,10 +113,7 @@ namespace NetMQ
         /// Gets whether the last frame received on the socket had the <em>more</em> flag set or not.
         /// </summary>
         /// <value><c>true</c> if receive more; otherwise, <c>false</c>.</value>
-        public bool ReceiveMore
-        {
-            get { return m_socket.GetSocketOptionX<bool>(ZmqSocketOption.ReceiveMore); }
-        }
+        public bool ReceiveMore => m_socket.GetSocketOptionX<bool>(ZmqSocketOption.ReceiveMore);
 
         /// <summary>
         /// Get or set the linger period for the specified socket,
@@ -271,10 +268,7 @@ namespace NetMQ
         /// </summary>
         [Obsolete("Use LastEndpoint instead")]
         [CanBeNull]
-        public string GetLastEndpoint
-        {
-            get { return LastEndpoint; }
-        }
+        public string GetLastEndpoint => LastEndpoint;
 
         /// <summary>
         /// Get the last endpoint bound for TCP and IPC transports.
@@ -285,10 +279,7 @@ namespace NetMQ
         /// will be 0.0.0.0 (for IPv4).
         /// </remarks>
         [CanBeNull]
-        public string LastEndpoint
-        {
-            get { return m_socket.GetSocketOptionX<string>(ZmqSocketOption.LastEndpoint); }
-        }
+        public string LastEndpoint => m_socket.GetSocketOptionX<string>(ZmqSocketOption.LastEndpoint);
 
         public bool RouterMandatory
         {

--- a/src/Samples/Brokerless Reliability (Freelance Pattern)/Model One/Freelance.ModelOne.Client/Program.cs
+++ b/src/Samples/Brokerless Reliability (Freelance Pattern)/Model One/Freelance.ModelOne.Client/Program.cs
@@ -23,7 +23,7 @@ namespace Freelance.ModelOne.Client
                 {
                     for (int i = 0; i < MaxRetries; i++)
                     {
-                        if (TryRequest(context, endpoints[0], string.Format("Hello from endpoint {0}", endpoints[0])))
+                        if (TryRequest(context, endpoints[0], $"Hello from endpoint {endpoints[0]}"))
                             break;
                     }
                 }
@@ -31,7 +31,7 @@ namespace Freelance.ModelOne.Client
                 {
                     foreach (string endpoint in endpoints)
                     {
-                        if (TryRequest(context, endpoint, string.Format("Hello from endpoint {0}", endpoint)))
+                        if (TryRequest(context, endpoint, $"Hello from endpoint {endpoint}"))
                             break;
                     }
                 }

--- a/src/Samples/Brokerless Reliability (Freelance Pattern)/Model One/Freelance.ModelOne.Server/Program.cs
+++ b/src/Samples/Brokerless Reliability (Freelance Pattern)/Model One/Freelance.ModelOne.Server/Program.cs
@@ -20,7 +20,7 @@ namespace Freelance.ModelOne.Server
                 if (!string.IsNullOrEmpty(address))
                 {
                     Console.WriteLine("Binding tcp://{0}:{1}", address, PortNumber);
-                    response.Bind(string.Format("tcp://{0}:{1}", address, PortNumber));
+                    response.Bind($"tcp://{address}:{PortNumber}");
 
                     while (true)
                     {

--- a/src/Samples/InterBrokerRouter/Client.cs
+++ b/src/Samples/InterBrokerRouter/Client.cs
@@ -64,7 +64,7 @@ namespace InterBrokerRouter
                     }
                     else
                     {
-                        var msg = string.Format("[CLIENT {0}] ERR - EXIT - lost message {1}", m_id, messageId);
+                        var msg = $"[CLIENT {m_id}] ERR - EXIT - lost message {messageId}";
                         // send an error message 
                         monitor.Send(msg);
 
@@ -87,7 +87,7 @@ namespace InterBrokerRouter
                     if (reply.FrameCount == 0)
                     {
                         // something went wrong
-                        monitor.Send(string.Format("[CLIENT {0}] Received an empty message!", m_id));
+                        monitor.Send($"[CLIENT {m_id}] Received an empty message!");
                         // mark the exit flag to ensure the exit
                         exit = true;
                     }
@@ -100,9 +100,7 @@ namespace InterBrokerRouter
                             sb.Append("[" + frame.ConvertToString() + "]");
 
                         // send the success message
-                        monitor.Send(string.Format("[CLIENT {0}] Received answer {1}",
-                            m_id,
-                            sb.ToString()));
+                        monitor.Send($"[CLIENT {m_id}] Received answer {sb.ToString()}");
                     }
                 };
 

--- a/src/Samples/InterBrokerRouter/Program.cs
+++ b/src/Samples/InterBrokerRouter/Program.cs
@@ -349,14 +349,14 @@ namespace InterBrokerRouter
                 for (var i = 0; i < NbrClients; i++)
                 {
                     var client = new Client(localFrontendAddress, monitorAddress, (byte)i);
-                    clientTasks[i] = new Thread(client.Run) { Name = string.Format("Client_{0}", i) };
+                    clientTasks[i] = new Thread(client.Run) { Name = $"Client_{i}" };
                     clientTasks[i].Start();
                 }
 
                 for (var i = 0; i < NbrWorker; i++)
                 {
                     var worker = new Worker(localBackendAddress, (byte)i);
-                    workerTasks[i] = new Thread(worker.Run) { Name = string.Format("Worker_{0}", i) };
+                    workerTasks[i] = new Thread(worker.Run) { Name = $"Worker_{i}" };
                     workerTasks[i].Start();
                 }
 

--- a/src/Samples/Load Balancing Pattern/ROUTERbrokerDEALERworkers/Program.cs
+++ b/src/Samples/Load Balancing Pattern/ROUTERbrokerDEALERworkers/Program.cs
@@ -19,7 +19,7 @@ namespace ROUTERbrokerDEALERworkers
             using (var context = NetMQContext.Create())
             using (var client = context.CreateRouterSocket())
             {
-                client.Bind(string.Format("tcp://localhost:{0}", PortNumber));
+                client.Bind($"tcp://localhost:{PortNumber}");
 
                 foreach (var thread in workers)
                 {
@@ -54,7 +54,7 @@ namespace ROUTERbrokerDEALERworkers
             using (var worker = context.CreateDealerSocket())
             {
                 worker.Options.Identity = Encoding.Unicode.GetBytes("A");
-                worker.Connect(string.Format("tcp://localhost:{0}", portNumber));
+                worker.Connect($"tcp://localhost:{portNumber}");
 
                 int total = 0;
 
@@ -84,7 +84,7 @@ namespace ROUTERbrokerDEALERworkers
             using (var worker = context.CreateDealerSocket())
             {
                 worker.Options.Identity = Encoding.Unicode.GetBytes("B");
-                worker.Connect(string.Format("tcp://localhost:{0}", portNumber));
+                worker.Connect($"tcp://localhost:{portNumber}");
 
                 int total = 0;
 

--- a/src/Samples/Load Balancing Pattern/ROUTERbrokerREQworkers/Program.cs
+++ b/src/Samples/Load Balancing Pattern/ROUTERbrokerREQworkers/Program.cs
@@ -18,7 +18,7 @@ namespace ROUTERbrokerREQworkers
             using (var context = NetMQContext.Create())
             using (var client = context.CreateRouterSocket())
             {
-                string cnn = string.Format("tcp://localhost:{0}", PortNumber);
+                string cnn = $"tcp://localhost:{PortNumber}";
                 client.Bind(cnn);
                 Console.WriteLine("[B] Connect to {0}", cnn);
 
@@ -77,7 +77,7 @@ namespace ROUTERbrokerREQworkers
             {
                 // We use a string identity for ease here
                 string id = ZHelpers.SetID(worker, Encoding.Unicode);
-                string cnn = string.Format("tcp://localhost:{0}", portNumber);
+                string cnn = $"tcp://localhost:{portNumber}";
                 worker.Connect(cnn);
                 Console.WriteLine("[W] ID {0} connect to {1}", id, cnn);
 

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
@@ -83,7 +83,7 @@ namespace MajordomoProtocol
         ///     the interval at which the broker send heartbeats to workers
         ///     initially set to 2.500 ms
         /// </summary>
-        public TimeSpan HeartbeatInterval { get { return m_heartbeatInterval; } }
+        public TimeSpan HeartbeatInterval => m_heartbeatInterval;
 
         /// <summary>
         ///     after so many heartbeat cycles a worker is deemed to dead 

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
@@ -161,9 +161,8 @@ namespace MajordomoProtocol
             }
             catch (Exception e)
             {
-                var error = string.Format ("The bind operation failed. Most likely because 'endpoint' ({0}) is malformed!",
-                                           m_endpoint);
-                error += string.Format ("\nMessage: {0}", e.Message);
+                var error = $"The bind operation failed. Most likely because 'endpoint' ({m_endpoint}) is malformed!";
+                error += $"\nMessage: {e.Message}";
                 throw new ApplicationException (error);
             }
 
@@ -172,7 +171,7 @@ namespace MajordomoProtocol
             var major = Assembly.GetExecutingAssembly ().GetName ().Version.Major;
             var minor = Assembly.GetExecutingAssembly ().GetName ().Version.Minor;
 
-            Log (string.Format ("MDP Broker/{0}.{1} is active at {2}", major, minor, m_endpoint));
+            Log ($"MDP Broker/{major}.{minor} is active at {m_endpoint}");
         }
 
         /// <summary>
@@ -306,7 +305,7 @@ namespace MajordomoProtocol
         {
             var msg = e.Socket.ReceiveMultipartMessage ();
 
-            DebugLog (string.Format ("Received: {0}", msg));
+            DebugLog ($"Received: {msg}");
 
             var senderFrame = msg.Pop ();               // [e][protocol header][service or command][data]
             var empty = msg.Pop ();                     // [protocol header][service or command][data]
@@ -355,7 +354,7 @@ namespace MajordomoProtocol
                         // service and a potential waiting list therein
                         RemoveWorker (m_knownWorkers.Find (w => w.Id == workerId));
 
-                        Log (string.Format ("READY out of sync. Removed worker {0}.", workerId));
+                        Log ($"READY out of sync. Removed worker {workerId}.");
                     }
                     else
                     {
@@ -368,9 +367,7 @@ namespace MajordomoProtocol
                         // now add the worker
                         AddWorker (worker, service);
 
-                        Log (string.Format ("READY processed. Worker {0} added to service {1}",
-                                            workerId,
-                                            serviceName));
+                        Log ($"READY processed. Worker {workerId} added to service {serviceName}");
                     }
                     break;
                 case MDPCommand.Reply:
@@ -386,10 +383,7 @@ namespace MajordomoProtocol
 
                         Socket.SendMessage (reply);
 
-                        DebugLog (string.Format ("REPLY from {0} received and send to {1} -> {2}",
-                                            workerId,
-                                            client.ConvertToString (),
-                                            message));
+                        DebugLog ($"REPLY from {workerId} received and send to {client.ConvertToString()} -> {message}");
                         // relist worker for further requests
                         AddWorker (worker, worker.Service);
                     }
@@ -400,7 +394,7 @@ namespace MajordomoProtocol
                         var worker = m_knownWorkers.Find (w => w.Id == workerId);
                         worker.Expiry = DateTime.UtcNow + m_heartbeatExpiry;
 
-                        DebugLog (string.Format ("HEARTBEAT from {0} received.", workerId));
+                        DebugLog ($"HEARTBEAT from {workerId} received.");
                     }
                     break;
                 default:
@@ -459,7 +453,7 @@ namespace MajordomoProtocol
                 // send to back to CLIENT(!)
                 Socket.SendMessage (reply);
 
-                DebugLog (string.Format ("MMI request processed. Answered {0}", reply));
+                DebugLog ($"MMI request processed. Answered {reply}");
             }
             else
             {
@@ -467,7 +461,7 @@ namespace MajordomoProtocol
                 var service = ServiceRequired (serviceName);
 
                 // a standard REQUEST received
-                DebugLog (string.Format ("Dispatching -> {0} to {1}", request, serviceName));
+                DebugLog ($"Dispatching -> {request} to {serviceName}");
 
                 // send to a worker offering the requested service
                 // will add command, header and worker adr envelope
@@ -520,14 +514,12 @@ namespace MajordomoProtocol
             {
                 m_knownWorkers.Add (worker);
 
-                DebugLog (string.Format ("added {0} to known worker.", worker.Id));
+                DebugLog ($"added {worker.Id} to known worker.");
             }
 
             service.AddWaitingWorker (worker);
 
-            DebugLog (string.Format ("added {0} to waiting worker in service {1}.",
-                                     worker.Id,
-                                     service.Name));
+            DebugLog ($"added {worker.Id} to waiting worker in service {service.Name}.");
 
             // get pending messages out
             ServiceDispatch (service, null);
@@ -546,14 +538,12 @@ namespace MajordomoProtocol
                 var service = m_services.Find (s => s.Equals (worker.Service));
                 service.DeleteWorker (worker);
 
-                DebugLog (string.Format ("removed worker {0} from service {1}",
-                                         worker.Id,
-                                         service.Name));
+                DebugLog ($"removed worker {worker.Id} from service {service.Name}");
             }
 
             m_knownWorkers.Remove (worker);
 
-            DebugLog (string.Format ("removed {0} from known worker.", worker.Id));
+            DebugLog ($"removed {worker.Id} from known worker.");
         }
 
         /// <summary>
@@ -573,7 +563,7 @@ namespace MajordomoProtocol
             // stack routing envelope
             var request = Wrap (worker.Identity, msg);
 
-            DebugLog (string.Format ("Sending {0}", request));
+            DebugLog ($"Sending {request}");
             // send to worker
             Socket.SendMessage (request);
         }
@@ -607,9 +597,7 @@ namespace MajordomoProtocol
         /// </summary>
         private void ServiceDispatch (Service service, NetMQMessage message)
         {
-            DebugLog (string.Format ("Service [{0}] dispatches -> {1}",
-                                     service.Name,
-                                     message == null ? "PURGING" : "message = " + message));
+            DebugLog ($"Service [{service.Name}] dispatches -> {(message == null ? "PURGING" : "message = " + message)}");
 
             // if message is 'null' just send pending requests
             if (!ReferenceEquals (message, null))
@@ -628,7 +616,7 @@ namespace MajordomoProtocol
                 {
                     var request = service.GetNextRequest ();
 
-                    DebugLog (string.Format ("Service Dispatch -> pending request {0} to {1}", request, worker.Id));
+                    DebugLog ($"Service Dispatch -> pending request {request} to {worker.Id}");
 
                     WorkerSend (worker, MDPCommand.Request, request);
                 }

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
@@ -77,7 +77,7 @@ namespace MajordomoProtocol
         /// <summary>
         ///     the socket for communicating with clients and workers
         /// </summary>
-        public NetMQSocket Socket { get; private set; }
+        public NetMQSocket Socket { get; }
 
         /// <summary>
         ///     the interval at which the broker send heartbeats to workers

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
@@ -640,18 +640,12 @@ namespace MajordomoProtocol
 
         protected virtual void OnLogInfoReady (MDPLogEventArgs e)
         {
-            var handler = LogInfoReady;
-
-            if (handler != null)
-                handler (this, e);
+            LogInfoReady?.Invoke (this, e);
         }
 
         protected virtual void OnDebugInfoReady (MDPLogEventArgs e)
         {
-            var handler = DebugInfoReady;
-
-            if (handler != null)
-                handler (this, e);
+            DebugInfoReady?.Invoke (this, e);
         }
 
         private void Log (string info)

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPBroker.cs
@@ -135,7 +135,7 @@ namespace MajordomoProtocol
             : this ()
         {
             if (string.IsNullOrWhiteSpace (endpoint))
-                throw new ArgumentNullException ("endpoint", "An 'endpoint' were the broker binds to must be given!");
+                throw new ArgumentNullException (nameof(endpoint), "An 'endpoint' were the broker binds to must be given!");
 
             if (heartbeatInterval > 0)
                 m_heartbeatInterval = TimeSpan.FromMilliseconds (heartbeatInterval);

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPClient.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPClient.cs
@@ -37,12 +37,12 @@ namespace MajordomoProtocol
         /// <summary>
         ///     returns the address of the broker the client is connected to
         /// </summary>
-        public string Address { get { return m_brokerAddress; } }
+        public string Address => m_brokerAddress;
 
         /// <summary>
         ///     returns the name of the client
         /// </summary>
-        public byte[] Identity { get { return m_identity; } }
+        public byte[] Identity => m_identity;
 
         /// <summary>
         ///     if client has a log message available if fires this event

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPClient.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPClient.cs
@@ -73,7 +73,7 @@ namespace MajordomoProtocol
             : this ()
         {
             if (string.IsNullOrWhiteSpace (brokerAddress))
-                throw new ArgumentNullException ("brokerAddress", "The broker address must not be null, empty or whitespace!");
+                throw new ArgumentNullException (nameof(brokerAddress), "The broker address must not be null, empty or whitespace!");
 
             m_identity = identity;
             m_brokerAddress = brokerAddress;
@@ -87,7 +87,7 @@ namespace MajordomoProtocol
         public MDPClient (string brokerAddress, string identity)
         {
             if (string.IsNullOrWhiteSpace (brokerAddress))
-                throw new ArgumentNullException ("brokerAddress", "The broker address must not be null, empty or whitespace!");
+                throw new ArgumentNullException (nameof(brokerAddress), "The broker address must not be null, empty or whitespace!");
 
             if (!string.IsNullOrWhiteSpace (identity))
                 m_identity = Encoding.UTF8.GetBytes (identity);

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPClient.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPClient.cs
@@ -242,10 +242,7 @@ namespace MajordomoProtocol
         /// <param name="e"></param>
         protected virtual void OnLogInfoReady (MDPLogEventArgs e)
         {
-            var handler = LogInfoReady;
-
-            if (handler != null)
-                handler (this, e);
+            LogInfoReady?.Invoke (this, e);
         }
 
         public void Dispose ()

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPClient.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPClient.cs
@@ -134,7 +134,7 @@ namespace MajordomoProtocol
             message.Push (serviceName);
             message.Push (m_mdpClient);
 
-            Log (string.Format ("[CLIENT INFO] sending {0} to service {1}", message, serviceName));
+            Log ($"[CLIENT INFO] sending {message} to service {serviceName}");
 
             var retiesLeft = Retries;
 
@@ -194,7 +194,7 @@ namespace MajordomoProtocol
 
             m_connected = true;
 
-            Log (string.Format ("[CLIENT] connecting to broker at {0}", m_brokerAddress));
+            Log ($"[CLIENT] connecting to broker at {m_brokerAddress}");
         }
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace MajordomoProtocol
             // a message is available within the timeout period
             var reply = m_client.ReceiveMultipartMessage ();
 
-            Log (string.Format ("\n[CLIENT INFO] received the reply {0}\n", reply));
+            Log ($"\n[CLIENT INFO] received the reply {reply}\n");
 
             // in production code malformed messages should be handled smarter
             if (reply.FrameCount < 2)
@@ -219,13 +219,12 @@ namespace MajordomoProtocol
             var header = reply.Pop (); // [MDPHeader] <- [service name][reply] OR ['mmi.service'][return code]
 
             if (header.ConvertToString () != m_mdpClient)
-                throw new ApplicationException (string.Format ("[CLIENT INFO] MDP Version mismatch: {0}", header));
+                throw new ApplicationException ($"[CLIENT INFO] MDP Version mismatch: {header}");
 
             var service = reply.Pop (); // [service name or 'mmi.service'] <- [reply] OR [return code]
 
             if (service.ConvertToString () != m_serviceName)
-                throw new ApplicationException (string.Format ("[CLIENT INFO] answered by wrong service: {0}",
-                                                               service.ConvertToString ()));
+                throw new ApplicationException ($"[CLIENT INFO] answered by wrong service: {service.ConvertToString()}");
             // now set the value for the reply of the send method!
             m_reply = reply;        // [reply] OR [return code]
         }

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPWorker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPWorker.cs
@@ -192,10 +192,7 @@ namespace MajordomoProtocol
         /// <param name="e">the wrapped logging information</param>
         protected virtual void OnLogInfoReady (MDPLogEventArgs e)
         {
-            var handler = LogInfoReady;
-
-            if (handler != null)
-                handler (this, e);
+            LogInfoReady?.Invoke (this, e);
         }
 
         /// <summary>

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPWorker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPWorker.cs
@@ -211,7 +211,7 @@ namespace MajordomoProtocol
             // a request has arrived process it
             var request = m_worker.ReceiveMultipartMessage ();
 
-            Log (string.Format ("[WORKER] received {0}", request));
+            Log ($"[WORKER] received {request}");
 
             // make sure that we have no valid request yet!
             // if something goes wrong we'll return 'null'
@@ -279,7 +279,7 @@ namespace MajordomoProtocol
 
             var command = (MDPCommand) cmd.Buffer[0];
 
-            Log (string.Format ("[WORKER] received {0}/{1}", request, command));
+            Log ($"[WORKER] received {request}/{command}");
 
             return command;
         }
@@ -306,7 +306,7 @@ namespace MajordomoProtocol
 
             m_worker.Connect (m_brokerAddress);
 
-            Log (string.Format ("[WORKER] connected to broker at {0}", m_brokerAddress));
+            Log ($"[WORKER] connected to broker at {m_brokerAddress}");
 
             // signal that worker is connected
             m_connected = true;
@@ -346,7 +346,7 @@ namespace MajordomoProtocol
             // set MDP empty frame as separator
             msg.Push (NetMQFrame.Empty);                // [e][command][header][data]
 
-            Log (string.Format ("[WORKER] sending {0} to broker / Command {1}", msg, mdpCommand));
+            Log ($"[WORKER] sending {msg} to broker / Command {mdpCommand}");
 
             m_worker.SendMessage (msg);
         }

--- a/src/Samples/Majordomo/MajordomoProtocol/MDPWorker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/MDPWorker.cs
@@ -86,11 +86,11 @@ namespace MajordomoProtocol
             : this ()
         {
             if (string.IsNullOrWhiteSpace (brokerAddress))
-                throw new ArgumentNullException ("brokerAddress",
+                throw new ArgumentNullException (nameof(brokerAddress),
                                                  "The address of the broker must not be null, empty or whitespace!");
 
             if (string.IsNullOrWhiteSpace (serviceName))
-                throw new ArgumentNullException ("serviceName",
+                throw new ArgumentNullException (nameof(serviceName),
                                                  "The name of the service must not be null, empty or whitespace!");
             m_identity = identity;
             m_brokerAddress = brokerAddress;

--- a/src/Samples/Majordomo/MajordomoProtocol/Service.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/Service.cs
@@ -27,12 +27,12 @@ namespace MajordomoProtocol
         ///     we need to copy the array in order to allow the changing of it in an iteration
         ///     since we will change the list while iterating we must operate on a copy
         /// </remarks>
-        public IEnumerable<Worker> WaitingWorkers { get { return m_waitingWorkers.ToArray (); } }
+        public IEnumerable<Worker> WaitingWorkers => m_waitingWorkers.ToArray ();
 
         /// <summary>
         /// Returns a list of requests pending for being send to workers
         /// </summary>
-        public List<NetMQMessage> PendingRequests { get { return m_pendingRequests; } }
+        public List<NetMQMessage> PendingRequests => m_pendingRequests;
 
         /// <summary>
         /// Ctor for a service

--- a/src/Samples/Majordomo/MajordomoProtocol/Service.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/Service.cs
@@ -18,7 +18,7 @@ namespace MajordomoProtocol
         /// <summary>
         /// The service name.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         ///     returns a readonly sequence of waiting workers - some of which may have expired

--- a/src/Samples/Majordomo/MajordomoProtocol/Service.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/Service.cs
@@ -144,11 +144,7 @@ namespace MajordomoProtocol
 
         public override string ToString ()
         {
-            return string.Format ("Name = {0} / Worker {1} - Waiting {2} - Pending REQ {3}",
-                Name,
-                m_workers.Count,
-                m_waitingWorkers.Count,
-                m_pendingRequests.Count);
+            return $"Name = {Name} / Worker {m_workers.Count} - Waiting {m_waitingWorkers.Count} - Pending REQ {m_pendingRequests.Count}";
         }
 
         public override bool Equals (object obj)

--- a/src/Samples/Majordomo/MajordomoProtocol/Worker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/Worker.cs
@@ -31,10 +31,7 @@ namespace MajordomoProtocol
 
         public override string ToString()
         {
-            return string.Format("Name = {0} / Service = {1} / Expires {2}",
-                Id,
-                Service.Name,
-                Expiry.ToShortTimeString());
+            return $"Name = {Id} / Service = {Service.Name} / Expires {Expiry.ToShortTimeString()}";
         }
 
         public override bool Equals(object obj)

--- a/src/Samples/Majordomo/MajordomoProtocol/Worker.cs
+++ b/src/Samples/Majordomo/MajordomoProtocol/Worker.cs
@@ -9,7 +9,7 @@ namespace MajordomoProtocol
     internal class Worker
     {
         // the id of the worker as string
-        public string Id { get; private set; }
+        public string Id { get; }
         // identity of worker for routing
         public NetMQFrame Identity { get; private set; }
         // owing service if known

--- a/src/Samples/Majordomo/MajordomoProtocolTests/ServiceTests.cs
+++ b/src/Samples/Majordomo/MajordomoProtocolTests/ServiceTests.cs
@@ -60,7 +60,7 @@ namespace MajordomoTests
 
             for (var i = 0; i < 10; i++)
             {
-                var id = string.Format("W0{0:N3}", i);
+                var id = $"W0{i:N3}";
                 var worker = new Worker(id, new NetMQFrame(id), service);
 
                 if (i == 5)
@@ -85,7 +85,7 @@ namespace MajordomoTests
 
             for (var i = 0; i < 10; i++)
             {
-                var id = string.Format("W0{0:N3}", i);
+                var id = $"W0{i:N3}";
                 var worker = new Worker(id, new NetMQFrame(id), service);
 
                 if (i == 0)
@@ -105,7 +105,7 @@ namespace MajordomoTests
 
             for (var i = 0; i < 10; i++)
             {
-                var id = string.Format("W0{0:N3}", i);
+                var id = $"W0{i:N3}";
                 var worker = new Worker(id, new NetMQFrame(id), service);
                 service.AddWaitingWorker(worker);
                 service.GetNextWorker();
@@ -123,7 +123,7 @@ namespace MajordomoTests
 
             for (var i = 0; i < 10; i++)
             {
-                var id = string.Format("W0{0:N3}", i);
+                var id = $"W0{i:N3}";
                 var worker = new Worker(id, new NetMQFrame(id), service);
 
                 service.AddWaitingWorker(worker);
@@ -144,7 +144,7 @@ namespace MajordomoTests
 
             for (var i = 0; i < 10; i++)
             {
-                var id = string.Format("W0{0:N3}", i);
+                var id = $"W0{i:N3}";
                 var worker = new Worker(id, new NetMQFrame(id), service);
                 service.AddWaitingWorker(worker);
                 service.DeleteWorker(worker);
@@ -213,7 +213,7 @@ namespace MajordomoTests
                 var request = new NetMQMessage();
                 request.Push("DATA");
                 request.Push("SERVICE");
-                request.Push(string.Format("HEADER_{0}", i));
+                request.Push($"HEADER_{i}");
 
                 service.AddRequest(request);
             }
@@ -222,7 +222,7 @@ namespace MajordomoTests
             {
                 var req = service.GetNextRequest();
 
-                Assert.That(req.First.ConvertToString(), Is.EqualTo(string.Format("HEADER_{0}", i)));
+                Assert.That(req.First.ConvertToString(), Is.EqualTo($"HEADER_{i}"));
             }
 
             Assert.That(service.PendingRequests.Count, Is.EqualTo(5));

--- a/src/Samples/Multithreading/Multithreaded Service/MultithreadedService/Program.cs
+++ b/src/Samples/Multithreading/Multithreaded Service/MultithreadedService/Program.cs
@@ -123,7 +123,7 @@ namespace MultithreadedService
     public class Worker
     {
         public Guid WorkerId { get; private set; }
-        public NetMQContext Context { get; private set; }
+        public NetMQContext Context { get; }
 
         public Worker(Guid workerId, NetMQContext context)
         {

--- a/src/Samples/Multithreading/Multithreaded Service/MultithreadedService/Program.cs
+++ b/src/Samples/Multithreading/Multithreaded Service/MultithreadedService/Program.cs
@@ -57,7 +57,7 @@ namespace MultithreadedService
                 {
                     req.Connect("tcp://localhost:5555");
 
-                    byte[] message = Encoding.Unicode.GetBytes(string.Format("{0} Hello", clientId));
+                    byte[] message = Encoding.Unicode.GetBytes($"{clientId} Hello");
 
                     Console.WriteLine("Client {0} sent \"{0} Hello\"", clientId);
                     req.Send(message, message.Length);

--- a/src/Samples/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Queue/Workers.cs
+++ b/src/Samples/Pirate Pattern/Paranoid Pirate/ParanoidPirate.Queue/Workers.cs
@@ -13,10 +13,7 @@ namespace ParanoidPirate.Queue
         /// <summary>
         /// true if there are workers available
         /// </summary>
-        public bool Available
-        {
-            get { return m_workers.Count > 0; }
-        }
+        public bool Available => m_workers.Count > 0;
 
         /// <summary>
         /// stores a worker for a LRU pattern

--- a/src/Samples/Titanic Pattern/TitanicBroker/RequestEntry.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/RequestEntry.cs
@@ -62,7 +62,7 @@ namespace TitanicProtocol
         public override string ToString ()
         {
             var status = State == Is_Processed ? "processed" : State == Is_Pending ? "pending" : "closed";
-            return string.Format ("Id={0} / Position={1} / IsProcessed={2} / Message={3}", RequestId, Position, status, Request);
+            return $"Id={RequestId} / Position={Position} / IsProcessed={status} / Message={Request}";
         }
 
         public override int GetHashCode ()

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicBroker.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicBroker.cs
@@ -462,10 +462,7 @@ namespace TitanicProtocol
 
         protected virtual void OnLogInfoReady (TitanicLogEventArgs e)
         {
-            var handler = LogInfoReady;
-
-            if (handler != null)
-                handler (this, e);
+            LogInfoReady?.Invoke (this, e);
         }
 
         #region IDisposable

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicBroker.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicBroker.cs
@@ -72,7 +72,7 @@ namespace TitanicProtocol
         /// <summary>
         ///     returns the ip-address of the titanic broker
         /// </summary>
-        public string TitanicAddress { get { return m_titanicAddress; } }
+        public string TitanicAddress => m_titanicAddress;
 
         /// <summary>
         ///     if broker has a log message available if fires this event

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicBroker.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicBroker.cs
@@ -165,7 +165,7 @@ namespace TitanicProtocol
                             Log ("[TITANIC BROKER] Received a malformed GUID via pipe - throw it away");
                         else
                         {
-                            Log (string.Format ("[TITANIC BROKER] Received request GUID {0} via pipe", msg));
+                            Log ($"[TITANIC BROKER] Received request GUID {msg} via pipe");
                             // now we have a valid GUID - save it to disk for further use
                             m_io.SaveNewRequestEntry (guid);
                         }
@@ -213,7 +213,7 @@ namespace TitanicProtocol
                     // a request should be [service name][request data]
                     var request = worker.Receive (reply);
 
-                    Log (string.Format ("[TITANIC REQUEST] Received request: {0}", request));
+                    Log ($"[TITANIC REQUEST] Received request: {request}");
 
                     //! has there been a breaking cause? -> exit
                     if (ReferenceEquals (request, null))
@@ -226,7 +226,7 @@ namespace TitanicProtocol
                     // save request to file -> [service name][request data]
                     m_io.SaveMessage (TitanicOperation.Request, requestId, request);
 
-                    Log (string.Format ("[TITANIC REQUEST] sending through pipe: {0}", requestId));
+                    Log ($"[TITANIC REQUEST] sending through pipe: {requestId}");
 
                     // send GUID through message queue to main thread
                     pipe.Send (requestId.ToString ());
@@ -237,7 +237,7 @@ namespace TitanicProtocol
                     // [Ok][Guid]
                     reply.Push (TitanicReturnCode.Ok.ToString ());
 
-                    Log (string.Format ("[TITANIC REQUEST] sending reply: {0}", reply));
+                    Log ($"[TITANIC REQUEST] sending reply: {reply}");
                 }
             }
         }
@@ -261,7 +261,7 @@ namespace TitanicProtocol
                     // since there is no initial reply everytime thereafter the reply will be send
                     var request = worker.Receive (reply);
 
-                    Log (string.Format ("TITANIC REPLY] received: {0}", request));
+                    Log ($"TITANIC REPLY] received: {request}");
 
                     //! has there been a breaking cause? -> exit
                     if (ReferenceEquals (request, null))
@@ -272,7 +272,7 @@ namespace TitanicProtocol
 
                     if (m_io.ExistsMessage (TitanicOperation.Reply, requestId))
                     {
-                        Log (string.Format ("[TITANIC REPLY] reply for request exists: {0}", requestId));
+                        Log ($"[TITANIC REPLY] reply for request exists: {requestId}");
 
                         reply = m_io.GetMessage (TitanicOperation.Reply, requestId);    // [service][reply]
                         reply.Push (TitanicReturnCode.Ok.ToString ());                  // ["OK"][service][reply]
@@ -288,7 +288,7 @@ namespace TitanicProtocol
                         reply.Push (replyCommand.ToString ());
                     }
 
-                    Log (string.Format ("[TITANIC REPLY] reply: {0}", reply));
+                    Log ($"[TITANIC REPLY] reply: {reply}");
                 }
             }
         }
@@ -310,7 +310,7 @@ namespace TitanicProtocol
                     // initiate the communication with sending a null, since there is no reply yet
                     var request = worker.Receive (reply);
 
-                    Log (string.Format ("[TITANIC CLOSE] received: {0}", request));
+                    Log ($"[TITANIC CLOSE] received: {request}");
 
                     //! has there been a breaking cause? -> exit
                     if (ReferenceEquals (request, null))
@@ -320,7 +320,7 @@ namespace TitanicProtocol
                     var guidAsString = request.Pop ().ConvertToString ();
                     var guid = Guid.Parse (guidAsString);
 
-                    Log (string.Format ("[TITANIC CLOSE] closing {0}", guid));
+                    Log ($"[TITANIC CLOSE] closing {guid}");
 
                     // close the request
                     m_io.CloseRequest (guid);
@@ -343,7 +343,7 @@ namespace TitanicProtocol
             // threat this as successfully processed
             if (!m_io.ExistsMessage (TitanicOperation.Request, requestId))
             {
-                Log (string.Format ("[TITANIC DISPATCH] Request {0} does not exist. Removing it from queue.", requestId));
+                Log ($"[TITANIC DISPATCH] Request {requestId} does not exist. Removing it from queue.");
                 // close request inorder to avoid any further processing
                 m_io.CloseRequest (requestId);
 
@@ -355,7 +355,7 @@ namespace TitanicProtocol
             // [service name][data]
             var serviceName = request[0].ConvertToString ();
 
-            Log (string.Format ("[TITANIC DISPATCH] Do a ServiceCall for {0} - {1}.", serviceName, request));
+            Log ($"[TITANIC DISPATCH] Do a ServiceCall for {serviceName} - {request}.");
 
             var reply = ServiceCall (serviceName, request, serviceClient);
 
@@ -363,7 +363,7 @@ namespace TitanicProtocol
                 return false;       // no reply
 
             // a reply has been received -> save it
-            Log (string.Format ("[TITANIC DISPATCH] Saving reply for request {0}.", requestId));
+            Log ($"[TITANIC DISPATCH] Saving reply for request {requestId}.");
             // save the reply for further use
             m_io.SaveMessage (TitanicOperation.Reply, requestId, reply);
 
@@ -403,15 +403,12 @@ namespace TitanicProtocol
                 // answer == "Ok" -> service is available -> make the request
                 if (answer == MmiCode.Ok)
                 {
-                    Log (string.Format ("[TITANIC SERVICECALL] -> {0} - {1}", serviceName, request));
+                    Log ($"[TITANIC SERVICECALL] -> {serviceName} - {request}");
 
                     return session.Send (serviceName, request);
                 }
 
-                Log (string.Format ("[TITANIC SERVICECALL] Service {0} (RC = {1}/{2}) is not available.",
-                                    serviceName,
-                                    answer,
-                                    request));
+                Log ($"[TITANIC SERVICECALL] Service {serviceName} (RC = {answer}/{request}) is not available.");
 
                 //! shall this information be available for request? Unknown or Pending
                 //! so TitanicRequest could utilize this information 
@@ -449,10 +446,10 @@ namespace TitanicProtocol
 
         private void LogExceptions (AggregateException exception)
         {
-            Log (string.Format ("Exception: {0}", exception.Message));
+            Log ($"Exception: {exception.Message}");
 
             foreach (var ex in exception.Flatten ().InnerExceptions)
-                Log (string.Format ("Inner Exception: {0}", ex.Message));
+                Log ($"Inner Exception: {ex.Message}");
         }
 
         private void Log ([NotNull] string info)

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicClient.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicClient.cs
@@ -68,7 +68,7 @@ namespace TitanicProtocol
                                                            int waitInBetween = 2500)
         {
             if (string.IsNullOrWhiteSpace (serviceName))
-                throw new ArgumentNullException ("serviceName", "The name of the service requested must not be empty or 'null'!");
+                throw new ArgumentNullException (nameof(serviceName), "The name of the service requested must not be empty or 'null'!");
 
             Log (string.Format ("requesting service {0} to process {1}", serviceName, request));
 
@@ -124,7 +124,7 @@ namespace TitanicProtocol
                                                            int waitInBetween = 2500)
         {
             if (string.IsNullOrWhiteSpace (serviceName))
-                throw new ArgumentNullException ("serviceName", "The name of the service requested must not be empty or 'null'!");
+                throw new ArgumentNullException (nameof(serviceName), "The name of the service requested must not be empty or 'null'!");
 
             return GetResult (serviceName, Encoding.UTF8.GetBytes (request), retries, waitInBetween);
         }
@@ -146,7 +146,7 @@ namespace TitanicProtocol
                                                            int waitInBetween = 2500)
         {
             if (string.IsNullOrWhiteSpace (serviceName))
-                throw new ArgumentNullException ("serviceName", "The name of the service requested must not be empty or 'null'!");
+                throw new ArgumentNullException (nameof(serviceName), "The name of the service requested must not be empty or 'null'!");
 
             var reply = GetResult (serviceName, enc.GetBytes (request), retries, waitInBetween);
 
@@ -172,7 +172,7 @@ namespace TitanicProtocol
             where TOut : ITitanicConvert<TOut>, new ()
         {
             if (string.IsNullOrWhiteSpace (serviceName))
-                throw new ArgumentNullException ("serviceName", "The name of the service requested must not be empty or 'null'!");
+                throw new ArgumentNullException (nameof(serviceName), "The name of the service requested must not be empty or 'null'!");
 
             var reply = GetResult (serviceName, request.ConvertToBytes (), retries, waitInBetween);
             var result = new TOut ();
@@ -195,7 +195,7 @@ namespace TitanicProtocol
         public Guid Request (string serviceName, byte[] request)
         {
             if (string.IsNullOrWhiteSpace (serviceName))
-                throw new ArgumentNullException ("serviceName", "The name of the service requested must not be empty or 'null'!");
+                throw new ArgumentNullException (nameof(serviceName), "The name of the service requested must not be empty or 'null'!");
 
             var message = new NetMQMessage ();
             // set request data
@@ -228,7 +228,7 @@ namespace TitanicProtocol
         public Guid Request (string serviceName, string request)
         {
             if (string.IsNullOrWhiteSpace (serviceName))
-                throw new ArgumentNullException ("serviceName", "The name of the service requested must not be empty or 'null'!");
+                throw new ArgumentNullException (nameof(serviceName), "The name of the service requested must not be empty or 'null'!");
 
             return Request (serviceName, Encoding.UTF8.GetBytes (request));
         }
@@ -246,7 +246,7 @@ namespace TitanicProtocol
         public Guid Request<T> (string serviceName, T request) where T : ITitanicConvert<T>
         {
             if (string.IsNullOrWhiteSpace (serviceName))
-                throw new ArgumentNullException ("serviceName", "The name of the service requested must not be empty or 'null'!");
+                throw new ArgumentNullException (nameof(serviceName), "The name of the service requested must not be empty or 'null'!");
 
             return Request (serviceName, request.ConvertToBytes ());
         }
@@ -283,7 +283,7 @@ namespace TitanicProtocol
         public Tuple<byte[], TitanicReturnCode> Reply (Guid requestId, int retries, TimeSpan waitBetweenRetries)
         {
             if (requestId == Guid.Empty)
-                throw new ArgumentNullException ("requestId", "The id of the request must not be empty!");
+                throw new ArgumentNullException (nameof(requestId), "The id of the request must not be empty!");
 
             var message = new NetMQMessage ();
             var rc = TitanicReturnCode.Failure;
@@ -322,7 +322,7 @@ namespace TitanicProtocol
         public Tuple<byte[], TitanicReturnCode> Reply (Guid requestId, TimeSpan waitFor)
         {
             if (requestId == Guid.Empty)
-                throw new ArgumentNullException ("requestId", "The id of the request must not be empty!");
+                throw new ArgumentNullException (nameof(requestId), "The id of the request must not be empty!");
 
             var retries = waitFor.Milliseconds > 5000 ? 8 : 4;
             var waitBetween = waitFor.Milliseconds / retries;
@@ -341,7 +341,7 @@ namespace TitanicProtocol
         public Tuple<T, TitanicReturnCode> Reply<T> (Guid requestId, TimeSpan waitFor) where T : ITitanicConvert<T>, new ()
         {
             if (requestId == Guid.Empty)
-                throw new ArgumentNullException ("requestId", "The id of the request must not be empty!");
+                throw new ArgumentNullException (nameof(requestId), "The id of the request must not be empty!");
 
             var reply = Reply (requestId, waitFor);
 
@@ -363,7 +363,7 @@ namespace TitanicProtocol
             where T : ITitanicConvert<T>, new ()
         {
             if (requestId == Guid.Empty)
-                throw new ArgumentNullException ("requestId", "The id of the request must not be empty!");
+                throw new ArgumentNullException (nameof(requestId), "The id of the request must not be empty!");
 
             var reply = Reply (requestId, retries, waitBetweenRetries);
 

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicClient.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicClient.cs
@@ -434,10 +434,7 @@ namespace TitanicProtocol
 
         protected virtual void OnLogInfoReady (TitanicLogEventArgs e)
         {
-            var handler = LogInfoReady;
-
-            if (handler != null)
-                handler (this, e);
+            LogInfoReady?.Invoke (this, e);
         }
 
         private void RecreateClient ()

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicClient.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicClient.cs
@@ -70,7 +70,7 @@ namespace TitanicProtocol
             if (string.IsNullOrWhiteSpace (serviceName))
                 throw new ArgumentNullException (nameof(serviceName), "The name of the service requested must not be empty or 'null'!");
 
-            Log (string.Format ("requesting service {0} to process {1}", serviceName, request));
+            Log ($"requesting service {serviceName} to process {request}");
 
             var count = 0;
             var requestId = Guid.Empty;
@@ -91,7 +91,7 @@ namespace TitanicProtocol
                 }
 
             }
-            Log (string.Format ("RequestId = {0}", requestId));
+            Log ($"RequestId = {requestId}");
 
             // 2. wait for reply
             var reply = Reply (requestId, retries, TimeSpan.FromMilliseconds (waitInBetween));
@@ -203,7 +203,7 @@ namespace TitanicProtocol
             // set requested service
             message.Push (serviceName);              // [service name][data]
 
-            Log (string.Format ("requesting: {0}", message));
+            Log ($"requesting: {message}");
 
             var reply = ServiceCall (m_client, TitanicOperation.Request, message);
 
@@ -294,7 +294,7 @@ namespace TitanicProtocol
             {
                 message.Push (requestId.ToString ());
 
-                Log (string.Format ("requesting reply for: {0}", message));
+                Log ($"requesting reply for: {message}");
 
                 var reply = ServiceCall (m_client, TitanicOperation.Reply, message);
 
@@ -385,7 +385,7 @@ namespace TitanicProtocol
             var message = new NetMQMessage ();
             message.Push (requestId.ToString ());
 
-            Log (string.Format ("request close: {0}", message));
+            Log ($"request close: {message}");
 
             ServiceCall (m_client, TitanicOperation.Close, message);
         }
@@ -403,7 +403,7 @@ namespace TitanicProtocol
             //      in goes -> [titanic operation][request id]
             var reply = session.Send (op.ToString (), message);
 
-            Log (string.Format ("received message: {0}", reply));
+            Log ($"received message: {reply}");
 
             if (ReferenceEquals (reply, null) || reply.IsEmpty)
                 return null; // went wrong - why? I don't care!

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicFileIO.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicFileIO.cs
@@ -53,14 +53,14 @@ namespace TitanicProtocol
         /// </summary>
         private readonly string m_appDir;
 
-        public string TitanicDirectory { get { return m_appDir; } }
+        public string TitanicDirectory => m_appDir;
 
         /// <summary>
         ///     represents the filename of the queue of requests
         /// </summary>
         private readonly string m_titanicQueue;
 
-        public string TitanicQueue { get { return m_titanicQueue; } }
+        public string TitanicQueue => m_titanicQueue;
 
         /// <summary>
         ///     ctor - creation with all standard values

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicFileIO.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicFileIO.cs
@@ -540,10 +540,7 @@ namespace TitanicProtocol
 
         protected virtual void OnLogInfoReady (TitanicLogEventArgs e)
         {
-            var handler = LogInfoReady;
-
-            if (handler != null)
-                handler (this, e);
+            LogInfoReady?.Invoke (this, e);
         }
     }
 }

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicMemoryIO.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicMemoryIO.cs
@@ -43,7 +43,7 @@ namespace TitanicProtocol
         /// </summary>
         public string TitanicQueue { get { throw new InvalidOperationException ("In-Memory IO does not provide a file name for the titanic queue."); } }
 
-        internal int NumberOfRequests { get { return m_titanicQueue.Count; } }
+        internal int NumberOfRequests => m_titanicQueue.Count;
 
         /// <summary>
         ///     ctor

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicMemoryIO.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicMemoryIO.cs
@@ -102,7 +102,7 @@ namespace TitanicProtocol
         public void SaveRequestEntry (RequestEntry entry)
         {
             if (ReferenceEquals (entry, null))
-                throw new ArgumentNullException ("entry", "The RequestEntry to save must not be null!");
+                throw new ArgumentNullException (nameof(entry), "The RequestEntry to save must not be null!");
 
             m_titanicQueue.AddOrUpdate (entry.RequestId, entry, (id, e) => entry);
         }

--- a/src/Samples/Titanic Pattern/TitanicBroker/TitanicMemoryIO.cs
+++ b/src/Samples/Titanic Pattern/TitanicBroker/TitanicMemoryIO.cs
@@ -16,7 +16,7 @@ namespace TitanicProtocol
     ///     this class handles the I/O for TITANIC
     ///     if allows to transparently write, read, find and delete entries
     ///     in memory (CocurrentQueue)
-    /// 
+    ///
     ///     it is fast but all information is lost in case this computer or
     ///     the process dies!
     /// </summary>
@@ -250,7 +250,7 @@ namespace TitanicProtocol
         /// <param name="op">commands whether it is for a REQUEST or a REPLY</param>
         /// <param name="id">the GUID für the Request/Reply</param>
         /// <returns>
-        ///         true if it exists and false otherwise and if 'op' is not one 
+        ///         true if it exists and false otherwise and if 'op' is not one
         ///         of the aforementioned
         /// </returns>
         public bool ExistsMessage (TitanicOperation op, Guid id)
@@ -274,10 +274,7 @@ namespace TitanicProtocol
         /// <exception cref="Exception">A delegate callback throws an exception. </exception>
         protected virtual void OnLogInfoReady (TitanicLogEventArgs e)
         {
-            var handler = LogInfoReady;
-
-            if (handler != null)
-                handler (this, e);
+            LogInfoReady?.Invoke (this, e);
         }
     }
 }

--- a/src/Samples/Titanic Pattern/TitanicPatternTests/TestEntities/FakeDispatchMDPClient.cs
+++ b/src/Samples/Titanic Pattern/TitanicPatternTests/TestEntities/FakeDispatchMDPClient.cs
@@ -19,9 +19,9 @@ namespace TitanicProtocolTests.TestEntities
 
         public int Retries { get; set; }
 
-        public string Address { get { return "NO ADDRESS"; } }
+        public string Address => "NO ADDRESS";
 
-        public byte[] Identity { get { return Encoding.UTF8.GetBytes ("NO IDENTITY"); } }
+        public byte[] Identity => Encoding.UTF8.GetBytes ("NO IDENTITY");
 
         public NetMQMessage Send (string serviceName, NetMQMessage request)
         {

--- a/src/Samples/Titanic Pattern/TitanicPatternTests/TestEntities/MDPTestClientForTitanicClient.cs
+++ b/src/Samples/Titanic Pattern/TitanicPatternTests/TestEntities/MDPTestClientForTitanicClient.cs
@@ -108,10 +108,7 @@ namespace TitanicProtocolTests.TestEntities
 
         protected virtual void OnLogInfoReady (MDPLogEventArgs e)
         {
-            var handler = LogInfoReady;
-
-            if (handler != null)
-                handler (this, e);
+            LogInfoReady?.Invoke (this, e);
         }
 
     }

--- a/src/Samples/Titanic Pattern/TitanicPatternTests/TestEntities/MDPTestClientForTitanicClient.cs
+++ b/src/Samples/Titanic Pattern/TitanicPatternTests/TestEntities/MDPTestClientForTitanicClient.cs
@@ -20,9 +20,9 @@ namespace TitanicProtocolTests.TestEntities
 
         public int Retries { get { throw new NotImplementedException (); } set { throw new NotImplementedException (); } }
 
-        public string Address { get { return "Fake Address"; } }
+        public string Address => "Fake Address";
 
-        public byte[] Identity { get { return Encoding.UTF8.GetBytes ("Fake Identity"); } }
+        public byte[] Identity => Encoding.UTF8.GetBytes ("Fake Identity");
 
         /// <remarks>
         ///  return messages can be:

--- a/src/Samples/Titanic Pattern/TitanicPatternTests/TestEntities/MDPTestClientForTitanicClient.cs
+++ b/src/Samples/Titanic Pattern/TitanicPatternTests/TestEntities/MDPTestClientForTitanicClient.cs
@@ -62,7 +62,7 @@ namespace TitanicProtocolTests.TestEntities
         //
         public NetMQMessage Send (string serviceName, NetMQMessage message)
         {
-            Log (string.Format ("requested service <{0}> with request <{1}>", serviceName, message));
+            Log ($"requested service <{serviceName}> with request <{message}>");
 
             if (ReplyMessage != null)
                 return new NetMQMessage (ReplyMessage);     // to keep it intact for multiple tries return a copy(!)
@@ -94,7 +94,7 @@ namespace TitanicProtocolTests.TestEntities
                     break;
             }
 
-            Log (string.Format ("reply <{0}>", reply));
+            Log ($"reply <{reply}>");
 
             return reply;
         }

--- a/src/Samples/Titanic Pattern/TitanicPatternTests/TitanicBrokerTests.cs
+++ b/src/Samples/Titanic Pattern/TitanicPatternTests/TitanicBrokerTests.cs
@@ -34,7 +34,7 @@ namespace TitanicProtocolTests
                 var path = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, _titanic_directory);
                 var queue = Path.Combine (path, _titanic_queue);
 
-                File.Exists (queue).Should ().BeTrue (string.Format ("because {0} should NOT have been created!", queue));
+                File.Exists (queue).Should ().BeTrue ($"because {queue} should NOT have been created!");
 
                 // clean up
                 File.Delete (queue);
@@ -56,7 +56,7 @@ namespace TitanicProtocolTests
 
                 try
                 {
-                    File.Exists (queue).Should ().BeTrue (string.Format ("because {0} should have been created!", queue));
+                    File.Exists (queue).Should ().BeTrue ($"because {queue} should have been created!");
                 }
                 finally
                 {
@@ -79,8 +79,8 @@ namespace TitanicProtocolTests
                 var path = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, _titanic_directory);
                 var queue = Path.Combine (path, _titanic_queue);
 
-                Directory.Exists (path).Should ().BeTrue (string.Format ("because {0} should have been created!", path));
-                File.Exists (queue).Should ().BeTrue (string.Format ("because {0} should have been created!", queue));
+                Directory.Exists (path).Should ().BeTrue ($"because {path} should have been created!");
+                File.Exists (queue).Should ().BeTrue ($"because {queue} should have been created!");
 
                 // clean up
                 cts.Cancel ();
@@ -106,8 +106,8 @@ namespace TitanicProtocolTests
                 var t = Task.Factory.StartNew (() => sut.Run (), cts.Token);
                 t.Status.Should ().Be (TaskStatus.WaitingToRun, "because it should wait for a request!");
 
-                Directory.Exists (path).Should ().BeTrue (string.Format ("because {0} should have been created!", path));
-                File.Exists (queue).Should ().BeTrue (string.Format ("because {0} should have been created!", queue));
+                Directory.Exists (path).Should ().BeTrue ($"because {path} should have been created!");
+                File.Exists (queue).Should ().BeTrue ($"because {queue} should have been created!");
 
                 // clean up
                 cts.Cancel ();

--- a/src/Samples/Titanic Pattern/TitanicPatternTests/TitanicFileIOTests.cs
+++ b/src/Samples/Titanic Pattern/TitanicPatternTests/TitanicFileIOTests.cs
@@ -27,11 +27,11 @@ namespace TitanicProtocolTests
 
             Directory.Exists (expectedDirectory)
                      .Should ()
-                     .BeTrue (string.Format ("because {0} should have been created!", expectedDirectory));
+                     .BeTrue ($"because {expectedDirectory} should have been created!");
 
             File.Exists (expectedFile)
                 .Should ()
-                .BeTrue (string.Format ("because {0} should have been created!", expectedFile));
+                .BeTrue ($"because {expectedFile} should have been created!");
         }
 
         [Test]
@@ -222,7 +222,7 @@ namespace TitanicProtocolTests
 
             var file = sut.TitanicQueue;
 
-            File.Exists (file).Should ().BeTrue (string.Format ("because {0} was created.", file));
+            File.Exists (file).Should ().BeTrue ($"because {file} was created.");
         }
 
         [Test]
@@ -401,7 +401,7 @@ namespace TitanicProtocolTests
                 sut.SaveNewRequestEntry (id); // -> fill titanic.queue
 
                 var message = new NetMQMessage ();
-                message.Push (string.Format ("Message #{0}", i));
+                message.Push ($"Message #{i}");
                 message.Push ("echo");
 
                 sut.SaveMessage (TitanicOperation.Request, id, message);

--- a/src/Samples/Titanic Pattern/TitanicPatternTests/TitanicMemoryIOTests.cs
+++ b/src/Samples/Titanic Pattern/TitanicPatternTests/TitanicMemoryIOTests.cs
@@ -309,7 +309,7 @@ namespace TitanicProtocolTests
             {
                 ids[i] = Guid.NewGuid ();
                 var request = new NetMQMessage ();
-                request.Push (string.Format ("Request #{0}", i));
+                request.Push ($"Request #{i}");
                 request.Push ("echo");
                 sut.SaveNewRequestEntry (ids[i], request);
             }
@@ -330,7 +330,7 @@ namespace TitanicProtocolTests
             {
                 ids[i] = Guid.NewGuid ();
                 var request = new NetMQMessage ();
-                request.Push (string.Format ("Request #{0}", i));
+                request.Push ($"Request #{i}");
                 request.Push ("echo");
                 sut.SaveNewRequestEntry (ids[i], request);
             }
@@ -372,7 +372,7 @@ namespace TitanicProtocolTests
                 ids[i] = Guid.NewGuid ();
 
                 var request = new NetMQMessage ();
-                request.Push (string.Format ("Request #{0}", i));
+                request.Push ($"Request #{i}");
                 request.Push ("echo");
                 sut.SaveMessage (TitanicOperation.Request, ids[i], request);
             }
@@ -380,7 +380,7 @@ namespace TitanicProtocolTests
             sut.NumberOfRequests.Should ().Be (10);
 
             var reply = new NetMQMessage ();
-            reply.Push (string.Format ("This is a REPLY to Request #{0}", id_to_retrieve));
+            reply.Push ($"This is a REPLY to Request #{id_to_retrieve}");
             reply.Push ("echo");
 
             sut.SaveMessage (TitanicOperation.Reply, ids[id_to_retrieve], reply).Should ().BeTrue ();
@@ -407,7 +407,7 @@ namespace TitanicProtocolTests
                 ids[i] = Guid.NewGuid ();
 
                 var request = new NetMQMessage ();
-                request.Push (string.Format ("Request #{0}", i));
+                request.Push ($"Request #{i}");
                 request.Push ("echo");
                 sut.SaveMessage (TitanicOperation.Request, ids[i], request);
             }
@@ -427,7 +427,7 @@ namespace TitanicProtocolTests
                 ids[i] = Guid.NewGuid ();
 
                 var request = new NetMQMessage ();
-                request.Push (string.Format ("Request #{0}", i));
+                request.Push ($"Request #{i}");
                 request.Push ("echo");
                 sut.SaveMessage (TitanicOperation.Request, ids[i], request);
             }
@@ -448,7 +448,7 @@ namespace TitanicProtocolTests
                 ids[i] = Guid.NewGuid ();
 
                 var request = new NetMQMessage ();
-                request.Push (string.Format ("Request #{0}", i));
+                request.Push ($"Request #{i}");
                 request.Push ("echo");
                 sut.SaveMessage (TitanicOperation.Request, ids[i], request);
             }

--- a/src/Samples/WeatherUpdater/WeatherUpdateClient/WeatherUpdateClient.cs
+++ b/src/Samples/WeatherUpdater/WeatherUpdateClient/WeatherUpdateClient.cs
@@ -35,7 +35,7 @@ namespace WeatherUpdateClient
                     int zip = int.Parse(split[0]);
                     if (zip != zipToSubscribeTo)
                     {
-                        throw new Exception(string.Format("Received message for unexpected zipcode: {0} (expected {1})", zip, zipToSubscribeTo));
+                        throw new Exception($"Received message for unexpected zipcode: {zip} (expected {zipToSubscribeTo})");
                     }
 
                     totalTemp += int.Parse(split[1]);

--- a/src/Samples/WeatherUpdater/WeatherUpdateServer/WeatherUpdateServer.cs
+++ b/src/Samples/WeatherUpdater/WeatherUpdateServer/WeatherUpdateServer.cs
@@ -29,7 +29,7 @@ namespace WeatherUpdateServer
                     int temperature = rng.Next(-80, 135);
                     int relhumidity = rng.Next(0, 90);
 
-                    publisher.Send(string.Format("{0} {1} {2}", zipcode, temperature, relhumidity));
+                    publisher.Send($"{zipcode} {temperature} {relhumidity}");
                 }
             }
         }


### PR DESCRIPTION
Now that C# 6 is out, is there any reason not to start taking advantage of its features? We can still target CLR versions 3.5 and 4.0.

* `nameof` operator (e0c5a4718cc2ea2404300f321fc276d4eb28f542)
* Null propagation operators (1903ff5223840a59d3e43c561ffddffad6e0f6a4)
* Immutable read only auto properties (f8afd9f0a2ba42c79e97a6ca9b9b654b948d301a)
* Expression bodies (aabf98da9000732f9d05422be04f73971c5a23c5)
* String interpolation (d5e382f83b78d4c6a9333b232fd9f850503d8400)

VS2015 Community Edition is available for open source work, so upgrading the project shouldn't exclude contributors.

I upgraded another of my projects recently to MSBuild 14.0 (VS2015/C#6) and had to [contact AppVeyor](http://help.appveyor.com/discussions/problems/2534-building-vs2015-rtm-solution) to get the project migrated to a build server that worked. I'm happy to sort that out.

Please share any thoughts here. Each of the C# 6 features has been introduced in a separate commit, so we can pick the PR apart if we want to take only some of the features and not others.

Do people like these new language features for NetMQ?