### PR TITLE
Upgraded zproto for NetMQ.Zyre

### DIFF
--- a/src/NetMQ.Zyre.Tests/ZreMsgTests.cs
+++ b/src/NetMQ.Zyre.Tests/ZreMsgTests.cs
@@ -271,9 +271,12 @@ namespace NetMQ.Zyre.Tests
 
 			using (var client = new DealerSocket())
 			using (var server = new RouterSocket())
-			{
-				server.Bind("inproc://zprototest");
-				client.Connect("inproc://zprototest");
+            {
+                // TODO: If I use inproc://zprototest ReSharper TestRunner fails with NetMQ.AddressAlreadyInUseException : 
+                //  Cannot bind address ( inproc://zprototest ) - already in use.
+                //  But only when I run all these tests at the same time.
+                server.Bind("inproc://zprototestLeave"); 
+                client.Connect("inproc://zprototestLeave");
 
 				ZreMsg clientMessage = new ZreMsg();
 				ZreMsg serverMessage = new ZreMsg();

--- a/src/NetMQ.Zyre.Tests/ZreMsgTests.cs
+++ b/src/NetMQ.Zyre.Tests/ZreMsgTests.cs
@@ -56,8 +56,8 @@ namespace NetMQ.Zyre.Tests
 			using (var client = new DealerSocket())
 			using (var server = new RouterSocket())
 			{
-				server.Bind("inproc://zprototest");
-				client.Connect("inproc://zprototest");
+				server.Bind("inproc://zprototestHello");
+				client.Connect("inproc://zprototestHello");
 
 				ZreMsg clientMessage = new ZreMsg();
 				ZreMsg serverMessage = new ZreMsg();
@@ -108,8 +108,8 @@ namespace NetMQ.Zyre.Tests
 			using (var client = new DealerSocket())
 			using (var server = new RouterSocket())
 			{
-				server.Bind("inproc://zprototest");
-				client.Connect("inproc://zprototest");
+				server.Bind("inproc://zprototestWhisper");
+				client.Connect("inproc://zprototestWhisper");
 
 				ZreMsg clientMessage = new ZreMsg();
 				ZreMsg serverMessage = new ZreMsg();
@@ -162,8 +162,8 @@ namespace NetMQ.Zyre.Tests
 			using (var client = new DealerSocket())
 			using (var server = new RouterSocket())
 			{
-				server.Bind("inproc://zprototest");
-				client.Connect("inproc://zprototest");
+				server.Bind("inproc://zprototestShout");
+				client.Connect("inproc://zprototestShout");
 
 				ZreMsg clientMessage = new ZreMsg();
 				ZreMsg serverMessage = new ZreMsg();
@@ -217,8 +217,8 @@ namespace NetMQ.Zyre.Tests
 			using (var client = new DealerSocket())
 			using (var server = new RouterSocket())
 			{
-				server.Bind("inproc://zprototest");
-				client.Connect("inproc://zprototest");
+				server.Bind("inproc://zprototestJoin");
+				client.Connect("inproc://zprototestJoin");
 
 				ZreMsg clientMessage = new ZreMsg();
 				ZreMsg serverMessage = new ZreMsg();
@@ -326,8 +326,8 @@ namespace NetMQ.Zyre.Tests
 			using (var client = new DealerSocket())
 			using (var server = new RouterSocket())
 			{
-				server.Bind("inproc://zprototest");
-				client.Connect("inproc://zprototest");
+				server.Bind("inproc://zprototestPing");
+				client.Connect("inproc://zprototestPing");
 
 				ZreMsg clientMessage = new ZreMsg();
 				ZreMsg serverMessage = new ZreMsg();
@@ -377,8 +377,8 @@ namespace NetMQ.Zyre.Tests
 			using (var client = new DealerSocket())
 			using (var server = new RouterSocket())
 			{
-				server.Bind("inproc://zprototest");
-				client.Connect("inproc://zprototest");
+				server.Bind("inproc://zprototestPingOk");
+				client.Connect("inproc://zprototestPingOk");
 
 				ZreMsg clientMessage = new ZreMsg();
 				ZreMsg serverMessage = new ZreMsg();

--- a/src/NetMQ.Zyre.Tests/ZreMsgTests.cs
+++ b/src/NetMQ.Zyre.Tests/ZreMsgTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Collections.Generic;
 using NUnit.Framework;
 using NetMQ;
+using NetMQ.Sockets;
 using NetMQ.Zyre;
 
 namespace NetMQ.Zyre.Tests
@@ -52,9 +53,8 @@ namespace NetMQ.Zyre.Tests
 				Assert.That(m.Hello.Headers["Age"], Is.EqualTo("43"));                                          
 			};
 
-			using (NetMQContext context = NetMQContext.Create())
-			using (var client = context.CreateDealerSocket())
-			using (var server = context.CreateRouterSocket())
+			using (var client = new DealerSocket())
+			using (var server = new RouterSocket())
 			{
 				server.Bind("inproc://zprototest");
 				client.Connect("inproc://zprototest");
@@ -105,9 +105,8 @@ namespace NetMQ.Zyre.Tests
 				Assert.That(m.Whisper.Content.FrameCount, Is.EqualTo(1));                
 			};
 
-			using (NetMQContext context = NetMQContext.Create())
-			using (var client = context.CreateDealerSocket())
-			using (var server = context.CreateRouterSocket())
+			using (var client = new DealerSocket())
+			using (var server = new RouterSocket())
 			{
 				server.Bind("inproc://zprototest");
 				client.Connect("inproc://zprototest");
@@ -160,9 +159,8 @@ namespace NetMQ.Zyre.Tests
 				Assert.That(m.Shout.Content.FrameCount, Is.EqualTo(1));                  
 			};
 
-			using (NetMQContext context = NetMQContext.Create())
-			using (var client = context.CreateDealerSocket())
-			using (var server = context.CreateRouterSocket())
+			using (var client = new DealerSocket())
+			using (var server = new RouterSocket())
 			{
 				server.Bind("inproc://zprototest");
 				client.Connect("inproc://zprototest");
@@ -216,9 +214,8 @@ namespace NetMQ.Zyre.Tests
 				Assert.That(m.Join.Status, Is.EqualTo(123));                    
 			};
 
-			using (NetMQContext context = NetMQContext.Create())
-			using (var client = context.CreateDealerSocket())
-			using (var server = context.CreateRouterSocket())
+			using (var client = new DealerSocket())
+			using (var server = new RouterSocket())
 			{
 				server.Bind("inproc://zprototest");
 				client.Connect("inproc://zprototest");
@@ -272,9 +269,8 @@ namespace NetMQ.Zyre.Tests
 				Assert.That(m.Leave.Status, Is.EqualTo(123));                   
 			};
 
-			using (NetMQContext context = NetMQContext.Create())
-			using (var client = context.CreateDealerSocket())
-			using (var server = context.CreateRouterSocket())
+			using (var client = new DealerSocket())
+			using (var server = new RouterSocket())
 			{
 				server.Bind("inproc://zprototest");
 				client.Connect("inproc://zprototest");
@@ -324,9 +320,8 @@ namespace NetMQ.Zyre.Tests
 				Assert.That(m.Ping.Sequence, Is.EqualTo(123));                  
 			};
 
-			using (NetMQContext context = NetMQContext.Create())
-			using (var client = context.CreateDealerSocket())
-			using (var server = context.CreateRouterSocket())
+			using (var client = new DealerSocket())
+			using (var server = new RouterSocket())
 			{
 				server.Bind("inproc://zprototest");
 				client.Connect("inproc://zprototest");
@@ -376,9 +371,8 @@ namespace NetMQ.Zyre.Tests
 				Assert.That(m.PingOk.Sequence, Is.EqualTo(123));                
 			};
 
-			using (NetMQContext context = NetMQContext.Create())
-			using (var client = context.CreateDealerSocket())
-			using (var server = context.CreateRouterSocket())
+			using (var client = new DealerSocket())
+			using (var server = new RouterSocket())
 			{
 				server.Bind("inproc://zprototest");
 				client.Connect("inproc://zprototest");

--- a/src/NetMQ.Zyre/NetMQ.Zyre.csproj
+++ b/src/NetMQ.Zyre/NetMQ.Zyre.csproj
@@ -45,15 +45,17 @@
     <Compile Include="ZreMsg.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="zproto\Generate.bat" />
     <None Include="zproto\zproto_codec_cs.gsl" />
     <None Include="zproto\zproto_lib.gsl" />
     <None Include="zproto\zproto_lib_cs.gsl" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="zproto\License.xml" />
     <Content Include="zproto\Example.xml" />
+    <Content Include="zproto\License.xml" />
     <Content Include="zproto\zre_msg.xml">
       <SubType>Designer</SubType>
     </Content>

--- a/src/NetMQ.Zyre/ZreMsg.cs
+++ b/src/NetMQ.Zyre/ZreMsg.cs
@@ -301,6 +301,7 @@ namespace NetMQ.Zyre
 				frameSize += 2;          
 
 				//  Content
+                //  A frame or a message with special handling in Receive() and Send()
 
 				return frameSize;
 			}		
@@ -396,9 +397,10 @@ namespace NetMQ.Zyre
 				//  Group
 				frameSize += 1 + Group.Length;
 
-				//  Content
+                //  Content
+                //  A frame or a message with special handling in Receive() and Send()
 
-				return frameSize;
+                return frameSize;
 			}		
 
 			internal void Write(ZreMsg m)
@@ -971,9 +973,20 @@ namespace NetMQ.Zyre
 					break;
 				default:
 					throw new MessageException("Bad message id");            					
-				}        
-			}
-			finally
+				}
+
+                // Receive message content for types with content
+                switch (Id)
+                {
+                    case MessageId.Whisper:
+                        Whisper.Content = input.ReceiveMultipartMessage();
+                        break;
+                    case MessageId.Shout:
+                        Shout.Content = input.ReceiveMultipartMessage();
+                        break;
+                }
+            }
+            finally
 			{
 				m_buffer = null;
 				msg.Close();		
@@ -1055,208 +1068,217 @@ namespace NetMQ.Zyre
 				}
 
 				//  Send the data frame				
-				output.Send(ref msg, false);       
+			    var more = Id == MessageId.Whisper || Id == MessageId.Shout;
+				output.Send(ref msg, more);
+
+                // Send message content for types with content
+			    switch (Id)
+			    {
+			        case MessageId.Whisper:
+			            if (Whisper.Content == null)
+			            {
+			                Whisper.Content = new NetMQMessage();
+                            Whisper.Content.PushEmptyFrame();
+			            }
+                        output.SendMultipartMessage(Whisper.Content);
+			            break;
+			        case MessageId.Shout:
+                        if (Shout.Content == null)
+                        {
+                            Shout.Content = new NetMQMessage();
+                            Shout.Content.PushEmptyFrame();
+                        }
+                        output.SendMultipartMessage(Shout.Content);
+                        break;
+			    }
 			}
 			finally
 			{
-				m_buffer = null;
-				msg.Close();
+			    m_buffer = null;
+			    msg.Close();
 			}
-		}	
-
-		#region Network data encoding methods
-
-		//  Put a block of octets to the frame
-		private void PutOctets(byte[] host, int size) 
-		{ 
-			Buffer.BlockCopy(host, 0, m_buffer, m_offset, size);   
-			m_offset += size; 
 		}
 
-		//  Get a block of octets from the frame
-		private void GetOctets(byte[] host, int size) 
-		{
-			if (m_offset + size > m_buffer.Length) 
-			{ 
-				throw new MessageException("Malformed message");            			
-			} 
-			
-			Buffer.BlockCopy(m_buffer, m_offset, host, 0, size);
-			m_offset += size; 			
-		}
+	    #region Network data encoding methods
 
-		//  Put a 1-byte number to the frame
-		private void PutNumber1(byte host) 
-		{ 
-			m_buffer[m_offset] = host;
-			m_offset++;
-		}
+	    //  Put a block of octets to the frame
+	    private void PutOctets(byte[] host, int size)
+	    {
+	        Buffer.BlockCopy(host, 0, m_buffer, m_offset, size);
+	        m_offset += size;
+	    }
 
-		//  Put a 2-byte number to the frame
-		private void PutNumber2(UInt16 host) 
-		{ 
-			m_buffer[m_offset] = (byte) (((host) >> 8)  & 255);
-			m_buffer[m_offset+1] = (byte) (((host))       & 255); 
+	    //  Get a block of octets from the frame
+	    private void GetOctets(byte[] host, int size)
+	    {
+	        if (m_offset + size > m_buffer.Length)
+	        {
+	            throw new MessageException("Malformed message");
+	        }
 
-			m_offset+=2;
-		}
+	        Buffer.BlockCopy(m_buffer, m_offset, host, 0, size);
+	        m_offset += size;
+	    }
 
-		//  Put a 4-byte number to the frame
-		private void PutNumber4(UInt32 host) 
-		{
-			m_buffer[m_offset] = (byte) (((host) >> 24) & 255);
-			m_buffer[m_offset+1] = (byte) (((host) >> 16) & 255); 
-			m_buffer[m_offset+2] = (byte) (((host) >> 8)  & 255); 
-			m_buffer[m_offset+3] = (byte) (((host))       & 255);
+	    //  Put a 1-byte number to the frame
+	    private void PutNumber1(byte host)
+	    {
+	        m_buffer[m_offset] = host;
+	        m_offset++;
+	    }
 
-			m_offset+=4;
-		}
+	    //  Put a 2-byte number to the frame
+	    private void PutNumber2(UInt16 host)
+	    {
+	        m_buffer[m_offset] = (byte) (((host) >> 8) & 255);
+	        m_buffer[m_offset + 1] = (byte) (((host)) & 255);
 
-		//  Put a 8-byte number to the frame
-		private void PutNumber8(UInt64 host) 
-		{
-			m_buffer[m_offset] = (byte) (((host) >> 56) & 255);
-			m_buffer[m_offset+1] = (byte) (((host) >> 48) & 255);
-			m_buffer[m_offset+2] = (byte) (((host) >> 40) & 255);
-			m_buffer[m_offset+3] = (byte) (((host) >> 32) & 255);
-			m_buffer[m_offset+4] = (byte) (((host) >> 24) & 255); 
-			m_buffer[m_offset+5] = (byte) (((host) >> 16) & 255);
-			m_buffer[m_offset+6] = (byte) (((host) >> 8)  & 255);
-			m_buffer[m_offset+7] = (byte) (((host))       & 255);
+	        m_offset += 2;
+	    }
 
-			m_offset+=8;
-		}
+	    //  Put a 4-byte number to the frame
+	    private void PutNumber4(UInt32 host)
+	    {
+	        m_buffer[m_offset] = (byte) (((host) >> 24) & 255);
+	        m_buffer[m_offset + 1] = (byte) (((host) >> 16) & 255);
+	        m_buffer[m_offset + 2] = (byte) (((host) >> 8) & 255);
+	        m_buffer[m_offset + 3] = (byte) (((host)) & 255);
 
-		//  Get a 1-byte number from the frame
-		private byte GetNumber1() 
-		{
-			if (m_offset + 1 > m_buffer.Length) 
-			{
-				throw new MessageException("Malformed message.");
-			} 
-    
-			byte b = m_buffer[m_offset];
-		
-			m_offset++;
+	        m_offset += 4;
+	    }
 
-			return b;
-		}
+	    //  Put a 8-byte number to the frame
+	    private void PutNumber8(UInt64 host)
+	    {
+	        m_buffer[m_offset] = (byte) (((host) >> 56) & 255);
+	        m_buffer[m_offset + 1] = (byte) (((host) >> 48) & 255);
+	        m_buffer[m_offset + 2] = (byte) (((host) >> 40) & 255);
+	        m_buffer[m_offset + 3] = (byte) (((host) >> 32) & 255);
+	        m_buffer[m_offset + 4] = (byte) (((host) >> 24) & 255);
+	        m_buffer[m_offset + 5] = (byte) (((host) >> 16) & 255);
+	        m_buffer[m_offset + 6] = (byte) (((host) >> 8) & 255);
+	        m_buffer[m_offset + 7] = (byte) (((host)) & 255);
 
-		//  Get a 2-byte number from the frame
-		private UInt16 GetNumber2() 
-		{ 
-			if (m_offset + 2 > m_buffer.Length) 
-			{
-				throw new MessageException("Malformed message.");
-			} 
-    
-			UInt16 number = (UInt16)((m_buffer[m_offset] << 8) + 
-							m_buffer[m_offset+1]);
-		
-			m_offset+=2;
+	        m_offset += 8;
+	    }
 
-			return number;
-		}
+	    //  Get a 1-byte number from the frame
+	    private byte GetNumber1()
+	    {
+	        if (m_offset + 1 > m_buffer.Length)
+	        {
+	            throw new MessageException("Malformed message.");
+	        }
 
-		//  Get a 4-byte number from the frame
-		private UInt32 GetNumber4() 
-		{ 
-			if (m_offset + 4 > m_buffer.Length) 
-			{
-				throw new MessageException("Malformed message.");
-			} 
-    
-			UInt32 number = 
-				(((UInt32)m_buffer[m_offset]) << 24) + 
-				(((UInt32)m_buffer[m_offset+1]) << 16)  +
-				(((UInt32)m_buffer[m_offset+2]) << 8) +
-				(UInt32)m_buffer[m_offset+3];
-		
-			m_offset+=4;
+	        byte b = m_buffer[m_offset];
 
-			return number;
-		}
+	        m_offset++;
 
-		//  Get a 8byte number from the frame
-		private UInt64 GetNumber8() 
-		{ 
-			if (m_offset + 8 > m_buffer.Length) 
-			{
-				throw new MessageException("Malformed message.");
-			} 
-    
-			UInt64 number = 
-				(((UInt64) m_buffer[m_offset]) << 56) + 
-				(((UInt64) m_buffer[m_offset+1]) << 48)  +
-				(((UInt64) m_buffer[m_offset+2]) << 40) +
-				(((UInt64) m_buffer[m_offset+3]) << 32) +
-				(((UInt64) m_buffer[m_offset+4]) << 24) +
-				(((UInt64) m_buffer[m_offset+5]) << 16) +
-				(((UInt64) m_buffer[m_offset+6]) << 8) +		
-				(UInt64) m_buffer[m_offset+7];
-		
-			m_offset+=8;
+	        return b;
+	    }
 
-			return number;
-		}
+	    //  Get a 2-byte number from the frame
+	    private UInt16 GetNumber2()
+	    {
+	        if (m_offset + 2 > m_buffer.Length)
+	        {
+	            throw new MessageException("Malformed message.");
+	        }
 
-		//  Put a string to the frame
-		private void PutString(string host) 
-		{   
-			int length = Encoding.UTF8.GetByteCount(host); 
-			
-			if (length > 255)
-				length = 255;
-		
-			PutNumber1((byte)length); 
+	        UInt16 number = (UInt16) ((m_buffer[m_offset] << 8) + m_buffer[m_offset + 1]);
 
-			Encoding.UTF8.GetBytes(host, 0, length, m_buffer, m_offset);
-    
-			m_offset += length;
-		}
+	        m_offset += 2;
 
-		//  Get a string from the frame
-		private string GetString() 
-		{ 
-			int length = GetNumber1();    
-			if (m_offset + length > m_buffer.Length) 
-			{ 
-			  throw new MessageException("Malformed message.");
-			} 
+	        return number;
+	    }
 
-			string s = Encoding.UTF8.GetString(m_buffer, m_offset, length);
+	    //  Get a 4-byte number from the frame
+	    private UInt32 GetNumber4()
+	    {
+	        if (m_offset + 4 > m_buffer.Length)
+	        {
+	            throw new MessageException("Malformed message.");
+	        }
 
-			m_offset += length;
+	        UInt32 number = (((UInt32) m_buffer[m_offset]) << 24) + (((UInt32) m_buffer[m_offset + 1]) << 16) + (((UInt32) m_buffer[m_offset + 2]) << 8) + (UInt32) m_buffer[m_offset + 3];
 
-			return s;
-		}
+	        m_offset += 4;
 
-		//  Put a long string to the frame
-		private void PutLongString(string host) 
-		{     
-			PutNumber4((UInt32)Encoding.UTF8.GetByteCount(host));
-	 
-			Encoding.UTF8.GetBytes(host, 0, host.Length, m_buffer, m_offset);
-    
-			m_offset += host.Length;
-		}
+	        return number;
+	    }
 
-		//  Get a long string from the frame
-		private string GetLongString() 
-		{ 
-			int length = (int)GetNumber4();    
-			if (m_offset + length > m_buffer.Length) 
-			{ 
-			  throw new MessageException("Malformed message.");
-			} 
+	    //  Get a 8byte number from the frame
+	    private UInt64 GetNumber8()
+	    {
+	        if (m_offset + 8 > m_buffer.Length)
+	        {
+	            throw new MessageException("Malformed message.");
+	        }
 
-			string s = Encoding.UTF8.GetString(m_buffer, m_offset, length);
+	        UInt64 number = (((UInt64) m_buffer[m_offset]) << 56) + (((UInt64) m_buffer[m_offset + 1]) << 48) + (((UInt64) m_buffer[m_offset + 2]) << 40) + (((UInt64) m_buffer[m_offset + 3]) << 32) + (((UInt64) m_buffer[m_offset + 4]) << 24) + (((UInt64) m_buffer[m_offset + 5]) << 16) + (((UInt64) m_buffer[m_offset + 6]) << 8) + (UInt64) m_buffer[m_offset + 7];
 
-			m_offset += length;
+	        m_offset += 8;
 
-			return s;
-		}
+	        return number;
+	    }
 
-		#endregion
+	    //  Put a string to the frame
+	    private void PutString(string host)
+	    {
+	        int length = Encoding.UTF8.GetByteCount(host);
+
+	        if (length > 255)
+	            length = 255;
+
+	        PutNumber1((byte) length);
+
+	        Encoding.UTF8.GetBytes(host, 0, length, m_buffer, m_offset);
+
+	        m_offset += length;
+	    }
+
+	    //  Get a string from the frame
+	    private string GetString()
+	    {
+	        int length = GetNumber1();
+	        if (m_offset + length > m_buffer.Length)
+	        {
+	            throw new MessageException("Malformed message.");
+	        }
+
+	        string s = Encoding.UTF8.GetString(m_buffer, m_offset, length);
+
+	        m_offset += length;
+
+	        return s;
+	    }
+
+	    //  Put a long string to the frame
+	    private void PutLongString(string host)
+	    {
+	        PutNumber4((UInt32) Encoding.UTF8.GetByteCount(host));
+
+	        Encoding.UTF8.GetBytes(host, 0, host.Length, m_buffer, m_offset);
+
+	        m_offset += host.Length;
+	    }
+
+	    //  Get a long string from the frame
+	    private string GetLongString()
+	    {
+	        int length = (int) GetNumber4();
+	        if (m_offset + length > m_buffer.Length)
+	        {
+	            throw new MessageException("Malformed message.");
+	        }
+
+	        string s = Encoding.UTF8.GetString(m_buffer, m_offset, length);
+
+	        m_offset += length;
+
+	        return s;
+	    }
+
+	    #endregion
 	}
 }

--- a/src/NetMQ.Zyre/ZreMsg.cs
+++ b/src/NetMQ.Zyre/ZreMsg.cs
@@ -20,6 +20,7 @@ using System.Text;
 using NetMQ;
 using NetMQ.Sockets;
 using NetMQ.zmq;
+#pragma warning disable 168
 
 namespace NetMQ.Zyre
 {

--- a/src/NetMQ.Zyre/packages.config
+++ b/src/NetMQ.Zyre/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="gsl" version="4.1.0.1" targetFramework="net452" developmentDependency="true" />
-  <package id="NetMQ.zproto" version="0.1.4" targetFramework="net40" />
+  <package id="NetMQ.zproto" version="0.1.5" targetFramework="net40" />
 </packages>

--- a/src/NetMQ.Zyre/zproto/Example.xml
+++ b/src/NetMQ.Zyre/zproto/Example.xml
@@ -7,6 +7,7 @@
     test_dir ="./csharp/ZProto.Tests"
     namespace ="ZProto"
     test_namespace="ZProto.Test"
+    modifier="public"
     >
 This is an example protocol designed to teach you how this stuff works.
 

--- a/src/NetMQ.Zyre/zproto/zproto_codec_cs.gsl
+++ b/src/NetMQ.Zyre/zproto/zproto_codec_cs.gsl
@@ -41,7 +41,11 @@ namespace $(class.namespace)
 	/// <summary>
 	/// $(class.title:)
 	/// </summary>
-	public class $(class.name:Pascal)
+.if class.modifier <> ""
+	$(class.modifier) class $(class.name:Pascal)
+.else
+	class $(class.name:Pascal)
+.endif
 	{
 		public class MessageException : Exception
 		{

--- a/src/NetMQ.Zyre/zproto/zproto_codec_cs.gsl
+++ b/src/NetMQ.Zyre/zproto/zproto_codec_cs.gsl
@@ -777,6 +777,7 @@ using System.Text;
 using System.Collections.Generic;
 using NUnit.Framework;
 using NetMQ;
+using NetMQ.Sockets;
 .if class.namespace <> class.test_namespace
 using $(class.namespace);
 .endif
@@ -854,9 +855,8 @@ namespace $(class.test_namespace)
 .   endfor
 			};
 
-			using (NetMQContext context = NetMQContext.Create())
-			using (var client = context.CreateDealerSocket())
-			using (var server = context.CreateRouterSocket())
+			using (var client = new DealerSocket())
+			using (var server = new RouterSocket())
 			{
 				server.Bind("inproc://zprototest");
 				client.Connect("inproc://zprototest");

--- a/src/NetMQ.Zyre/zproto/zproto_lib_cs.gsl
+++ b/src/NetMQ.Zyre/zproto/zproto_lib_cs.gsl
@@ -9,6 +9,7 @@ function set_cs_defaults ()
     class.test_dir ?= "."
     class.namespace ?= "ZProto"
     class.test_namespace ?= "ZProto.Tests"
+    class.modifier ?= ""
 
     class.export_macro ?= ""
     if class.export_macro <> ""

--- a/src/NetMQ.Zyre/zproto/zre_msg.xml
+++ b/src/NetMQ.Zyre/zproto/zre_msg.xml
@@ -7,6 +7,7 @@
     test_dir ="../../NetMQ.Zyre.Tests"
     namespace ="NetMQ.Zyre"
     test_namespace="NetMQ.Zyre.Tests"
+    modifier="public"
     >
     This is the ZRE protocol, version 2 draft, as defined by rfc.zeromq.org/spec:36/ZRE.
 


### PR DESCRIPTION
@somdoron , I think NetMQ.zproto is wonderful.
But, if I read this correctly, there is quite a bit of work to do on zproto_codec_cs.gsl to be able to generate a clean ZreMsg.cs class (in particular, to handle the msg type).
Yet it seems to me that this work should be first, rather than "rolling by hand" the ZreMsg.cs class.
What do you recommend? Should @vadian and/or I dig into changing zproto_codec_cs.gsl, or leave it to you and continue ZreMsg.cs without zproto?
Thank you.