### PR TITLE
Problem: no way to use any dotnet queue with Poller

### DIFF
--- a/src/NetMQ.QueuePerformance/NetMQ.QueuePerformance.csproj
+++ b/src/NetMQ.QueuePerformance/NetMQ.QueuePerformance.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{138E2AA0-F26E-4175-9758-1A5EA0699162}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NetMQ.QueuePerformance</RootNamespace>
+    <AssemblyName>NetMQ.QueuePerformance</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NetMQ\NetMQ.csproj">
+      <Project>{82934BAC-07FB-41AC-AE59-46FEE6026A40}</Project>
+      <Name>NetMQ</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NetMQ.QueuePerformance/Program.cs
+++ b/src/NetMQ.QueuePerformance/Program.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NetMQ.QueuePerformance
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            int count = 10000000;
+
+            using (NetMQContext context = NetMQContext.Create())
+            {
+                NetMQQueue<int> queue = new NetMQQueue<int>(context);
+
+                var task = Task.Factory.StartNew(() =>
+                {
+                    queue.Dequeue();
+
+                    Stopwatch stopwatch = Stopwatch.StartNew();
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        queue.Dequeue();
+                    }
+
+                    stopwatch.Stop();
+
+                    Console.WriteLine("Dequeueing items per second: {0:N0}", count /stopwatch.Elapsed.TotalSeconds);
+                });
+
+                queue.Enqueue(-1);
+
+                Stopwatch writeStopwatch = Stopwatch.StartNew();
+
+                for (int i = 0; i < count; i++)
+                {
+                    queue.Enqueue(i);
+                }
+
+                writeStopwatch.Stop();
+
+                Console.WriteLine("Enqueueing items per second: {0:N0}", count/writeStopwatch.Elapsed.TotalSeconds);
+
+                task.Wait();
+            }
+        }
+    }
+}

--- a/src/NetMQ.QueuePerformance/Properties/AssemblyInfo.cs
+++ b/src/NetMQ.QueuePerformance/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NetMQ.QueuePerformance")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NetMQ.QueuePerformance")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("138e2aa0-f26e-4175-9758-1a5ea0699162")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="InProcActors\Echo\EchoActorTests.cs" />
     <Compile Include="MockBufferPool.cs" />
     <Compile Include="MsgTests.cs" />
+    <Compile Include="NetMQQueueTests.cs" />
     <Compile Include="OutgoingSocketExtensionsTests.cs" />
     <Compile Include="ReceivingSocketExtensionsTests.cs" />
     <Compile Include="RouterTests.cs" />

--- a/src/NetMQ.Tests/NetMQQueueTests.cs
+++ b/src/NetMQ.Tests/NetMQQueueTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using NUnit.Framework;
+
+namespace NetMQ.Tests
+{
+    [TestFixture]
+    public class NetMQQueueTests
+    {
+        [Test]
+        public void EnqueueDequeue()
+        {
+            using (NetMQContext context = NetMQContext.Create())
+            using (NetMQQueue<int> queue = new NetMQQueue<int>(context))
+            {
+                queue.Enqueue(1);
+
+                Assert.AreEqual(1, queue.Dequeue());
+            }
+        }
+
+        [Test]
+        public void TryDequeue()
+        {
+            using (NetMQContext context = NetMQContext.Create())
+            using (NetMQQueue<int> queue = new NetMQQueue<int>(context))
+            {
+                int result;
+                Assert.IsFalse(queue.TryDequeue(out result, TimeSpan.FromMilliseconds(100)));
+
+                queue.Enqueue(1);
+
+                Assert.IsTrue(queue.TryDequeue(out result, TimeSpan.FromMilliseconds(100)));
+                Assert.AreEqual(1, result);
+            }
+        }
+
+        [Test]
+        public void WithPoller()
+        {
+            using (NetMQContext context = NetMQContext.Create())
+            using (NetMQQueue<int> queue = new NetMQQueue<int>(context))
+            {
+                Poller poller = new Poller();
+                poller.AddSocket(queue);
+
+                ManualResetEvent manualResetEvent = new ManualResetEvent(false);
+
+                queue.ReceiveReady += (sender, args) =>
+                {
+                    manualResetEvent.Set();
+                };
+
+                poller.PollTillCancelledNonBlocking();
+
+                Assert.IsFalse(manualResetEvent.WaitOne(100));
+                queue.Enqueue(1);
+                Assert.IsTrue(manualResetEvent.WaitOne(100));
+
+                poller.CancelAndJoin();
+            }
+        }
+    }
+}

--- a/src/NetMQ.sln
+++ b/src/NetMQ.sln
@@ -169,6 +169,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TitanicWorkerExample", "Sam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MDPCommons", "Samples\Majordomo\MDPCommons\MDPCommons.csproj", "{EC5A112C-5652-4EAA-BEE9-BF1A98F719C4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetMQ.QueuePerformance", "NetMQ.QueuePerformance\NetMQ.QueuePerformance.csproj", "{138E2AA0-F26E-4175-9758-1A5EA0699162}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -698,6 +700,22 @@ Global
 		{EC5A112C-5652-4EAA-BEE9-BF1A98F719C4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{EC5A112C-5652-4EAA-BEE9-BF1A98F719C4}.Release|x64.ActiveCfg = Release|Any CPU
 		{EC5A112C-5652-4EAA-BEE9-BF1A98F719C4}.Release|x86.ActiveCfg = Release|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Debug|x64.Build.0 = Debug|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Debug|x86.Build.0 = Debug|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Release|Any CPU.Build.0 = Release|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Release|x64.ActiveCfg = Release|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Release|x64.Build.0 = Release|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Release|x86.ActiveCfg = Release|Any CPU
+		{138E2AA0-F26E-4175-9758-1A5EA0699162}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -758,5 +776,6 @@ Global
 		{F516F643-D475-43FD-AEC7-B5CA8B997D22} = {6E473EBF-8344-4EC4-B66B-D6349B6F0F5F}
 		{32B1FA88-2A00-41C9-AF28-1EB9F8BB51F3} = {6E473EBF-8344-4EC4-B66B-D6349B6F0F5F}
 		{EC5A112C-5652-4EAA-BEE9-BF1A98F719C4} = {813D3184-CAE9-4EA5-AD8F-CF0B5E890E79}
+		{138E2AA0-F26E-4175-9758-1A5EA0699162} = {1D49A4C6-C03C-4F72-9A27-42C8E5219BBA}
 	EndGlobalSection
 EndGlobal

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -60,6 +60,7 @@
     <Compile Include="ISocketPollable.cs" />
     <Compile Include="IReceivingSocket.cs" />
     <Compile Include="NetMQBeacon.cs" />
+    <Compile Include="NetMQQueue.cs" />
     <Compile Include="NetMQScheduler.cs" />
     <Compile Include="NetworkOrderBitsConverter.cs" />
     <Compile Include="OutgoingSocketExtensions.cs" />

--- a/src/NetMQ/NetMQQueue.cs
+++ b/src/NetMQ/NetMQQueue.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using NetMQ.Core.Utils;
+using NetMQ.Sockets;
+
+namespace NetMQ
+{
+    public class NetMQQueueEventArgs<T> : EventArgs
+    {
+        public NetMQQueueEventArgs(NetMQQueue<T> queue)
+        {
+            Queue = queue;
+        }
+
+        public NetMQQueue<T> Queue { get; private set; }
+    }
+
+    /// <summary>
+    /// Multi producer singler consumer queue which you can poll on with a Poller.
+    /// </summary>
+    /// <typeparam name="T">Type of the item in queue</typeparam>
+    public class NetMQQueue<T> : IDisposable, ISocketPollable
+    {
+        static byte[] s_empty = new byte[0];
+        private static int s_sequence = 0;
+
+        private readonly NetMQContext m_context;
+        private readonly PairSocket m_writer;
+        private readonly PairSocket m_reader;
+        private readonly ConcurrentQueue<T> m_queue;
+        private readonly EventDelegator<NetMQQueueEventArgs<T>> m_eventDelegator;        
+        private Msg m_dequeueMsg;
+
+        /// <summary>
+        /// Create new NetMQQueue.
+        /// </summary>
+        /// <param name="context">NetMQContext must be provided to the queue</param>
+        /// <param name="capacity">The capacity of the queue, use zero for unlimited</param>
+        public NetMQQueue(NetMQContext context, int capacity = 0)
+        {
+            m_context = context;
+            m_queue = new ConcurrentQueue<T>();
+            m_writer = m_context.CreatePairSocket();
+            m_reader = m_context.CreatePairSocket();
+
+            if (capacity != 0)
+            {
+                m_writer.Options.SendHighWatermark = m_reader.Options.ReceiveHighWatermark = capacity / 2;
+            }
+            else
+            {
+                m_writer.Options.SendHighWatermark = m_reader.Options.ReceiveHighWatermark = 0;
+            }
+
+            m_eventDelegator = new EventDelegator<NetMQQueueEventArgs<T>>(() =>
+            {
+                m_reader.ReceiveReady += OnReceiveReady;
+            }, () =>
+            {
+                m_reader.ReceiveReady -= OnReceiveReady;
+            });
+
+            string address = string.Format("inproc://NetMQQueue#{0}", Interlocked.Increment(ref s_sequence));
+            m_reader.Bind(address);
+            m_writer.Connect(address);
+
+            m_dequeueMsg = new Msg();
+            m_dequeueMsg.InitEmpty();            
+        }
+
+        private void OnReceiveReady(object sender, NetMQSocketEventArgs e)
+        {
+            m_eventDelegator.Fire(this, new NetMQQueueEventArgs<T>(this));
+        }
+
+        /// <summary>
+        /// Register for this event for notification when there are items in the queue. Queue must be added to a poller for this to work.
+        /// </summary>
+        public event EventHandler<NetMQQueueEventArgs<T>> ReceiveReady
+        {
+            add { m_eventDelegator.Event += value; }
+            remove { m_eventDelegator.Event -= value; }
+        }
+
+        NetMQSocket ISocketPollable.Socket
+        {
+            get
+            {
+                return m_reader;
+            }
+        }
+
+        /// <summary>
+        /// Try to dequeue an item from the queue. Dequeueing and item is not thread safe.
+        /// </summary>
+        /// <param name="result">Will be filled with the item upon success</param>
+        /// <param name="timeout">Timeout to try and dequeue and item</param>
+        /// <returns>Will return false if it didn't succeed to dequeue an item after the timeout.</returns>
+        public bool TryDequeue(out T result, TimeSpan timeout)
+        {
+            if (m_reader.TryReceive(ref m_dequeueMsg, timeout))
+            {
+                return m_queue.TryDequeue(out result);
+            }
+            else
+            {
+                result = default(T);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Dequeue an item from the queue, will block if queue is empty. Dequeueing and item is not thread safe.
+        /// </summary>
+        /// <returns>Dequeued item</returns>
+        public T Dequeue()
+        {
+            m_reader.TryReceive(ref m_dequeueMsg, SendReceiveConstants.InfiniteTimeout);
+
+            T result;
+            m_queue.TryDequeue(out result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Enqueue an item to the queue, will block if the queue is full.
+        /// </summary>
+        /// <param name="value"></param>
+        public void Enqueue(T value)
+        {
+            m_queue.Enqueue(value);
+            
+            Msg msg = new Msg();
+            msg.InitGC(s_empty, 0);
+
+            lock (m_writer)
+            {
+                m_writer.TrySend(ref msg, SendReceiveConstants.InfiniteTimeout, false);
+            }            
+            msg.Close();        
+        }
+
+        /// <summary>
+        /// Dispose the queue.
+        /// </summary>
+        public void Dispose()
+        {
+            m_eventDelegator.Dispose();
+            m_writer.Dispose();
+            m_reader.Dispose();
+            m_dequeueMsg.Close();
+        }
+    }
+}


### PR DESCRIPTION
If you want to poll on both NetMQSockets and wait for messages from queue right now it is not possible.

NetMQQueue is new queue which can be added to a poller and to poll on. The queue is multi producer single consumer. Enqueueing is thread safe but dequeueing is not