### PR TITLE
Add TrimPrefix method

### DIFF
--- a/src/NetMQ.Tests/XPubSubTests.cs
+++ b/src/NetMQ.Tests/XPubSubTests.cs
@@ -427,7 +427,7 @@ namespace NetMQ.Tests
                 var message = pub.ReceiveFrameBytes();
 
                 Assert.AreEqual(2, topic[0]);
-                // we must ski the first byte if we have detected a broadcast message
+                // we must skip the first byte if we have detected a broadcast message
                 // the sender of this message is already marked for exclusion
                 // but the match logic in Send should work with normal topic.
                 topic = topic.Skip(1).ToArray();

--- a/src/NetMQ/Msg.cs
+++ b/src/NetMQ/Msg.cs
@@ -445,6 +445,17 @@ namespace NetMQ
         }
 
         /// <summary>
+        /// Increase Offset and decrease Size by the given count.
+        /// </summary>
+        /// <param name="count">Number of bytes to remove from a message</param>
+        public void TrimPrefix(int count)
+        {
+            if (count > Size || count < 0) throw new ArgumentOutOfRangeException("count", "Count should be between 0 and size");
+            Offset = Offset + count;
+            Size = Size - count;
+        }
+
+        /// <summary>
         /// Close this Msg and make it reference the given source Msg, and then clear the Msg to empty.
         /// </summary>
         /// <param name="src">the source-Msg to become</param>


### PR DESCRIPTION
Re: your comment that Offset/Size is internal. In the test we use Skip(1).ToArray(), but this includes copying of bytes. In my real code I already need this method after we changed the prefix removal logic in #401.