### PR TITLE
problem: context might block forever is socket is not disposed or linger is not zero

### DIFF
--- a/src/NetMQ/NetMQConfig.cs
+++ b/src/NetMQ/NetMQConfig.cs
@@ -13,6 +13,7 @@ namespace NetMQ
         static NetMQConfig()
         {
             s_ctx = new Ctx();
+            s_ctx.Block = false;
             s_settingsSync = new object();
             s_linger = TimeSpan.Zero;
 

--- a/src/NetMQ/NetMQContext.cs
+++ b/src/NetMQ/NetMQContext.cs
@@ -67,6 +67,23 @@ namespace NetMQ
             set { m_ctx.CheckDisposed(); m_ctx.MaxSockets = value; }
         }
 
+        /// <summary>
+        /// Should context wait for all sockets before terminating?
+        /// </summary>
+        public bool Block
+        {
+            get
+            {
+                m_ctx.CheckDisposed();
+                return m_ctx.Block;
+            }
+            set
+            {
+                m_ctx.CheckDisposed();
+                m_ctx.Block = value;
+            }
+        }
+
         #region Socket Creation
 
         /// <summary>


### PR DESCRIPTION
solution: allow context to terminate without waiting for sockets

For NetMQContext you can use the Block keyword.
When creating sockets without context this is the default behavior, as the context is disposed when application exists.

fixes #384 