### PR TITLE
Fix bug with disconnected subscribers.

### DIFF
--- a/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
@@ -155,7 +155,7 @@ namespace NetMQ.Core.Patterns.Utils
             // Remove the subscription from this node.
             if (m_pipes != null && m_pipes.Remove(pipe) && m_pipes.Count == 0)
             {
-                func(null, buffer, bufferSize, arg);
+                func(pipe, buffer, bufferSize, arg);
                 m_pipes = null;
             }
 


### PR DESCRIPTION
Fix bug with disconnected subscribers. The pipe queue was keeping them, and automatic unsubscribe messages were failing in manual mode because m_lastPipe was not set correctly. "Tested in production." KeyValuePair is semantically correct, because each pipe is associated with a message. Also KVP is a struct, while built-in tuples are classes, so there is no object allocation.