### PR TITLE
Write null string length still

### DIFF
--- a/src/NetMQ/Core/MonitorEvent.cs
+++ b/src/NetMQ/Core/MonitorEvent.cs
@@ -87,6 +87,8 @@ namespace NetMQ.Core
                 buffer.PutString(m_addr, pos);
                 pos += m_addr.Length;
             }
+            else
+                buffer[pos++] = 0;
 
             buffer[pos++] = ((byte)m_flag);
             if (m_flag == ValueInteger)


### PR DESCRIPTION
When m_addr is null, still write zero string length.
Issue https://github.com/zeromq/netmq/issues/528
