### PR TITLE
Use consistent AsyncIO version across solution (0.1.18.0)

### DIFF
--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -37,9 +37,9 @@
     <StartupObject>NetMQ.Tests.NetMQTestRunner</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncIO, Version=0.1.17.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+    <Reference Include="AsyncIO, Version=0.1.18.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net40\AsyncIO.dll</HintPath>
+      <HintPath>..\packages\AsyncIO.0.1.18.0\lib\net40\AsyncIO.dll</HintPath>
     </Reference>
     <Reference Include="JetBrains.Annotations">
       <HintPath>..\packages\JetBrains.Annotations.10.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>

--- a/src/NetMQ.Tests/NetMQ3.5.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ3.5.Tests.csproj
@@ -38,9 +38,9 @@
     <StartupObject>NetMQ.Tests.NetMQTestRunner</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncIO, Version=0.1.17.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+    <Reference Include="AsyncIO, Version=0.1.18.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net40\AsyncIO.dll</HintPath>
+      <HintPath>..\packages\AsyncIO.0.1.18.0\lib\net40\AsyncIO.dll</HintPath>
     </Reference>
     <Reference Include="JetBrains.Annotations">
       <HintPath>..\packages\JetBrains.Annotations.10.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>

--- a/src/NetMQ.Tests/packages.NetMQ.Tests.config
+++ b/src/NetMQ.Tests/packages.NetMQ.Tests.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncIO" version="0.1.17.0" targetFramework="net40" />
+  <package id="AsyncIO" version="0.1.18.0" targetFramework="net40" />
   <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
 </packages>

--- a/src/NetMQ.Tests/packages.NetMQ3.5.Tests.config
+++ b/src/NetMQ.Tests/packages.NetMQ3.5.Tests.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncIO" version="0.1.17.0" targetFramework="net40" />
+  <package id="AsyncIO" version="0.1.18.0" targetFramework="net40" />
   <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
 </packages>

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AsyncIO">
-      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net40\AsyncIO.dll</HintPath>
+      <HintPath>..\packages\AsyncIO.0.1.18.0\lib\net40\AsyncIO.dll</HintPath>
     </Reference>
     <Reference Include="JetBrains.Annotations">
       <HintPath>..\packages\JetBrains.Annotations.10.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>

--- a/src/NetMQ/NetMQ3.5.csproj
+++ b/src/NetMQ/NetMQ3.5.csproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AsyncIO">
-      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net35\AsyncIO.dll</HintPath>
+      <HintPath>..\packages\AsyncIO.0.1.18.0\lib\net35\AsyncIO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="JetBrains.Annotations">


### PR DESCRIPTION
We had a mix of 0.1.17 and 0.1.18.

This meant the `3.3.3-rc2` NuGet package I created didn't work without assembly redirects. I've deleted that package from NuGet and pushed `3.3.3-rc3` instead.