### PR TITLE
Problem: Problem: Links to references getting github.com 404 error

### DIFF
--- a/docs/message.md
+++ b/docs/message.md
@@ -28,13 +28,13 @@ Truth is ZeroMQ, and therefore NetMQ are really frame based, which implies some 
 
 While it is true that if you wish to come up with some complex and elaborate architecture you would be best of coming up with a nice protocol, thankfully you will not need to do this all the time. This is largely down to ZeroMQ/NetMQ's clever sockets that abstract away a lot of that from you, and the way in which you can treat the sockets as building blocks to build complex architecture (think lego).
 
-One precanned example of this is the [RouterSocket](router-dealer) which makes very clever use of frames for you out of the box. Where it effectively onion skins the current message with the senders return address, so that when it gets a message back (say from a worker socket), it can use that frame information again to obtain the correct return address and send it back to the correct socket.
+One precanned example of this is the [RouterSocket](router-dealer.md) which makes very clever use of frames for you out of the box. Where it effectively onion skins the current message with the senders return address, so that when it gets a message back (say from a worker socket), it can use that frame information again to obtain the correct return address and send it back to the correct socket.
 
-So that is one inbuilt use of frames that you should be aware of, but frames are not limited to [RouterSocket](router-dealer), you can use them yourself for all sorts of things, here are some examples:
+So that is one inbuilt use of frames that you should be aware of, but frames are not limited to [RouterSocket](router-dealer.md), you can use them yourself for all sorts of things, here are some examples:
 
 + You may decide to have `frame[0]` denote the specific message type of following frame(s).
   This allows receivers to discard message types they are disinterested in without wasting time deserialising a message they do not care about anyway.
-  ZeroMQ/NetMQ uses this approach in its [Pub-Sub sockets](pub-sub), and you can replicate or extend this idea.
+  ZeroMQ/NetMQ uses this approach in its [Pub-Sub sockets](pub-sub.md), and you can replicate or extend this idea.
 + You may decide to use `frame[0]` as some sort of command, `frame[1]` and some sort of parameter and have `frame[2]` as the message payload (where it may contain some serialized object).
 
 These are just some examples. You can use frames however you wish really, although some socket types expect or produce certain frame structures.

--- a/docs/poller.md
+++ b/docs/poller.md
@@ -58,7 +58,7 @@ For ZeroMQ/NetMQ to give great performance, some restrictions exist on how we ca
 
 For example, consider socket A with a service loop in thread A, and socket B with a service loop in thread B. It would be invalid to receive a message from socket A (on thread A) and then attempt to send it on socket B. The socket is not threadsafe, and so attempts to use is simultaneously from threads A and B would cause errors.
 
-In fact the pattern described here is known as a [proxy](proxy), and one is built into NetMQ. At this point you may not be surprised to learn that it is powered by a `NetMQPoller`.
+In fact the pattern described here is known as a [proxy](proxy.md), and one is built into NetMQ. At this point you may not be surprised to learn that it is powered by a `NetMQPoller`.
 
 ## Example: ReceiveReady
 

--- a/docs/pub-sub.md
+++ b/docs/pub-sub.md
@@ -14,7 +14,7 @@ NetMQ comes with support for Pub/Sub by way of two socket types:
 
 ## Topics
 
-ZeroMQ/NetMQ uses multipart [messages](message) to convey topic information. Topics are expressed as an array of bytes, though you may use a string and suitable `System.Text.Encoding`.
+ZeroMQ/NetMQ uses multipart [messages](message.md) to convey topic information. Topics are expressed as an array of bytes, though you may use a string and suitable `System.Text.Encoding`.
 
 A publisher must include the topic in the message's' first frame, prior to the message payload. For example, to publish a status message to subscribers of the `status` topic:
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -67,7 +67,7 @@ InProc (in-process) allows you to connect sockets running with the same process.
 + To do away with shared state/locks. When you send data down the wire (socket) there is no shared state to worry about. Each end of the socket will have its own copy.
 + Being able to communicate between very disparate parts of a system.
 
-NetMQ comes with several components that use InProc, such the as [Actor model](actor) and [Devices](devices), which are discussed in their relevant documentation pages.
+NetMQ comes with several components that use InProc, such the as [Actor model](actor.md) and [Devices](devices.md), which are discussed in their relevant documentation pages.
 
 ### Example
 
@@ -129,7 +129,7 @@ regard for scalability and network efficiency.
 To use PGM with NetMQ, we do not have to do too much. We just need to follow these three pointers:
 
 1. The socket types are now `PublisherSocket` and `SubscriberSocket`
-   which are talked about in more detail in the [pub-sub pattern](pub-sub) documentation.
+   which are talked about in more detail in the [pub-sub pattern](pub-sub.md) documentation.
 2. Make sure you are running the app as "Administrator"
 3. Make sure you have turned on the "Multicasting Support". You can do that as follows:
 

--- a/docs/xpub-xsub.md
+++ b/docs/xpub-xsub.md
@@ -1,7 +1,7 @@
 XPub / XSub
 =====
 
-The [Pub/Sub](pub-sub) pattern is great for multiple subscribers and a single publisher, but if you need multiple publishers then the XPub/XSub pattern will be of interest.
+The [Pub/Sub](pub-sub.md) pattern is great for multiple subscribers and a single publisher, but if you need multiple publishers then the XPub/XSub pattern will be of interest.
 
 XPub/XSub can also assist with the so-called _dynamic discovery problem_. From the [ZeroMQ guide](http://zguide.zeromq.org/page:all#The-Dynamic-Discovery-Problem):
 
@@ -107,4 +107,4 @@ When run, it should look something like this:
 
 ![](Images/XPubXSubDemo.png)
 
-Unlike the [Pub/Sub](pub-sub) pattern, we can have an arbitrary number of publishers and subscribers.
+Unlike the [Pub/Sub](pub-sub.md) pattern, we can have an arbitrary number of publishers and subscribers.


### PR DESCRIPTION
Solution: fixed broken links by adding ".md" at the end of the referenced link.
Found more instances...