### PR TITLE
problem: dispose a socket is not blocking and when used without a context you have no way to know the status of the socket

### DIFF
--- a/src/NetMQ/Core/CommandType.cs
+++ b/src/NetMQ/Core/CommandType.cs
@@ -65,9 +65,9 @@ namespace NetMQ.Core
         PipeTerm,
 
         /// <summary>
-        /// Pipe writer acknowledges pipe_term command.
+        /// Sent by pipe to itself to complete the termination
         /// </summary>
-        PipeTermAck,
+        PipeCompleteTerm,
 
         /// <summary>
         /// Sent by I/O object to the socket to request the shutdown of

--- a/src/NetMQ/Core/Ctx.cs
+++ b/src/NetMQ/Core/Ctx.cs
@@ -36,8 +36,8 @@ namespace NetMQ.Core
     /// <remarks>Internal analog of the public <see cref="NetMQContext"/> class.</remarks>
     internal sealed class Ctx
     {
-        private const int DefaultIOThreads = 1;
-        private const int DefaultMaxSockets = 1024;
+        public const int DefaultIOThreads = 1;
+        public const int DefaultMaxSockets = 1024;
 
         #region Nested class: Endpoint
 

--- a/src/NetMQ/Core/SessionBase.cs
+++ b/src/NetMQ/Core/SessionBase.cs
@@ -510,7 +510,8 @@ namespace NetMQ.Core
             // TODO: Should this go into pipe_t::terminate ?
             // In case there's no engine and there's only delimiter in the
             // pipe it wouldn't be ever read. Thus we check for it explicitly.
-            m_pipe.CheckRead();
+            if (m_engine == null && m_pipe != null)
+                m_pipe.CheckRead();
         }
 
         /// <summary>

--- a/src/NetMQ/Core/ZObject.cs
+++ b/src/NetMQ/Core/ZObject.cs
@@ -197,9 +197,9 @@ namespace NetMQ.Core
             SendCommand(new Command(destination, CommandType.PipeTerm));
         }
 
-        protected void SendPipeTermAck([NotNull] Pipe destination)
+        protected void SendPipeCompleteTerm([NotNull] Pipe destination)
         {
-            SendCommand(new Command(destination, CommandType.PipeTermAck));
+            SendCommand(new Command(destination, CommandType.PipeCompleteTerm));
         }
 
         /// <summary>
@@ -298,8 +298,8 @@ namespace NetMQ.Core
                     ProcessPipeTerm();
                     break;
 
-                case CommandType.PipeTermAck:
-                    ProcessPipeTermAck();
+                case CommandType.PipeCompleteTerm:
+                    ProcessPipeCompleteTerm();
                     break;
 
                 case CommandType.TermReq:
@@ -398,13 +398,13 @@ namespace NetMQ.Core
         }
 
         /// <summary>
-        /// Process the terminate-pipe acknowledgement command.
+        /// Process the complete close pipe command.
         /// </summary>
         /// <exception cref="NotSupportedException">Not supported on the ZObject class.</exception>
-        protected virtual void ProcessPipeTermAck()
+        protected virtual void ProcessPipeCompleteTerm()
         {
             throw new NotSupportedException();
-        }
+        }        
 
         /// <summary>
         /// Process a termination-request command on the Own object.

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -38,7 +38,7 @@ namespace NetMQ
         internal NetMQSocket(ZmqSocketType socketType, string connectionString, DefaultAction defaultAction)
         {
             m_fromGlobalContext = true;
-            m_socketHandle = NetMQConfig.Context.CreateSocket(socketType);
+            m_socketHandle = NetMQConfig.CreateSocketHandle(socketType);
             m_selector = new Selector();
             Options = new SocketOptions(this);
             m_socketEventArgs = new NetMQSocketEventArgs(this);
@@ -260,6 +260,9 @@ namespace NetMQ
 
             // We only block if the socket is using the global context
             m_socketHandle.Close(block: m_fromGlobalContext);
+
+            if (m_fromGlobalContext)
+                NetMQConfig.SocketDisposed();
         }
 
         #endregion

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -21,6 +21,7 @@ namespace NetMQ
         private EventHandler<NetMQSocketEventArgs> m_receiveReady;
         private EventHandler<NetMQSocketEventArgs> m_sendReady;
         private bool m_isClosed;
+        private bool m_fromGlobalContext;
 
         internal enum DefaultAction
         {
@@ -36,6 +37,7 @@ namespace NetMQ
         /// <param name="defaultAction"></param>
         internal NetMQSocket(ZmqSocketType socketType, string connectionString, DefaultAction defaultAction)
         {
+            m_fromGlobalContext = true;
             m_socketHandle = NetMQConfig.Context.CreateSocket(socketType);
             m_selector = new Selector();
             Options = new SocketOptions(this);
@@ -77,6 +79,7 @@ namespace NetMQ
         /// <param name="socketHandle">a SocketBase object to assign to the new socket</param>
         internal NetMQSocket([NotNull] SocketBase socketHandle)
         {
+            m_fromGlobalContext = false;
             m_selector = new Selector();
             m_socketHandle = socketHandle;
             Options = new SocketOptions(this);
@@ -254,7 +257,9 @@ namespace NetMQ
             m_isClosed = true;
 
             m_socketHandle.CheckDisposed();
-            m_socketHandle.Close();
+
+            // We only block if the socket is using the global context
+            m_socketHandle.Close(block: m_fromGlobalContext);
         }
 
         #endregion


### PR DESCRIPTION
solution: make the socket block on dispose.

This change is only for sockets created without socket, regular socket dispose will continue to be async.

