### PR TITLE
Set the title of the package to NetMQ

### DIFF
--- a/src/NetMQ/NetMQ.nuspec
+++ b/src/NetMQ/NetMQ.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>NetMQ</id>
     <version>$version$</version>
-    <title>NetMQ4</title>
+    <title>NetMQ</title>
     <authors>NetMQ</authors>
     <owners>NetMQ</owners>
     <licenseUrl>https://github.com/zeromq/netmq/blob/master/COPYING.LESSER</licenseUrl>


### PR DESCRIPTION
It was set to NetMQ4 which change the name of the package on Nuget.