### PR TITLE
Problem: typo in comments

### DIFF
--- a/src/build.bat
+++ b/src/build.bat
@@ -2,9 +2,9 @@
 :: Usage:     build.bat [Clean]
 ::
 ::  Requires NuGet.exe to get references NuGets prior to command line build.
-::  If you prefer to not install NuGet.exe fom https://nuget.org/nuget.exe),
+::  If you prefer to not install NuGet.exe fom https://nuget.org/nuget.exe,
 ::  build first time from NetMQ.sln using DevStudio, and the referenced NuGet
-:;  packages will be downloaded for you.
+::  packages will be downloaded for you.
 ::  After that first build, you can then use this script to build with no errors.
 ::
 @setlocal


### PR DESCRIPTION
Solution: corrected typo in comments
	There were two: there was a stray close parenthesis after nuget.exe in URL
	There was a comment line that started :; when it should have started ::.
	Thanks C-RACK for noticing it.