### PR TITLE
Make it so NetMQSockets supply their own ZmqSocketType ids.

### DIFF
--- a/src/NetMQ/Sockets/DealerSocket.cs
+++ b/src/NetMQ/Sockets/DealerSocket.cs
@@ -9,12 +9,28 @@ namespace NetMQ.Sockets
     public class DealerSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Dealer; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new DealerSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new DealerSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>                 
-        public DealerSocket(string connectionString = null) : base(ZmqSocketType.Dealer, connectionString, DefaultAction.Connect)
+        public DealerSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Connect)
         {            
         }
 

--- a/src/NetMQ/Sockets/PairSocket.cs
+++ b/src/NetMQ/Sockets/PairSocket.cs
@@ -11,12 +11,28 @@ namespace NetMQ.Sockets
         static private int s_sequence = 0;
 
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Pair; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new PairSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new PairSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>                 
-        public PairSocket(string connectionString = null) : base(ZmqSocketType.Pair, connectionString, DefaultAction.Connect)
+        public PairSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Connect)
         {
             
         }

--- a/src/NetMQ/Sockets/PublisherSocket.cs
+++ b/src/NetMQ/Sockets/PublisherSocket.cs
@@ -10,12 +10,28 @@ namespace NetMQ.Sockets
     public class PublisherSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Pub; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+        
+        /// <summary>
         /// Create a new PublisherSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new PublisherSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>               
-        public PublisherSocket(string connectionString = null) : base(ZmqSocketType.Pub, connectionString, DefaultAction.Bind)
+        public PublisherSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Bind)
         {
             
         }

--- a/src/NetMQ/Sockets/PullSocket.cs
+++ b/src/NetMQ/Sockets/PullSocket.cs
@@ -10,12 +10,28 @@ namespace NetMQ.Sockets
     public class PullSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Pull; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new PullSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new PullSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>               
-        public PullSocket(string connectionString = null) : base(ZmqSocketType.Pull, connectionString, DefaultAction.Bind)
+        public PullSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Bind)
         {
 
         }

--- a/src/NetMQ/Sockets/PushSocket.cs
+++ b/src/NetMQ/Sockets/PushSocket.cs
@@ -10,12 +10,28 @@ namespace NetMQ.Sockets
     public class PushSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Push; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new PushSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new PushSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>               
-        public PushSocket(string connectionString = null) : base(ZmqSocketType.Push, connectionString, DefaultAction.Connect)
+        public PushSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Connect)
         {
             
         }

--- a/src/NetMQ/Sockets/RequestSocket.cs
+++ b/src/NetMQ/Sockets/RequestSocket.cs
@@ -11,12 +11,28 @@ namespace NetMQ.Sockets
     public class RequestSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Req; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new RequestSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new RequestSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>  
-        public RequestSocket(string connectionString = null) : base(ZmqSocketType.Req, connectionString, DefaultAction.Connect)
+        public RequestSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Connect)
         {
 
         }

--- a/src/NetMQ/Sockets/ResponseSocket.cs
+++ b/src/NetMQ/Sockets/ResponseSocket.cs
@@ -9,12 +9,28 @@ namespace NetMQ.Sockets
     public class ResponseSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Rep; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new ResponseSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new ResponseSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>  
-        public ResponseSocket(string connectionString = null) : base(ZmqSocketType.Rep, connectionString, DefaultAction.Bind)
+        public ResponseSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Bind)
         {
             
         }

--- a/src/NetMQ/Sockets/RouterSocket.cs
+++ b/src/NetMQ/Sockets/RouterSocket.cs
@@ -8,12 +8,28 @@ namespace NetMQ.Sockets
     public class RouterSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Router; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new RouterSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new RouterSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>  
-        public RouterSocket(string connectionString = null) : base(ZmqSocketType.Router, connectionString, DefaultAction.Bind)
+        public RouterSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Bind)
         {
             
         }

--- a/src/NetMQ/Sockets/StreamSocket.cs
+++ b/src/NetMQ/Sockets/StreamSocket.cs
@@ -13,12 +13,28 @@ namespace NetMQ.Sockets
     public class StreamSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Stream; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new StreamSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new StreamSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>  
-        public StreamSocket(string connectionString = null) : base(ZmqSocketType.Stream, connectionString, DefaultAction.Connect)
+        public StreamSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Connect)
         {
             
         }

--- a/src/NetMQ/Sockets/SubscriberSocket.cs
+++ b/src/NetMQ/Sockets/SubscriberSocket.cs
@@ -11,12 +11,28 @@ namespace NetMQ.Sockets
     public class SubscriberSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Sub; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new SubscriberSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new SubscriberSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>  
-        public SubscriberSocket(string connectionString = null) : base(ZmqSocketType.Sub, connectionString, DefaultAction.Connect)
+        public SubscriberSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Connect)
         {
             
         }

--- a/src/NetMQ/Sockets/XPublisherSocket.cs
+++ b/src/NetMQ/Sockets/XPublisherSocket.cs
@@ -11,12 +11,28 @@ namespace NetMQ.Sockets
     public class XPublisherSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Xpub; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new XPublisherSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is bind (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new XPublisherSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>  
-        public XPublisherSocket(string connectionString = null) : base(ZmqSocketType.Xpub, connectionString, DefaultAction.Bind)
+        public XPublisherSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Bind)
         {
             
         }

--- a/src/NetMQ/Sockets/XSubscriberSocket.cs
+++ b/src/NetMQ/Sockets/XSubscriberSocket.cs
@@ -11,12 +11,28 @@ namespace NetMQ.Sockets
     public class XSubscriberSocket : NetMQSocket
     {
         /// <summary>
+        /// The type identifier for this Socket Class
+        /// </summary>
+        public static ZmqSocketType TypeId
+        {
+            get { return ZmqSocketType.Xsub; }
+        }
+
+        /// <summary>
+        /// The Socket Class type identifier for this Socket
+        /// </summary>
+        public override ZmqSocketType SocketType
+        {
+            get { return PairSocket.TypeId; }
+        }
+
+        /// <summary>
         /// Create a new XSubscriberSocket and attach socket to zero or more endpoints.               
         /// </summary>                
         /// <param name="connectionString">List of NetMQ endpoints, seperated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
         /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
         /// <example><code>var socket = new XSubscriberSocket(">tcp://127.0.0.1:5555,@127.0.0.1:55556");</code></example>  
-        public XSubscriberSocket(string connectionString = null) : base(ZmqSocketType.Xsub, connectionString, DefaultAction.Connect)
+        public XSubscriberSocket(string connectionString = null) : base(TypeId, connectionString, DefaultAction.Connect)
         {
             
         }


### PR DESCRIPTION
Added a static property called TypeId on each Child Class that returns its ZmqSocketType.  Added an abstract readonly property called SocketType on NetMQSocket.  Then had the implementation of SocketType on each child class return its own class TypeId. Ultimately this is heading toward eliminating the switch statements based on the SocketType, move the procedures into the Socket classes directly, and provides a Socket constructor that takes a NetMQContext as a parameter.