### PR TITLE
problem: no easy way to reset timer

### DIFF
--- a/src/NetMQ/NetMQTimer.cs
+++ b/src/NetMQ/NetMQTimer.cs
@@ -120,6 +120,17 @@ namespace NetMQ
         internal long When { get; set; }
 
         /// <summary>
+        /// Enable the timer and reset the interval
+        /// </summary>
+        public void EnableAndReset()
+        {
+            if (!Enable)
+                Enable = true;
+            else            
+                When = Clock.NowMs() + Interval;
+        }
+
+        /// <summary>
         /// If there are any subscribers - raise the Elapsed event.
         /// </summary>
         /// <param name="sender">the sender to include within the event's event-args</param>


### PR DESCRIPTION
The only the reset the timer interval is to disable and enable the timer.

Add a method called EnableAndReset that enable the timer if disabled and reset the interval.

Useful Example: when you use the timer to send heartbeat after you didn't get a message for X seconds. Each time you get a message you will just call EnableAndReset.