### PR TITLE
Loopback

### DIFF
--- a/src/NetMQ.Tests/BeaconTests.cs
+++ b/src/NetMQ.Tests/BeaconTests.cs
@@ -195,5 +195,30 @@ namespace NetMQ.Tests
                 Assert.AreEqual("H1", message);
             }
         }
+
+        [Test]
+        public void BothSpeakerAndListenerOverLoopback()
+        {
+            using (var beacon1 = new NetMQBeacon())
+            using (var beacon2 = new NetMQBeacon())
+            {
+                beacon1.Configure("loopback", 9998);
+                beacon1.Publish("H1", s_publishInterval);
+                beacon1.Subscribe("H");
+
+                beacon2.Configure("loopback", 9998);
+                beacon2.Publish("H2", s_publishInterval);
+                beacon2.Subscribe("H");
+
+                string peerName;
+                string message = beacon1.ReceiveString(out peerName);
+
+                Assert.AreEqual("H2", message);
+
+                message = beacon2.ReceiveString(out peerName);
+
+                Assert.AreEqual("H1", message);
+            }
+        }
     }
 }

--- a/src/NetMQ.Tests/BeaconTests.cs
+++ b/src/NetMQ.Tests/BeaconTests.cs
@@ -128,7 +128,7 @@ namespace NetMQ.Tests
                 };
 
                 using (var poller = new NetMQPoller { listener })
-                {                    
+                {
                     poller.RunAsync();
 
                     manualResetEvent.WaitOne();

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -89,6 +89,11 @@ namespace NetMQ
                     bindTo = IPAddress.Any;
                     sendTo = IPAddress.Broadcast;
                 }
+                else if (interfaceName == "loopback")
+                {
+                    bindTo = IPAddress.Loopback;
+                    sendTo = IPAddress.Broadcast;
+                }
                 else
                 {
                     var interfaceCollection = new InterfaceCollection();


### PR DESCRIPTION
Allows NetMQBeacon to be used over loopback, so network isn't flooded with packages if communications is required only within the same machine. 