### PR TITLE
Manual context termination

### DIFF
--- a/src/NetMQ.Tests/ManualContextTerminationTests.cs
+++ b/src/NetMQ.Tests/ManualContextTerminationTests.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using NetMQ.Sockets;
+using NUnit.Framework;
+
+namespace NetMQ.Tests
+{
+    [TestFixture]
+    public class ManualContextTerminationTests
+    {
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            NetMQConfig.ManualTerminationTakeOver();
+        }
+
+        [TestFixtureTearDown]
+        public void Cleanup()
+        {
+            NetMQConfig.DisableManualTermination();
+        }
+
+        [Test(Description = "When ManualTerminationTakeOver is not called the Context shouldn't be terminated.")]
+        public void CallTerminateDefaultBehavior()
+        {
+            NetMQConfig.DisableManualTermination();
+            NetMQConfig.ContextTerminate();
+            var isTerminated = VerifyTermination();
+
+            // Restore default test behavior
+            NetMQConfig.ManualTerminationTakeOver();
+            Assert.AreEqual(false, isTerminated);
+        }
+
+        [Test]
+        public void CreateContext()
+        {
+            NetMQConfig.ContextCreate();
+            var isTerminated = VerifyTermination();
+            Assert.AreEqual(false, isTerminated);
+        }
+
+        [Test, Repeat(10)]
+        public void CycleCreateTerminate()
+        {
+            NetMQConfig.ContextCreate();
+            var isTerminated = VerifyTermination();
+            Assert.AreEqual(false, isTerminated);
+
+            // We use the Poller Test code.
+            using (var rep = new ResponseSocket())
+            using (var req = new RequestSocket())
+            using (var poller = new NetMQPoller { rep })
+            {
+                var port = rep.BindRandomPort("tcp://127.0.0.1");
+
+                req.Connect("tcp://127.0.0.1:" + port);
+
+                rep.ReceiveReady += (s, e) =>
+                {
+                    bool more;
+                    Assert.AreEqual("Hello", e.Socket.ReceiveFrameString(out more));
+                    Assert.False(more);
+
+                    e.Socket.SendFrame("World");
+                };
+
+                poller.RunAsync();
+
+                req.SendFrame("Hello");
+
+                bool more2;
+                Assert.AreEqual("World", req.ReceiveFrameString(out more2));
+                Assert.IsFalse(more2);
+
+                poller.Stop();
+            }
+            NetMQConfig.ContextTerminate();
+            isTerminated = VerifyTermination();
+            Assert.AreEqual(true, isTerminated);
+        }
+
+        [Test]
+        public void TerminateAfterSocketsUse()
+        {
+            using (var rep = new ResponseSocket())
+            using (var req = new RequestSocket())
+            using (var poller = new NetMQPoller { rep })
+            {
+                var port = rep.BindRandomPort("tcp://127.0.0.1");
+
+                req.Connect("tcp://127.0.0.1:" + port);
+
+                rep.ReceiveReady += (s, e) =>
+                {
+                    bool more;
+                    Assert.AreEqual("Hello", e.Socket.ReceiveFrameString(out more));
+                    Assert.False(more);
+
+                    e.Socket.SendFrame("World");
+                };
+
+                poller.RunAsync();
+
+                req.SendFrame("Hello");
+
+                bool more2;
+                Assert.AreEqual("World", req.ReceiveFrameString(out more2));
+                Assert.IsFalse(more2);
+
+                poller.Stop();
+            }
+            NetMQConfig.ContextTerminate();
+            var isTerminated = VerifyTermination();
+            Assert.AreEqual(true, isTerminated);
+        }
+
+        [Test]
+        public void TerminateContext()
+        {
+            NetMQConfig.ContextTerminate();
+            var isTerminated = VerifyTermination();
+            Assert.AreEqual(true, isTerminated);
+        }
+
+        #region Helpers
+
+        private static bool VerifyTermination()
+        {
+            var isTerminated = false;
+            try
+            {
+                NetMQConfig.Context.CheckDisposed();
+            }
+            catch (ObjectDisposedException)
+            {
+                isTerminated = true;
+            }
+
+            return isTerminated;
+        }
+
+        #endregion
+
+    }
+}

--- a/src/NetMQ.Tests/ManualContextTerminationTests.cs
+++ b/src/NetMQ.Tests/ManualContextTerminationTests.cs
@@ -42,7 +42,7 @@ namespace NetMQ.Tests
         [Test, Repeat(10)]
         public void CycleCreateTerminate()
         {
-            NetMQConfig.ContextCreate();
+            NetMQConfig.ContextCreate(true);
             var isTerminated = VerifyTermination();
             Assert.AreEqual(false, isTerminated);
 
@@ -82,6 +82,7 @@ namespace NetMQ.Tests
         [Test]
         public void TerminateAfterSocketsUse()
         {
+            NetMQConfig.ContextCreate(true);
             using (var rep = new ResponseSocket())
             using (var req = new RequestSocket())
             using (var poller = new NetMQPoller { rep })
@@ -117,6 +118,7 @@ namespace NetMQ.Tests
         [Test]
         public void TerminateContext()
         {
+            NetMQConfig.ContextCreate(true);
             NetMQConfig.ContextTerminate();
             var isTerminated = VerifyTermination();
             Assert.AreEqual(true, isTerminated);

--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="InProcActors\ExceptionShimExample\ExceptionShimHandler.cs" />
     <Compile Include="InProcActors\Echo\EchoShimHandler.cs" />
     <Compile Include="InProcActors\Echo\EchoActorTests.cs" />
+    <Compile Include="ManualContextTerminationTests.cs" />
     <Compile Include="MockBufferPool.cs" />
     <Compile Include="MsgTests.cs" />
     <Compile Include="NetMQProactorTests.cs" />

--- a/src/NetMQ/NetMQConfig.cs
+++ b/src/NetMQ/NetMQConfig.cs
@@ -9,17 +9,123 @@ namespace NetMQ
     {
         private static TimeSpan s_linger;
 
-        private static readonly Ctx s_ctx;
+        private static Ctx s_ctx;
         private static readonly object s_settingsSync;
+        private static bool s_manualTakeOver;
 
         static NetMQConfig()
         {
+            s_manualTakeOver = false;
             s_ctx = new Ctx { Block = false };
             s_settingsSync = new object();
             s_linger = TimeSpan.Zero;
 
             // Register to destroy the context when application exit
-            AppDomain.CurrentDomain.ProcessExit += (sender, args) => s_ctx.Terminate();
+            AppDomain.CurrentDomain.ProcessExit += ProcessExitTerminateContext;
+        }
+
+        /// <summary>
+        /// Handles the context termination.
+        /// We use a named method so we can unregister it from the event handler.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private static void ProcessExitTerminateContext(object sender, EventArgs e)
+        {
+            try
+            {
+                s_ctx.CheckDisposed();
+                s_ctx.Terminate();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+
+        /// <summary>
+        /// WARNING:
+        /// Please use this with care, this removes the context cleanup, 
+        /// and may leave threads running if you don't do proper cleanup.
+        /// For proper termination, dispose all sockets, pollers and timmers
+        /// and call <see cref="ContextTerminate"/>.
+        /// </summary>
+        public static void ManualTerminationTakeOver()
+        {
+            // Ignore subsequence calls
+            if (s_manualTakeOver) return;
+            s_manualTakeOver = true;
+            AppDomain.CurrentDomain.ProcessExit -= ProcessExitTerminateContext;
+        }
+
+        /// <summary>
+        /// For use in testing
+        /// </summary>
+        internal static void DisableManualTermination()
+        {
+            if (!s_manualTakeOver) return;
+            s_manualTakeOver = false;
+            var isTerminated = false;
+            try
+            {
+                s_ctx.CheckDisposed();
+            }
+            catch (ObjectDisposedException)
+            {
+                isTerminated = true;
+            }
+
+            // Only creates if we don't have a context.
+            if (isTerminated)
+                s_ctx = new Ctx { Block = false };
+        }
+
+        /// <summary>
+        /// WARNING:
+        /// This terminate the context, blocking if called with the default options.
+        /// This as no effect if ManualTerminationTakeOver isn't called.
+        /// </summary>
+        /// <param name="block">Should the context block the thread while terminating.</param>
+        public static void ContextTerminate(bool block = true)
+        {
+            // Move along, nothing to see here :)
+            if (!s_manualTakeOver) return;
+
+            lock (s_settingsSync)
+                s_ctx.Block = block;
+
+            // Gracefully exit if Terminate was already called for the static context.
+            try
+            {
+                s_ctx.CheckDisposed();
+                s_ctx.Terminate();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Create a context, if needed.
+        /// </summary>
+        /// <param name="block">Should the context block the thread while terminating.</param>
+        public static void ContextCreate(bool block=false)
+        {
+            // Move along, nothing to see here :)
+            if (!s_manualTakeOver) return;
+
+            var isTerminated = false;
+            try
+            {
+                s_ctx.CheckDisposed();
+            }
+            catch (ObjectDisposedException)
+            {
+                isTerminated = true;
+            }
+
+            // Only creates if we don't have a context.
+            if(isTerminated)
+                s_ctx = new Ctx { Block = block };
         }
 
         internal static Ctx Context => s_ctx;


### PR DESCRIPTION
This pull request, adds the ability to terminate and create the global NetMQ context. For this to happen a ManualTerminationTakeOver, must be called at least once. After this the developer is responsible for the life time control of the NetMQ context.
This is a requirement for Unity3D development where the Editor wasn't playing nice with the static global context, since after calling Play, the context isn't terminated (no application exit happens). This may also help in some extreme cases like using pythonnet with NetMQ inside a DCC app, like 3dsmax or maya, where there is need for more control over the life of the context.