### PR TITLE
Broadcast feature for XPub socket

### DIFF
--- a/src/NetMQ.Tests/RouterTests.cs
+++ b/src/NetMQ.Tests/RouterTests.cs
@@ -2,11 +2,14 @@
 using NUnit.Framework;
 using System.Text;
 
-namespace NetMQ.Tests {
+namespace NetMQ.Tests 
+{
     [TestFixture]
-    public class RouterTests {
+    public class RouterTests 
+    {
         [Test]
-        public void Mandatory() {
+        public void Mandatory() 
+        {
             using (var context = NetMQContext.Create())
             using (var router = context.CreateRouterSocket()) {
                 router.Options.RouterMandatory = true;
@@ -17,7 +20,8 @@ namespace NetMQ.Tests {
         }
 
         [Test]
-        public void ReceiveReadyDot35Bug() {
+        public void ReceiveReadyDot35Bug() 
+        {
             // In .NET 3.5, we saw an issue where ReceiveReady would be raised every second despite nothing being received
 
             using (var context = NetMQContext.Create())
@@ -33,7 +37,8 @@ namespace NetMQ.Tests {
 
 
         [Test]
-        public void TwoMessagesFromRouterToDealer() {
+        public void TwoMessagesFromRouterToDealer() 
+        {
             using (var context = NetMQContext.Create())
             using (var poller = new Poller())
             using (var server = context.CreateRouterSocket())

--- a/src/NetMQ.Tests/XPubSubTests.cs
+++ b/src/NetMQ.Tests/XPubSubTests.cs
@@ -404,7 +404,6 @@ namespace NetMQ.Tests
             using (var pub = context.CreateXPublisherSocket())
             using (var sub1 = context.CreateXSubscriberSocket())
             using (var sub2 = context.CreateXSubscriberSocket())
-            using (var poller = new Poller())
             {
                 pub.Bind("inproc://manual");
                 pub.Options.XPubBroadcast = true;
@@ -441,12 +440,13 @@ namespace NetMQ.Tests
         }
 
         [Test]
-        public void BroadcastDisabled() {
+        public void BroadcastDisabled() 
+        {
             using (var context = NetMQContext.Create())
             using (var pub = context.CreateXPublisherSocket())
             using (var sub1 = context.CreateXSubscriberSocket())
-            using (var sub2 = context.CreateXSubscriberSocket())
-            using (var poller = new Poller()) {
+            using (var sub2 = context.CreateXSubscriberSocket()) 
+            {
                 pub.Bind("inproc://manual");
                 pub.Options.XPubBroadcast = false;
                 

--- a/src/NetMQ.Tests/XPubSubTests.cs
+++ b/src/NetMQ.Tests/XPubSubTests.cs
@@ -426,6 +426,12 @@ namespace NetMQ.Tests
                 var topic = pub.ReceiveFrameBytes();
                 var message = pub.ReceiveFrameBytes();
 
+                Assert.AreEqual(2, topic[0]);
+                // we must ski the first byte if we have detected a broadcast message
+                // the sender of this message is already marked for exclusion
+                // but the match logic in Send should work with normal topic.
+                topic = topic.Skip(1).ToArray();
+
                 pub.SendFrame(topic, true);
                 pub.SendFrame(message);
                 var broadcast2 = sub2.ReceiveFrameBytes();

--- a/src/NetMQ/Core/Patterns/XPub.cs
+++ b/src/NetMQ/Core/Patterns/XPub.cs
@@ -201,7 +201,6 @@ namespace NetMQ.Core.Patterns
                     m_pending.Enqueue(sub);
                 }
 
-                if(!m_lastPipeIsBroadcast) sub.Close();
             }
         }
 

--- a/src/NetMQ/Core/Patterns/XPub.cs
+++ b/src/NetMQ/Core/Patterns/XPub.cs
@@ -328,7 +328,11 @@ namespace NetMQ.Core.Patterns
             if (!msgMore)
             {
                 m_distribution.Unmatch();
-                if (m_broadcastEnabled) m_lastPipeIsBroadcast = false;
+                if (m_broadcastEnabled)
+                {
+                    m_lastPipeIsBroadcast = false;
+                    m_lastPipe = null;
+                }
             }
 
             m_more = msgMore;

--- a/src/NetMQ/Core/Patterns/XPub.cs
+++ b/src/NetMQ/Core/Patterns/XPub.cs
@@ -194,12 +194,10 @@ namespace NetMQ.Core.Patterns
 
                     }
                 }
-                else if (m_broadcastEnabled && size > 0 && sub.HasMore && sub[0] == 2)
+                else if (m_broadcastEnabled && size > 0 && sub[0] == 2)
                 {
                     m_lastPipe = pipe;
                     m_lastPipeIsBroadcast = true;
-                    sub.Offset = sub.Offset + 1;
-                    sub.Size = sub.Size - 1;
                     m_pending.Enqueue(sub);
                 }
                 else // process message unrelated to sub/unsub

--- a/src/NetMQ/Core/Patterns/XPub.cs
+++ b/src/NetMQ/Core/Patterns/XPub.cs
@@ -184,7 +184,14 @@ namespace NetMQ.Core.Patterns
                         // If the subscription is not a duplicate, store it so that it can be
                         // passed to used on next recv call.
                         if (m_options.SocketType == ZmqSocketType.Xpub && (unique || m_verbose))
+                        {
                             m_pending.Enqueue(sub);
+                        }
+                        else
+                        {
+                            sub.Close();
+                        }
+
                     }
                 }
                 else if (m_broadcastEnabled && size > 0 && sub.HasMore && sub[0] == 2)
@@ -194,7 +201,6 @@ namespace NetMQ.Core.Patterns
                     sub.Offset = sub.Offset + 1;
                     sub.Size = sub.Size - 1;
                     m_pending.Enqueue(sub);
-                    //XSend(ref sub);
                 }
                 else // process message unrelated to sub/unsub
                 {
@@ -345,7 +351,7 @@ namespace NetMQ.Core.Patterns
             // If there is at least one 
             if (m_pending.Count == 0)
                 return false;
-
+            msg.Close();
             msg = m_pending.Dequeue();
             
             return true;

--- a/src/NetMQ/Core/ZmqSocketOption.cs
+++ b/src/NetMQ/Core/ZmqSocketOption.cs
@@ -245,8 +245,15 @@ namespace NetMQ.Core
         /// This is an XPublisher-socket welcome-message.
         /// </summary>
         XPublisherWelcomeMessage = 43,
-        
+
+
         DisableTimeWait = 44,
+
+        /// <summary>
+        /// This applies only to XPub sockets.
+        /// If true, enable broadcast option on XPublishers
+        /// </summary>
+        XPublisherBroadcast = 45,
 
         /// <summary>
         /// Specifies the byte-order: big-endian, vs little-endian.

--- a/src/NetMQ/Msg.cs
+++ b/src/NetMQ/Msg.cs
@@ -96,13 +96,13 @@ namespace NetMQ
         /// <summary>
         /// Get the number of bytes within the Data property.
         /// </summary>
-        public int Size { get; private set; }
+        public int Size { get; internal set; }
 
         /// <summary>
         /// Gets the position of the first element in the Data property delimited by the message,
         //     relative to the start of the original array.
         /// </summary>
-        public int Offset { get; private set; }
+        public int Offset { get; internal set; }
 
         #region MsgType
 

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -383,6 +383,16 @@ namespace NetMQ
             set { m_socket.SetSocketOption(ZmqSocketOption.XpubVerbose, value); }
         }
 
+
+        /// <summary>
+        /// This applies only to publisher sockets.
+        /// Set whether to support broadcast functionality
+        /// </summary>
+        public bool XPubBroadcast {
+            set { m_socket.SetSocketOption(ZmqSocketOption.XPublisherBroadcast, value); }
+        }
+
+
         public bool RouterRawSocket
         {
             set { m_socket.SetSocketOption(ZmqSocketOption.RouterRawSocket, value); }


### PR DESCRIPTION
These changes add a broadcast feature that is similar to SignalR's `Clients.Others`. If the broadcast option is enabled and an XSub socket sends a topic prefixed with `2`, then that socket will never be matched on a subsequent `Send` by XPub. With this feature it is easy to turn a XPub into a message bus, when N XSub clients send a message to every other one - without additional Dealer/Router socket and without complicated check if a sender receives its own message back.

Without `XPubBroadcast` set to true, there is no change in behavior, so this change is backward compatible.

This PR depends on #400. It also removes unneeded copying of data in XSub by using the offset feature from #400.