### PR TITLE
Fix for issue #225

### DIFF
--- a/src/NetMQ/Core/Transports/ByteArraySegment.cs
+++ b/src/NetMQ/Core/Transports/ByteArraySegment.cs
@@ -215,6 +215,43 @@ namespace NetMQ.Core.Transports
         }
 
         /// <summary>
+        /// Return a 64-bit unsigned numeric value (ulong) that is read from the buffer, starting at the position marked by the offset plus the given index i,
+        /// based upon the given byte-ordering.
+        /// </summary>
+        /// <param name="endian">an Endianness to specify which byte-ordering to use to interpret the source bytes</param>
+        /// <param name="i">the index position beyond the offset to start reading the bytes</param>
+        /// <returns>an unsigend long that is read from the bytes of the buffer</returns>
+        public ulong GetUnsignedLong(Endianness endian, int i)
+        {
+            // we changed how NetMQ is serializing long to support zeromq, however we still want to support old releases of netmq
+            // so we check if the MSB is not zero, in case it not zero we need to reorder the bits
+            if (endian == Endianness.Big)
+            {
+                return
+                    (((ulong)m_innerBuffer[i + Offset]) << 56) |
+                    (((ulong)m_innerBuffer[i + Offset + 1]) << 48) |
+                    (((ulong)m_innerBuffer[i + Offset + 2]) << 40) |
+                    (((ulong)m_innerBuffer[i + Offset + 3]) << 32) |
+                    (((ulong)m_innerBuffer[i + Offset + 4]) << 24) |
+                    (((ulong)m_innerBuffer[i + Offset + 5]) << 16) |
+                    (((ulong)m_innerBuffer[i + Offset + 6]) << 8) |
+                    ((ulong)m_innerBuffer[i + Offset + 7]);
+            }
+            else
+            {
+                return
+                (((ulong)m_innerBuffer[i + Offset + 7]) << 56) |
+                (((ulong)m_innerBuffer[i + Offset + 6]) << 48) |
+                (((ulong)m_innerBuffer[i + Offset + 5]) << 40) |
+                (((ulong)m_innerBuffer[i + Offset + 4]) << 32) |
+                (((ulong)m_innerBuffer[i + Offset + 3]) << 24) |
+                (((ulong)m_innerBuffer[i + Offset + 2]) << 16) |
+                (((ulong)m_innerBuffer[i + Offset + 1]) << 8) |
+                ((ulong)m_innerBuffer[i + Offset + 0]);
+            }
+        }
+
+        /// <summary>
         /// Return a 32-bit integer that is read from the buffer, starting at the position marked by the offset plus the given index i,
         /// based upon the given byte-ordering.
         /// </summary>

--- a/src/NetMQ/Core/Transports/V2Decoder.cs
+++ b/src/NetMQ/Core/Transports/V2Decoder.cs
@@ -82,20 +82,20 @@ namespace NetMQ.Core.Transports
             m_tmpbuf.Reset();
 
             // The payload size is encoded as 64-bit unsigned integer.
-            // The most significant byte comes first.        
-
-            long msg_size = m_tmpbuf.GetLong(Endian, 0);
+            // The most significant byte comes first.
+            ulong msg_size = m_tmpbuf.GetUnsignedLong(Endian, 0);
 
             // Message size must not exceed the maximum allowed size.
             if (m_maxmsgsize >= 0)
-                if (msg_size > m_maxmsgsize)
+                if (msg_size > (ulong)m_maxmsgsize)
                 {
                     DecodingError();
                     return false;
                 }
 
+            // TODO: move this constant to a good place (0x7FFFFFC7)
             // Message size must fit within range of size_t data type.
-            if (msg_size > int.MaxValue)
+            if (msg_size > 0x7FFFFFC7)
             {
                 DecodingError();
                 return false;


### PR DESCRIPTION
There is a mismatch with ZeroMQ concerning unsigned 8 byte integer being used for size of payload. Comment was saying exactly that, but long was used instead. I also added max value check for max byte array size with 56 elements less (https://msdn.microsoft.com/en-us/library/hh285054.aspx remarks). Constant should be placed better though. So basically I just made code up to date with zeromq c++ for the eight byte size payloads on v2 decoder.

Other decoders/encoders are worth checking out too I guess.