### PR TITLE
problem: creating socket in NetMQ is verbose and require multiple of lines

### DIFF
--- a/src/NetMQ.Tests/SocketTests.cs
+++ b/src/NetMQ.Tests/SocketTests.cs
@@ -787,18 +787,90 @@ namespace NetMQ.Tests
         [Test]
         public void ContextFree()
         {
-            using (DealerSocket server = new DealerSocket())
+            using (DealerSocket server = new DealerSocket("@tcp://127.0.0.1:5555"))
             {
-                using (DealerSocket client = new DealerSocket())
-                {
-                    server.Bind("tcp://127.0.0.1:5555");
-                    client.Connect("tcp://127.0.0.1:5555");
-
+                using (DealerSocket client = new DealerSocket(">tcp://127.0.0.1:5555"))
+                {                    
                     client.SendFrame("Hello");
 
                     Assert.AreEqual("Hello", server.ReceiveFrameString());
                 }
             }            
         }
+
+        [Test]
+        public void ConnectionStringDefault()
+        {
+            using (ResponseSocket response = new ResponseSocket("tcp://127.0.0.1:5555"))
+            {
+                using (RequestSocket request = new RequestSocket("tcp://127.0.0.1:5555"))
+                {
+                    request.SendFrame("Hello");
+
+                    Assert.AreEqual("Hello", response.ReceiveFrameString());
+                }
+            }
+        }
+
+        [Test]
+        public void ConnectionStringSpecifyDefault()
+        {
+            using (ResponseSocket response = new ResponseSocket("@tcp://127.0.0.1:5555"))
+            {
+                using (RequestSocket request = new RequestSocket(">tcp://127.0.0.1:5555"))
+                {
+                    request.SendFrame("Hello");
+
+                    Assert.AreEqual("Hello", response.ReceiveFrameString());
+                }
+            }
+        }
+
+        [Test]
+        public void ConnectionStringSpecifyNonDefault()
+        {
+            using (ResponseSocket response = new ResponseSocket(">tcp://127.0.0.1:5555"))
+            {
+                using (RequestSocket request = new RequestSocket("@tcp://127.0.0.1:5555"))
+                {
+                    request.SendFrame("Hello");
+
+                    Assert.AreEqual("Hello", response.ReceiveFrameString());
+                }
+            }
+        }
+
+        [Test]
+        public void ConnectionStringWithWhiteSpace()
+        {
+            using (ResponseSocket response = new ResponseSocket(" >tcp://127.0.0.1:5555 "))
+            {
+                using (RequestSocket request = new RequestSocket("@tcp://127.0.0.1:5555, "))
+                {
+                    request.SendFrame("Hello");
+
+                    Assert.AreEqual("Hello", response.ReceiveFrameString());
+                }
+            }
+        }
+
+        [Test]
+        public void ConnectionStringMultipleAddresses()
+        {
+            using (DealerSocket server1 = new DealerSocket("@tcp://127.0.0.1:5555"))
+            using (DealerSocket server2 = new DealerSocket("@tcp://127.0.0.1:5556,@tcp://127.0.0.1:5557"))
+            using (DealerSocket client = new DealerSocket("tcp://127.0.0.1:5555,tcp://127.0.0.1:5556,tcp://127.0.0.1:5557"))
+            {
+                // send three helloes
+                client.SendFrame("Hello");
+                client.SendFrame("Hello");
+                client.SendFrame("Hello");
+
+                Assert.AreEqual("Hello", server1.ReceiveFrameString());
+                Assert.AreEqual("Hello", server2.ReceiveFrameString());
+                Assert.AreEqual("Hello", server2.ReceiveFrameString());
+            }
+        }
+
     }
 }

--- a/src/NetMQ/Sockets/DealerSocket.cs
+++ b/src/NetMQ/Sockets/DealerSocket.cs
@@ -9,9 +9,12 @@ namespace NetMQ.Sockets
     public class DealerSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new DealerSocket.
-        /// </summary>
-        public DealerSocket() :  base(ZmqSocketType.Dealer)
+        /// Create a new DealerSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new DealerSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>                 
+        public DealerSocket(string connectionString = null) : base(ZmqSocketType.Dealer, connectionString, DefaultAction.Connect)
         {            
         }
 

--- a/src/NetMQ/Sockets/PairSocket.cs
+++ b/src/NetMQ/Sockets/PairSocket.cs
@@ -8,9 +8,12 @@ namespace NetMQ.Sockets
     public class PairSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new PairSocket.
-        /// </summary>
-        public PairSocket() : base(ZmqSocketType.Pair)
+        /// Create a new PairSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new PairSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>                 
+        public PairSocket(string connectionString = null) : base(ZmqSocketType.Pair, connectionString, DefaultAction.Connect)
         {
             
         }

--- a/src/NetMQ/Sockets/PublisherSocket.cs
+++ b/src/NetMQ/Sockets/PublisherSocket.cs
@@ -10,9 +10,12 @@ namespace NetMQ.Sockets
     public class PublisherSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new PublisherSocket.
-        /// </summary>
-        public PublisherSocket() : base(ZmqSocketType.Pub)
+        /// Create a new PublisherSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new PublisherSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>               
+        public PublisherSocket(string connectionString = null) : base(ZmqSocketType.Pub, connectionString, DefaultAction.Bind)
         {
             
         }

--- a/src/NetMQ/Sockets/PullSocket.cs
+++ b/src/NetMQ/Sockets/PullSocket.cs
@@ -10,11 +10,14 @@ namespace NetMQ.Sockets
     public class PullSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new PullSocket.
-        /// </summary>
-        public PullSocket() : base(ZmqSocketType.Pull)
+        /// Create a new PullSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new PullSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>               
+        public PullSocket(string connectionString = null) : base(ZmqSocketType.Pull, connectionString, DefaultAction.Bind)
         {
-            
+
         }
 
         /// <summary>

--- a/src/NetMQ/Sockets/PushSocket.cs
+++ b/src/NetMQ/Sockets/PushSocket.cs
@@ -10,9 +10,12 @@ namespace NetMQ.Sockets
     public class PushSocket : NetMQSocket
     {
         /// <summary>
-        /// Create new PushSocket
-        /// </summary>
-        public PushSocket() : base(ZmqSocketType.Push)
+        /// Create a new PushSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new PushSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>               
+        public PushSocket(string connectionString = null) : base(ZmqSocketType.Push, connectionString, DefaultAction.Connect)
         {
             
         }

--- a/src/NetMQ/Sockets/RequestSocket.cs
+++ b/src/NetMQ/Sockets/RequestSocket.cs
@@ -11,10 +11,12 @@ namespace NetMQ.Sockets
     public class RequestSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new RequestSocket.
-        /// </summary>
-
-        public RequestSocket() : base(ZmqSocketType.Req)
+        /// Create a new RequestSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new RequestSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>  
+        public RequestSocket(string connectionString = null) : base(ZmqSocketType.Req, connectionString, DefaultAction.Connect)
         {
             
         }

--- a/src/NetMQ/Sockets/ResponseSocket.cs
+++ b/src/NetMQ/Sockets/ResponseSocket.cs
@@ -9,9 +9,12 @@ namespace NetMQ.Sockets
     public class ResponseSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new ResponseSocket.
-        /// </summary>
-        public ResponseSocket() : base(ZmqSocketType.Rep)
+        /// Create a new ResponseSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new ResponseSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>  
+        public ResponseSocket(string connectionString = null) : base(ZmqSocketType.Rep, connectionString, DefaultAction.Bind)
         {
             
         }

--- a/src/NetMQ/Sockets/RouterSocket.cs
+++ b/src/NetMQ/Sockets/RouterSocket.cs
@@ -8,9 +8,12 @@ namespace NetMQ.Sockets
     public class RouterSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new RouterSocket.
-        /// </summary>
-        public RouterSocket() : base(ZmqSocketType.Router)
+        /// Create a new RouterSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new RouterSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>  
+        public RouterSocket(string connectionString = null) : base(ZmqSocketType.Router, connectionString, DefaultAction.Bind)
         {
             
         }

--- a/src/NetMQ/Sockets/StreamSocket.cs
+++ b/src/NetMQ/Sockets/StreamSocket.cs
@@ -13,9 +13,12 @@ namespace NetMQ.Sockets
     public class StreamSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new StreamSocket.
-        /// </summary>
-        public StreamSocket() : base(ZmqSocketType.Stream)
+        /// Create a new StreamSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new StreamSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>  
+        public StreamSocket(string connectionString = null) : base(ZmqSocketType.Stream, connectionString, DefaultAction.Connect)
         {
             
         }

--- a/src/NetMQ/Sockets/SubscriberSocket.cs
+++ b/src/NetMQ/Sockets/SubscriberSocket.cs
@@ -11,9 +11,12 @@ namespace NetMQ.Sockets
     public class SubscriberSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new SubscriberSocket.
-        /// </summary>
-        public SubscriberSocket() : base(ZmqSocketType.Sub)
+        /// Create a new SubscriberSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new SubscriberSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>  
+        public SubscriberSocket(string connectionString = null) : base(ZmqSocketType.Sub, connectionString, DefaultAction.Connect)
         {
             
         }

--- a/src/NetMQ/Sockets/XPublisherSocket.cs
+++ b/src/NetMQ/Sockets/XPublisherSocket.cs
@@ -11,9 +11,12 @@ namespace NetMQ.Sockets
     public class XPublisherSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new XPublisherSocket.
-        /// </summary>
-        public XPublisherSocket() : base(ZmqSocketType.Xpub)
+        /// Create a new XPublisherSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new XPublisherSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>  
+        public XPublisherSocket(string connectionString = null) : base(ZmqSocketType.Xpub, connectionString, DefaultAction.Bind)
         {
             
         }

--- a/src/NetMQ/Sockets/XSubscriberSocket.cs
+++ b/src/NetMQ/Sockets/XSubscriberSocket.cs
@@ -11,9 +11,12 @@ namespace NetMQ.Sockets
     public class XSubscriberSocket : NetMQSocket
     {
         /// <summary>
-        /// Create a new XSubscriberSocket.
-        /// </summary>
-        public XSubscriberSocket() : base(ZmqSocketType.Xsub)
+        /// Create a new XSubscriberSocket and attach socket to zero or more endpoints.               
+        /// </summary>                
+        /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new XSubscriberSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>  
+        public XSubscriberSocket(string connectionString = null) : base(ZmqSocketType.Xsub, connectionString, DefaultAction.Connect)
         {
             
         }


### PR DESCRIPTION
like bind and connect methods, which can be multiple lines of code.

Solution: accept connection string parameter in the ctor. For example:

```csharp
/// <summary>
/// Create a new DealerSocket and attach socket to zero or more endpoints.               
/// </summary>                
/// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
/// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
/// <example><code>var socket = new DealerSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>                 
public DealerSocket(string connectionString = null)
```