### PR TITLE
Add settings to define send/receive low-watermark value

### DIFF
--- a/src/NetMQ/Core/Options.cs
+++ b/src/NetMQ/Core/Options.cs
@@ -45,6 +45,7 @@ namespace NetMQ.Core
             MulticastHops = 1;
             Rate = 100;
             ReceiveHighWatermark = 1000;
+            ReceiveLowWatermark = 0;
 #pragma warning disable 618
             // This is obsolete, but it is still used. Disable compiler warning.
             ReceiveTimeout = -1;
@@ -52,6 +53,7 @@ namespace NetMQ.Core
             ReconnectIvl = 100;
             RecoveryIvl = 10000;
             SendHighWatermark = 1000;
+            SendLowWatermark = 0;
             SendTimeout = -1;
             SocketType = ZmqSocketType.None;
             TcpKeepalive = -1;
@@ -217,6 +219,16 @@ namespace NetMQ.Core
         public int ReceiveHighWatermark { get; set; }
 
         /// <summary>
+        /// The low-water mark for message transmission. 
+        /// </summary>
+        public int SendLowWatermark { get; set; }
+
+        /// <summary>
+        /// The low-water mark for message reception. 
+        /// </summary>
+        public int ReceiveLowWatermark { get; set; }
+
+        /// <summary>
         /// Get or set the timeout for send operations for this socket.
         /// The default value is -1, which means no timeout.
         /// </summary>
@@ -287,6 +299,14 @@ namespace NetMQ.Core
 
                 case ZmqSocketOption.ReceiveHighWatermark:
                     ReceiveHighWatermark = (int)optionValue;
+                    break;
+
+                case ZmqSocketOption.SendLowWatermark:
+                    SendLowWatermark = (int)optionValue;
+                    break;
+
+                case ZmqSocketOption.ReceiveLowWatermark:
+                    ReceiveLowWatermark = (int)optionValue;
                     break;
 
                 case ZmqSocketOption.Affinity:
@@ -418,6 +438,12 @@ namespace NetMQ.Core
 
                 case ZmqSocketOption.ReceiveHighWatermark:
                     return ReceiveHighWatermark;
+
+                case ZmqSocketOption.SendLowWatermark:
+                    return SendLowWatermark;
+
+                case ZmqSocketOption.ReceiveLowWatermark:
+                    return ReceiveLowWatermark;
 
                 case ZmqSocketOption.Affinity:
                     return Affinity;

--- a/src/NetMQ/Core/SessionBase.cs
+++ b/src/NetMQ/Core/SessionBase.cs
@@ -435,8 +435,9 @@ namespace NetMQ.Core
             {
                 ZObject[] parents = { this, m_socket };
                 int[] highWaterMarks = { m_options.ReceiveHighWatermark, m_options.SendHighWatermark };
+                int[] lowWaterMarks = { m_options.ReceiveLowWatermark, m_options.SendLowWatermark };
                 bool[] delays = { m_options.DelayOnClose, m_options.DelayOnDisconnect };
-                Pipe[] pipes = Pipe.PipePair(parents, highWaterMarks, delays);
+                Pipe[] pipes = Pipe.PipePair(parents, highWaterMarks, lowWaterMarks, delays);
 
                 // Plug the local end of the pipe.
                 pipes[0].SetEventSink(this);

--- a/src/NetMQ/Core/ZmqSocketOption.cs
+++ b/src/NetMQ/Core/ZmqSocketOption.cs
@@ -256,6 +256,20 @@ namespace NetMQ.Core
         XPublisherBroadcast = 45,
 
         /// <summary>
+        /// The low-water mark for message transmission. This is the number of messages that should be processed
+        /// before transmission is unblocked (in case it was blocked by reaching high-watermark). The default value is 
+        /// calculated using relevant high-watermark (HWM): HWM > 2048 ? HWM - 1024 : (HWM + 1) / 2
+        /// </summary>
+        SendLowWatermark = 46,
+
+        /// <summary>
+        /// The low-water mark for message reception. This is the number of messages that should be processed 
+        /// before reception is unblocked (in case it was blocked by reaching high-watermark). The default value is 
+        /// calculated using relevant high-watermark (HWM): HWM > 2048 ? HWM - 1024 : (HWM + 1) / 2
+        /// </summary>
+        ReceiveLowWatermark = 47,
+
+        /// <summary>
         /// Specifies the byte-order: big-endian, vs little-endian.
         /// </summary>
         Endian = 1000

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -223,6 +223,30 @@ namespace NetMQ
         }
 
         /// <summary>
+        /// The low-water mark for message transmission. 
+        /// This is the number of messages that should be processed before transmission is 
+        /// unblocked (in case it was blocked by reaching high-watermark). The default value is 
+        /// calculated using relevant high-watermark (HWM): HWM > 2048 ? HWM - 1024 : (HWM + 1) / 2
+        /// </summary>
+        public int SendLowWatermark
+        {
+            get { return m_socket.GetSocketOption(ZmqSocketOption.SendLowWatermark); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.SendLowWatermark, value); }
+        }
+
+        /// <summary>
+        /// The low-water mark for message reception. 
+        /// This is the number of messages that should be processed  before reception is 
+        /// unblocked (in case it was blocked by reaching high-watermark). The default value is 
+        /// calculated using relevant high-watermark (HWM): HWM > 2048 ? HWM - 1024 : (HWM + 1) / 2
+        /// </summary>
+        public int ReceiveLowWatermark
+        {
+            get { return m_socket.GetSocketOption(ZmqSocketOption.ReceiveLowWatermark); }
+            set { m_socket.SetSocketOption(ZmqSocketOption.ReceiveLowWatermark, value); }
+        }
+
+        /// <summary>
         /// Get or set the time-to-live (maximum number of hops) that outbound multicast packets
         /// are allowed to propagate.
         /// The default value of 1 means that the multicast packets don't leave the local network.


### PR DESCRIPTION
This is a pull request for recently opened issue: "False positive high-watermark check in Pipe class #459". 

The main idea of proposed fix is to give explicit access to low-watermark value via configuration. The default low-watermark calculation logic is still in place and will be used when setting is not explicitly defined (or contains incorrect value).