### PR TITLE
Add traditional chinese translation for documents

### DIFF
--- a/docs/beacon.md
+++ b/docs/beacon.md
@@ -1,31 +1,23 @@
 Beacon
 ======
+`NetMQBeacon`實作了在區域網路中點對點的discovery服務。
 
-`NetMQBeacon` implements a peer-to-peer discovery service for local networks.
+一個`beacon`可在區域網路中透過UDP做擴播或捕捉service announcements，你可以定義廣播出去的beacon，也可以設定過濾器以過濾接收到的beacons。Beacons會在背景非同步的執行傳送及接收的動作。
 
-A beacon can broadcast and/or capture service announcements using UDP messages on the local area network.
-You can define the format of your outgoing beacons, and set a filter that validates incoming beacons.
-Beacons are sent and received asynchronously in the background.
+我們可以使用`NetMQBeacon`自動地在網路中尋找及連線至其它`NetMQ/CZMQ`的服務而不需要一個中央的設定。請注意若要使用`NetMQBeacon`在你的架構中需要支援廣播(broadcast)服務。而目前大部份的服端服務商並不支援。
 
-We can use the `NetMQBeacon` to discover and connect to other NetMQ/CZMQ services in the network automatically
-without central configuration. Please note that to use `NetMQBeacon` your infrastructure must support broadcast.
-Most cloud providers doesn't support broadcast.
-
-This implementation uses IPv4 UDP broadcasts, and is a port of [zbeacon from czmq](https://github.com/zeromq/czmq#toc4-425)
-with some extensions, though it maintains network compatibility.
+這個實作使用IPv4 UDP廣播，屬於[zbeacon from czmq](https://github.com/zeromq/czmq#toc4-425)並加上維護網路相容性的擴充函式。
 
 ## Example: Implementing a Bus
+`NetMQBeacon`可以用來建立簡單的bus系統，讓一組節點僅需透過一個共享的埠號即可找到其它的節點。
 
-`NetMQBeacon` can be used to create a simple bus that allows a set of nodes
-to discover one another, configured only via a shared port number.
+- 每個bus的節點綁定至一個subscriber socket且靠publisher socket連線至其它節點。
+- 每個節點會透過`NetMQBeacon`去公告它的存在及尋找其它節點，我們將使用`NetMQActor`來實作我們的節點。
 
-* Each bus node binds a subscriber socket and connects to other nodes with a publisher socket.
-* Each node will use `NetMQBeacon` to announce its existence and to discover other nodes. We will also use `NetMQActor` to implement our node.
+範例在此：
 
-The source for sample project is available online at:
-
-https://github.com/zeromq/netmq/blob/master/src/Samples/Beacon/BeaconDemo/Bus.cs
-
+[bus.cs](https://github.com/NetMQ/Samples/blob/master/src/Beacon/BeaconDemo/Bus.cs)
+(原文連結有誤，此處已修改)
 
 ## Further reading
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,15 @@
 ![](Images/NetMQLogo.svg)
 
-NetMQ is a 100% native C# port of ZeroMQ, a lightweight messaging library.
+NetMQ是100%原生從ZeroMQ移植至C#的輕量級訊息函式庫。
 
-NetMQ extends the standard socket interface with features traditionally provided by specialised messaging middleware products. NetMQ sockets provide an abstraction of asynchronous message queues, multiple messaging patterns, message filtering (subscriptions), seamless access to multiple transport protocols and more.
+NetMQ擴充了標準socket介面，具有傳統上由專用訊息中介軟體產品提供的功能。NetMQ socket提供非同步訊息佇列、多種訊息模式、訊息過濾（訂閱），多種傳輸協議間無縫訪問等等的抽象。
 
 ## Documentation
 
-NetMQ documentation is available at [netmq.readthedocs.org](http://netmq.readthedocs.org/en/latest/).
+NetMQ 的文件在 [netmq.readthedocs.org](http://netmq.readthedocs.org/en/latest/).
 
-Using NetMQ requires an understanding of ZeroMQ, for which there is no better documentation than the [ZeroMQ Guide](http://zguide.zeromq.org/page:all).
+使用`NetMQ`要先了解`ZeroMQ`，沒有比這更好的文件了ー[ZeroMQ Guide](http://zguide.zeromq.org/page:all).
 
 ## Installation
 
-You can install NetMQ from [NuGet](https://nuget.org/packages/NetMQ/).
+可以從這裡 [NuGet](https://nuget.org/packages/NetMQ/)安裝`NetMQ`。

--- a/docs/proactor.md
+++ b/docs/proactor.md
@@ -1,7 +1,7 @@
 Proactor
 ========
 
-`NetMQProactor` quickly processes messages received on a socket using a dedicated thread.
+`NetMQProactor`會使用專有的執行緒處理在socket上收到的訊息。
 
     :::csharp
     using (var receiveSocket = new DealerSocket(">tcp://localhost:5555"))
@@ -11,5 +11,4 @@ Proactor
         // ...
     }
 
-Internally the proactor creates a `NetMQPoller` for the socket, and a `NetMQActor` to coordinate
-the poller thread and disposal.
+在內部，proactor為socket建了一個`NetMQPoller`，以及一個`NetMQActor`處理poller執行緒及disposal。

--- a/docs/pub-sub.md
+++ b/docs/pub-sub.md
@@ -3,18 +3,18 @@ Pub/Sub
 
 From [Wikipedia](http://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern):
 
-> Publish–subscribe is a messaging pattern where senders of messages, called publishers, do not program the messages to be sent directly to specific receivers, called subscribers. Instead, published messages are characterized into classes, without knowledge of what, if any, subscribers there may be. Similarly, subscribers express interest in one or more classes, and only receive messages that are of interest, without knowledge of what, if any, publishers there are.
+> 發布/訂閱（Publish/subscribe 或pub/sub）是一種訊息規範，訊息的傳送者（發布者）不是計劃傳送其訊息給特定的接收者（訂閱者）。而是發布的訊息分為不同的類別，而不需要知道什麼樣的訂閱者訂閱。訂閱者對一個或多個類別表達興趣，於是只接收感興趣的訊息，而不需要知道什麼樣的發布者發布的訊息。這種發布者和訂閱者的解耦可以允許更好的可延伸性和更為動態的網路拓撲.
 
-The _classes_ mentioned in this description can also be referred to as _topics_ or _filters_.
+上述所謂的_類別_也可以當成是一個_"主題"_或_"過濾器"_。
 
-NetMQ comes with support for Pub/Sub by way of two socket types:
+`NetMQ`用兩種socket型別支援`Pub/Sub`模式：
 
 + `PublisherSocket`
 + `SubscriberSocket`
 
 ## Topics
 
-ZeroMQ/NetMQ uses multipart [messages](message.md) to convey topic information. Topics are expressed as an array of bytes, though you may use a string and suitable `System.Text.Encoding`.
+`ZeroMQ/NetMQ`使用多段訊息傳送主題資訊，可用byte陣列來表示主題，或是字串並加上適當的`System.Text.Encoding`。
 
 A publisher must include the topic in the message's' first frame, prior to the message payload. For example, to publish a status message to subscribers of the `status` topic:
 
@@ -22,7 +22,7 @@ A publisher must include the topic in the message's' first frame, prior to the m
     // send a message on the 'status' topic
     pub.SendMoreFrame("status").SendFrame("All is well");
 
-Subscribers specify which topics they are interested in via the `Subscribe` method of `SubscriberSocket`:
+訂閱者使用`SubscriberSocket`的`Subscribe`函式指定他們有興趣的主題。
 
     :::csharp
     // subscribe to the 'status' topic
@@ -31,20 +31,20 @@ Subscribers specify which topics they are interested in via the `Subscribe` meth
 
 ## Topic heirarchies
 
-A message's topic is compared against subscribers' subscription topics using a prefix check.
+一個訊息的主題會用prefix檢查和訂閱者的訂閱主題比較。
 
-That is, a subscriber who subscribed to `topic` would receive messages with topics:
+也就是說，訂閱`主題`的訂閱者會接收具有主題的訊息：
 
 * `topic`
 * `topic/subtopic`
 * `topical`
 
-However it would not receive messages with topics:
+然而它不會接受這些主題：
 
 * `topi`
-* `TOPIC` (remember, it's a byte-wise comparison)
+* `TOPIC` （記住，它是以byte做為比較方式）
 
-A consequence of this prefix matching behavious is that you can receive all published messages by subscribing with an empty topic string:
+使用prefix比對行為的結果，可以讓你以空字串來訂閱所有發佈的訊息。
 
     :::csharp
     sub.Subscribe(""); // subscribe to all topics
@@ -52,10 +52,10 @@ A consequence of this prefix matching behavious is that you can receive all publ
 
 ## An Example
 
-Time for an example. This example is very simple, and follows these rules.
+到了介紹範例的時間了，這範例很簡單，並遵守下列規則：
 
-+ There is one publisher process, who randomly publishes a message to either `TopicA` or `TopicB` every 500ms.
-+ There may be many subscribers. The topic name is passed as a command line argument.
++ 有一個發佈者的process，會以500ms的時間隨機發佈主題為`TopicA`或'TopicB`的訊息。
++ 可能會有很多訂閱者，欲訂閱的主題名稱會以命令列參數代入程式中。
 
 ### Publisher
 
@@ -151,7 +151,7 @@ Time for an example. This example is very simple, and follows these rules.
         }
     }
 
-To run this, these three BAT files may be useful, though you will need to change them to suit your code location should you choose to copy this example code into a new set of projects.
+在這邊提供三個批次檔，讓你方便執行，不過要稍微修改一下路徑等一適合你的環境。
 
 ### RunPubSub.bat
 
@@ -175,7 +175,7 @@ To run this, these three BAT files may be useful, though you will need to change
     Subscriber.exe %topic%
 
 
-When run, you should see something like this:
+執行時輸出如下：
 
 ![](Images/PubSubUsingTopics.png)
 
@@ -185,13 +185,13 @@ Other Considerations
 
 ### High water mark
 
-The `SendHighWaterMark`/`ReceiveHighWaterMark` options set the high water mark for the specified socket. The high water mark is a hard limit on the maximum number of outstanding messages NetMQ shall queue in memory for any single peer that the specified socket is communicating with.
+SendHighWaterMark / ReceiveHighWaterMark選項可設定指定socket的high water mark。High water mark是對未完成訊息的最大數量的限制，NetMQ會將正在與指定的socket通訊的任何端點的訊息排入佇列中。
 
-If this limit has been reached the socket shall enter an exceptional state and depending on the socket type, NetMQ shall take appropriate action such as blocking or dropping sent messages.
+如果到達此限制，socket會進入異常狀態，並且根據socket類型，NetMQ應採取適當的措施，如阻止或丟棄發送的訊息。
 
-The default `SendHighWaterMark`/`ReceiveHighWaterMark` value is 1000. The value of zero means "no limit".
+預設的SendHighWaterMark / ReceiveHighWaterMark值為1000.零值表示“無限制”。
 
-You would set these 2 options using the `xxxxSocket.Options` property as follows:
+你也可以使用`xxxSocket.Options`屬性值設定下列兩個屬性：
 
 +  `pubSocket.Options.SendHighWatermark = 1000;`
 +  `pubSocket.Options.ReceiveHighWatermark = 1000;`

--- a/docs/push-pull.md
+++ b/docs/push-pull.md
@@ -1,21 +1,21 @@
 Push / Pull
 =====
 
-NetMQ comes with a `PushSocket` and a `PullSocket`. What are these and how should they be used?
+`NetMQ`提供了`PushSocket`和`PullSocket`，這些是什麼？要如何使用？
 
-Well a `PushSocket` is normally used to push to a `PullSocket`, whilst the `PullSocket` will pull from a `PushSocket`. Sounds obvious right!
+嗯，`PushSocket`一般是用來推送訊息至`PullSocket`，而`PullSocket`是用來從`PushSocket`取得訊息，聽起來很對吧！
 
-You would typically use this configuration of sockets to produce some distributed work, kind of like a <a href="http://zguide.zeromq.org/page:all#Divide-and-Conquer" target="_blank">divide and conquer</a> arrangement.
+你通常使用這種設定的socket來產生一些分佈式的工作，有點像 <a href="http://zguide.zeromq.org/page:all#Divide-and-Conquer" target="_blank">divide and conquer</a> 的安排。
 
-The idea is that you have something that generates work, and then distributes the work out to n-many workers. The workers each do some work, and push their results to some other process (could be a thread too) where the workers results are accumulated.
+這個想法是，你有一些產生工作的東西，然後將工作分配給多個工人。工人每個都做一些工作，並將結果推送到其他工序（可能是一個執行緒），工人的產出在那裡累積。
 
-In the <a href="http://zguide.zeromq.org/page:all" target="_blank">ZeroMQ guide</a>, it shows an example that has the work generator just tell each worker to sleep for a period of time.
+在 <a href="http://zguide.zeromq.org/page:all" target="_blank">ZeroMQ guide</a> 中，它顯示了一個範例，其中work generator只是告訴每個工人睡眠一段時間。
 
-We toyed with creating a more elaborate example than this, but in the end felt that the example's simplicity was quite important, so we have stuck with the workload for each worker just being a value that tells the work to sleep for a number of milliseconds (thus simulating some actual work). This example, as I say, has been borrowed from the <a href="http://zguide.zeromq.org/page:all" target="_blank">ZeroMQ guide</a>.
+我們試圖創建一個比這更複雜的例子，但是最終覺得這個例子的簡單性是相當重要的，所以我們讓每個工人的工作量變成一個代入值，告訴工作休眠幾毫秒（從而模擬一些實際工作）。這個例子，正如我所說，是從 <a href="http://zguide.zeromq.org/page:all" target="_blank">ZeroMQ guide</a> 借來的。
 
 In real life the work could obviously be anything, though you would more than likely want the work to be something that could be cut up and distributed without the work generator caring/knowing how many workers there are.
 
-Here is what we are trying to achieve :
+這裡是我們試圖實作的：
 
 ![](Images/Fanout.png)
 
@@ -174,7 +174,7 @@ Here is what we are trying to achieve :
 
 ## Running the sample
 
-To run this, these three BAT files may be useful, though you will need to change them to suit your code location should you choose to copy this example code into a new set of projects.
+要執行這個，這三個批次檔會很有用，若你選擇將此程式碼複製到新方案中，你需要更改路徑以符合。
 
 ### Run1Worker.bat
 
@@ -189,7 +189,7 @@ To run this, these three BAT files may be useful, though you will need to change
     start Worker.exe
 
 
-Which when run should give you some output like this in the Sink process console output (obviously your PC may run faster/slower than mine):
+在這個Sink的Process執行後，應該會在Console有如下的輸出：（顯然你的PC可能運行比我的更快/更慢）：
 
     :::text
     ====== SINK ======
@@ -212,7 +212,7 @@ Which when run should give you some output like this in the Sink process console
     start Worker.exe
     start Worker.exe
 
-Which when run should give you some output like this in the Sink process console output (obviously you PC may run faster/slower than mine):
+在這個Sink的Process執行後，應該會在Console有如下的輸出：（顯然你的PC可能運行比我的更快/更慢）：
 
     :::text
     ====== SINK ======
@@ -238,7 +238,7 @@ Which when run should give you some output like this in the Sink process console
     start Worker.exe
 
 
-Which when run should give you some output like this in the Sink process console output (obviously you PC may run faster/slower than mine):
+在這個Sink的Process執行後，應該會在Console有如下的輸出：（顯然你的PC可能運行比我的更快/更慢）：
 
     :::text
     ====== SINK ======
@@ -247,9 +247,9 @@ Which when run should give you some output like this in the Sink process console
     :.........:.........
     Total elapsed time 1492 msec
 
-There are a couple of points to be aware of with this pattern
+這個模式有幾個要注意的重點：
 
-+ The `Ventilator` uses a NetMQ `PushSocket` to distribute work to the `Worker`s, this is referred to as load balancing.
-+ The `Ventilator` and the `Sink` are the static parts of the system, where as `Worker`s are dynamic. It is trivial to add more `Worker`s, we can just spin up a new instance of a `Worker`s, and in theory the work gets done quicker.
-+ We need to synchronize the starting of the batch (when  `Worker`s are ready), as if we did not do that, the first `Worker`s that connected would get more messages that the rest, which is not really load balanced.
-+ The `Sink` uses a NetMQ `PullSocket` to accumulate the results from the `Worker`s.
++ `Ventilator`使用`NetMQ`中的`PushSocket`以將工作發佈至`Worker`，這也稱為負載平衡。
++ `Ventilator`和`Sink`是系統中固定的部份，而`Worker`是動態的，添加更多`Worker`的是很簡單的事，我們可以啟動一個新的`Worker`實體，在理論上，工作會更快完成（越多`Worker`越快）。
++ 我們要同步啟動批次檔（當`Worker`準備好時），如果沒有，最先連線的`Worker`會比其它的取得更多的訊息，那就不夠負載平衡了。
++ `Sink`使用`NetMQ`的`PullSocket`去累積`Worker`的產出。

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -1,10 +1,9 @@
 Queue
 ======
 
-`NetMQQueue<T>` is a producer-consumer queue that supports multiple producers and a single consumer.
+`NetMQQueue<T>`是一個支援多個生產者及單一消費者的生產者/消費者佇列。
 
-You should add the queue to a `NetMQPoller`, and attach the consumer to its `ReceiveReady` event.
-Producers call `Enqueue(T)`.
+你應該將佇列加至`NetMQPoller`中，且在`ReceiveReady`事件中加上消費者程式碼，而生產者會呼叫`Enque(T)`將資料加入。
 
 This class can eliminate boilerplate code associated with marshalling operations onto a single thread.
 

--- a/docs/receiving-sending.md
+++ b/docs/receiving-sending.md
@@ -1,21 +1,21 @@
-If you have read the [Introduction](http://netmq.readthedocs.org/en/latest/introduction/) page you would have already seen an example of `ReceiveString()` and `SendString()`, but NetMQ allows us to send and receive more than just strings.
+如果你前面有讀過 [Introduction](http://netmq.readthedocs.org/en/latest/introduction/)，那你應該有看到範例中有使用到ReceiveString()和SendString()了，但NetMQ讓我們不只可以傳送和接收字串。
 
-In fact there are quite a few options available to you. Lets go through some of these options, shall we?
+實際上有不少可以使用的選項，讓我們來看其中的一部份吧！
 
 ---
 
 ## Receiving
 
-`IReceivingSocket` (which all the socket types inherit from) has two methods:
+`IReceivingSocket`(所有socket皆繼承自此介面)有兩個函式：
 
     :::csharp
     void Receive(ref Msg msg);
 
     bool TryReceive(ref Msg msg, TimeSpan timeout);
 
-The first blocks indefinitely until a message arrives, and the second allows control over a timeout (which may be zero).
+第一個函式會永遠阻塞直到訊息到達，第二個讓我們提供一個逾時時間(可能是零)。
 
-These methods offer great performance by reusing a `Msg` object. However much of the time you want a more convenient method to receive a `string`, `byte[]` and so on. NetMQ has many convenient methods provided as extension methods of `IReceivingSocket` in the `ReceivingSocketExtensions` class:
+這些函式依靠Msg物件的重覆使用提供我們很高的效能。然而大多時間你會想要更方便的函式來幫你接收`string`，`byte[]`等型別，NetMQ在`ReceivingSocketExtensions`類別中提供了很多`IReceivingSocket`型別的方便函式：
 
     :::csharp
     // Receiving byte[]
@@ -68,11 +68,11 @@ These methods offer great performance by reusing a `Msg` object. However much of
     bool TrySkipFrame(TimeSpan timeout)
     bool TrySkipFrame(TimeSpan timeout, out bool more)
 
-(Note the `this IReceivingSocket socket` argument is omitted from all of the above for readability.)
+注意為了可讀性`this IReceivingSocket socket`參數被省略掉了。
 
-These extension methods should meet most needs, but if they don't it's simple enough to write your own.
+這些擴充函式應符合大多數的需求，如果沒有的話你也可以很簡單的建立自己需要的。
 
-Here is an example of how one of the above extension methods is implemented, which may help you should you wish to write your own
+這裡是上述擴充函式之一實作的方式，可以幫助你建立自己的：
 
     :::csharp
     public static string ReceiveFrameString(this IReceivingSocket socket, Encoding encoding, out bool more)
@@ -92,14 +92,14 @@ Here is an example of how one of the above extension methods is implemented, whi
 
 ## Sending
 
-A `NetMQSocket` (which all the socket types inherit from) has a single send method:
+一個`NetMQSocket`(所有socket皆繼承至此)有一個send函式。
 
     :::csharp
     public virtual void Send(ref Msg msg, SendReceiveOptions options)
 
-But you will likely not actually use this method. Often it's more convenient to use one of the many extension methods for `IOutgoingSocket`.
+如果你不想使用這個函式，也可以用為了`IOutgoingSocket`建立的其它方便的擴充函式。
 
-These extension methods are shown below, one of these should give you what you want, but if it doesn't you simply need to write an extra extension method to suit your needs.
+下面列出這些擴充函式，應該夠你使用，若是不足也可以自行建立。
 
     :::csharp
     public static class OutgoingSocketExtensions
@@ -119,7 +119,7 @@ These extension methods are shown below, one of these should give you what you w
         ....
     }
 
-Here is an example of how one of the above extension methods is implemented, which may help you should you wish to write your own:
+這裡是上述擴充函式之一實作的方式，可以幫助你建立自己的：
 
     :::csharp
     public static void Send(this IOutgoingSocket socket, string message,

--- a/docs/request-response.md
+++ b/docs/request-response.md
@@ -1,31 +1,29 @@
 Request / Response
 =====
 
-Request / Response is perhaps the simplest of all the NetMQ socket combinations. That is not to say that `RequestSocket` and `ResponseSocket` MUST always be used together, that is not true at all, there are many occasions where you may want to use a particular NetMQ socket with another NetMQ socket. It is just that there are particular socket arrangements that happen to make a great deal of sense to use together, and `RequestSocket` with `ResponseSocket` is one such pattern.
+Request/Response 應該是所有`NetMQ` socket 組合中最簡單的一種了。這不是說RequestSocket和ResponseSocket必須總是一起使用，不是的，只是會有很多時候你想將某一種socket和另一種socket一起使用。有一些特定的socket的組合，剛好很適合在一起使用，而RequestSocket和ResponseSocket就是這樣的一個模式。
 
 The particular socket combinations that work well together are all covered in the <a href="http://zguide.zeromq.org/page:all" target="_blank">ZeroMQ guide</a>. Whilst it may seem a cop out to simply tell you to read more documentation somewhere else, there really is **NO BETTER** documentation on ZeroMQ/NetMQ than you will find in the <a href="http://zguide.zeromq.org/page:all" target="_blank">ZeroMQ guide</a>, as it covers well known patterns that have been proved in the field and are known to work well.
 
-Anyway we digress, this post is about Request/Response, so lets continue to look at that, shall we?
+我們有點離題了，無論如何，這篇文章是關於Request/Response，所以讓我們繼續吧！
 
 
 ## How it works
 
-Request / Response pattern is a configuration of two NetMQ sockets working harmoniously together. This combination of sockets are akin to what you might see when you make a web request. That is, you make a request and you expect a response.
+Request / Response模式是兩個NetMQ sockets協調工作的一個配置。這種組合類似於你在發出一個web request時看到的模式，也就是說，你提出請求，且期望得到回應。
 
-`RequestSocket` and `ResponseSocket` are **synchronous**, **blocking**, and throw exceptions if you try to read messages in the wrong order.
+RequestSocket 和 ResponseSocket 是**同步式**、**阻塞**的，如果你試著以錯誤的順序讀取訊息，你會得到一個例外。
 
-The way you should work with connected `RequestSocket` and `ResponseSocket`s is as follows:
+你應該使用`RequestSocket`和`ResponseSockets`連結的方式如下：
 
-1. Send a request message from a `RequestSocket`
-2. A `ResponseSocket` reads the request message
-3. The `ResponseSocket` sends the response message
-4. The `RequestSocket` receives the message from the `ResponseSocket`
+1. 從`RequestSocket`傳送訊息
+1. `ResponseSocket`讀取請求的訊息
+1. `ResponseSocket`傳送回應訊息
+1.  `RequestSocket`接收來自`ResponseSocket`的訊息
 
-Believe it or not you have more than likely already seen this example on numerous occasions as it is the simplest to demonstrate.
+不管你相信與否，你應該已看過這種範例很多次，因為它已是最簡單的示範了。
 
-Here is a small example where the `RequestSocket` and `ResponseSocket`s are both in the same process, but this could be easily split between two processes. We are keeping this as simple as possible for demonstration purposes.
-
-Example:
+這裡有一個小範例，其中`RequestSocket`和`ResponseSockets`都在同一個process中，但這可以很容易地放在兩個不同的process中。我們盡可能保持簡單以用於展示的目的。
 
     :::csharp
     using (var responseSocket = new ResponseSocket("@tcp://*:5555"))
@@ -47,21 +45,21 @@ Example:
         Console.ReadLine();
     }
 
-When you run this demo code you should see something like this:
+輸出如下：
 
 ![](Images/RequestResponse.png)
 
 
 ## Request/Response is blocking
 
-As stated above `RequestSocket` and `ResponseSocket` are blocking, which means any unexpected send or receive calls to **WILL** result in exceptions. Here is an example of just such an exception.
+如上所述，`RequestSocket`和`ResponseSocket`是阻塞的，這意味著任何意外的發送或接呼叫將會導致異常。這裡是這種例外的範例。
 
-In this example we try and call `Send()` twice from the `RequestSocket`
+這個範例中我們試著在`RequestSocket`中執行兩次Send()。
 
 ![](Images/RequestResponse2Sends.png)
 
-Or how about this example where we try and call `RecieveString()` twice, but there was only one message sent from the `RequestSocket`?
+或者這個範例，我們嘗試執行RecieveString()兩次，但只有一個訊息從RequestSocket傳送。
 
 ![](Images/RequestResponse2Receives.png)
 
-So be careful what you do with the Request/Response pattern, the devil is in the detail.
+所以要小心你用Request/Response模式做了什麼，魔鬼總在細節裡。

--- a/docs/router-dealer.md
+++ b/docs/router-dealer.md
@@ -12,9 +12,9 @@ From the [ZeroMQ guide](http://zguide.zeromq.org/page:all):
 >
 > Identities are a difficult concept to understand, but it's essential if you want to become a ZeroMQ expert. The ROUTER socket invents a random identity for each connection with which it works. If there are three REQ sockets connected to a ROUTER socket, it will invent three random identities, one for each REQ socket.
 
-So if we looked at a small example, let's say a `DealerSocket` socket has a 3-byte identity ABC. Internally, this means the `RouterSocket` socket keeps a hash table where it can search for ABC and find the TCP connection for the `DealerSocket` socket.
+所以我們來看一個較小的範例，我們有一個`DealerSocket`，帶有一個3 byte的示別碼"ABC"，在內部，這表示`RouterSocket`型別的socket內保有一個hash table，它可以搜尋"ABC"，並找到這一個`DealerSocket`的TCP連線。
 
-When we receive the message off the `DealerSocket` socket, we get three frames:
+當我們收到來自`DealerSocket`的訊息時，我們取得三個frames：
 
 ![](https://github.com/imatix/zguide/raw/master/images/fig28.png)
 
@@ -39,13 +39,13 @@ From [ZeroMQ guide, Identities and Addresses](http://zguide.zeromq.org/page:all#
 
 ## DealerSocket
 
-The NetMQ `DealerSocket` doesn't do anything particularly special, but what it does offer is the ability to work in a fully asynchronous manner.
+NetMQ的`DealerSocket`不做任何特別的事情，它提供的是以完全非同步方式工作的能力。
 
 Which if you recall was not something that other socket types could do, where the `ReceieveXXX` / `SendXXX` methods are blocking, and would also throw exceptions should you try to call
 things in the wrong order, or more than expected.
 
 
-The main selling point of a `DealerSocket` is its asynchronous abilities. Typically a `DealerSocket` would be used in conjunction with a `RouterSocket`, which is why we have decided to bundle the description of both these socket types into this documentation page.
+DealerSocket的主要賣點是它的非同步能力。通常，`DealerSocket`會與`RouterSocket`結合使用，這就是為什麼我們決定將這兩種socket型別的介紹放在一起。
 
 If you want to know more details about socket combinations involving `DealerSocket`s, then as ALWAYS the guide is your friend. In particular the <a href="http://zguide.zeromq.org/page:all#toc58" target="_blank">Request-Reply Combinations</a> page of the guide may be of interest.
 
@@ -54,10 +54,10 @@ If you want to know more details about socket combinations involving `DealerSock
 
 Time for an example. The best way to think of this example is summarized in the bullet points below:
 
-+ There is one server. It binds a `RouterSocket` which stores the inbound request's connection identity to work out how to route back the response message to the correct client socket.
-+ There are multiple clients, each in its own thread. These clients are `DealerSocket`s. The client socket will provide a fixed identity, such that the server (`RouterSocket`) will be able to use the identity supplied to correctly route back messages for this client.
+* 有一個伺服器，它綁定了一個`RouterSocket`，因此會儲存傳入的請求連線的示別資訊，所以可以正確的將訊息回應至client socket。
+* 有很多個client，每個client都屬於個別執行緒，這些client的型別是`DealerSocket`，這一個client socket會提供固定的示別碼，以讓伺服端(`DealerSocket`)可以正確的回應訊息。
 
-Ok so that is the overview. Let's see the code:
+程式碼如下：
 
     :::csharp
     public static void Main(string[] args)
@@ -163,7 +163,7 @@ Ok so that is the overview. Let's see the code:
         }
     }
 
-When run, this program should output something like this:
+執行後，輸出應如下所示：
 
 
     :::text
@@ -192,4 +192,4 @@ When run, this program should output something like this:
     REPLY client 1 back from server 08:05:56
     REPLY client 0 back from server 08:05:56
 
-Remember this is asynchronous code, so events may not occur in the order you logically expect.
+記住這是非同步的程式碼，所以事件的發生順序可能不如你所預期的。

--- a/docs/timer.md
+++ b/docs/timer.md
@@ -1,11 +1,8 @@
 Timer
 =====
+一個`NetMQTimer`讓你可以執行週期性的動作。Timer實體可以加至`NetMQPoller`中，且它的`Elapsed`事件會依指定的`Interval`及`Enabled`屬性值被觸發。
 
-A `NetMQTimer` allows actions to be performed periodically. Timer instances may be added to a `NetMQPoller`, and their
-`Elapsed` event will fire according to the specified `Interval` and `Enabled` property values.
-
-The event is raised on the poller's thread.
-
+下列事件在poller執行緒中被喚起。
     :::csharp
     var timer = new NetMQTimer(TimeSpan.FromMilliseconds(100));
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -1,22 +1,22 @@
 Transport Protocols
 ===
 
-NetMQ comes with support for three main protocols
+NetMQ支援三種主要的協定：
 
 + TCP (`tcp://`)
 + InProc (`inproc://`)
 + PGM (`pgm://`) &mdash; requires MSMQ and running as administrator
 
-Each of these is discussed below.
+下面會一一介紹。
 
 
 ## TCP
 
-TCP is the most commonly used protocol. As such, most example code will use TCP.
+TCP是最常用到的協定，因此，大部份的程式碼會使用TCP展示。
 
 ### Example
 
-Here is another trivial example:
+又一個簡單的範例：
 
     :::csharp
     using (var server = new ResponseSocket())
@@ -38,7 +38,7 @@ Here is another trivial example:
         Console.WriteLine("Received {0}", message);
     }
 
-This code outputs:
+輸出：
 
     :::text
     Sending Hello
@@ -48,30 +48,31 @@ This code outputs:
 
 ### Address format
 
-Notice the format of the address string passed to `Bind()` and `Connect()`. For TCP connections, it will resemble:
+注意位址格式字串會傳送給`Bind()`及`Connect()`函式。
+在TCP連線中，它會被組成：
 
     :::text
     tcp://*:5555
 
-This is made up of three parts:
+這由三個部份構成：
 
-1. The protocol (`tcp`)
-2. The host (an IP address, host name, or the wildcard `*` to match any)
-3. The port number (`5555`)
+ 1. 協議（tcp）
+ 2. 主機（IP地址，主機名或匹配`"*"`的wildcard）
+ 3. 埠號（5555）
 
 
 ## InProc
 
-InProc (in-process) allows you to connect sockets running with the same process. This is actually quite useful, and you may do this for several reasons:
+InProc (in-process)讓你可以在同一個process中用sockets連線溝通，這很有用，有幾個理由：
 
-+ To do away with shared state/locks. When you send data down the wire (socket) there is no shared state to worry about. Each end of the socket will have its own copy.
-+ Being able to communicate between very disparate parts of a system.
++ 取消共享狀態/鎖。當你傳送資料至socket時不需要擔心共享狀態。Socket的每一端都有自己的副本。
++ 能夠在系統的不同的部分之間進行通信。
 
-NetMQ comes with several components that use InProc, such the as [Actor model](actor.md) and [Devices](devices.md), which are discussed in their relevant documentation pages.
+NetMQ提供了幾個使用InProc的組件，例如[Actor模型](actor.md)和Devices，在相關文件中會再討論。
 
 ### Example
 
-For now let's demonstrate a simple InProc arrangement by sending a string (for simplicity) between two threads.
+現在讓我們通過在兩個執行緒之間傳送一個字串（為了簡單起見）展示一個簡單的InProc。
 
     :::csharp
     using (var end1 = new PairSocket())
@@ -95,7 +96,7 @@ For now let's demonstrate a simple InProc arrangement by sending a string (for s
         Task.WaitAll(new[] { end1Task, end2Task });
     }
 
-This outputs something similar to:
+輸出：
 
     :::text
     ThreadId = 12
@@ -105,15 +106,16 @@ This outputs something similar to:
 
 ### Address format
 
-Notice the format of the address string passed to `Bind()` and `Connect()`. For InProc connections, it will resemble:
+注意位址格式字串會傳送給`Bind()`及`Connect()`函式。
+在InProc連線中，它會被組成：
 
     :::text
     inproc://inproc-demo
 
-This is made up of two parts:
+這由兩個部份構成：
 
-1. The protocol (`inproc`)
-2. The identifier (`inproc-demo` which can be any string, uniquely identified within the scope of the process)
+1. 協定(inproc)
+2. 辨識名稱（inproc-demo可以是任何字串，在process範圍內是唯一的名稱）
 
 
 ## PGM

--- a/docs/xpub-xsub.md
+++ b/docs/xpub-xsub.md
@@ -1,9 +1,9 @@
 XPub / XSub
 =====
 
-The [Pub/Sub](pub-sub.md) pattern is great for multiple subscribers and a single publisher, but if you need multiple publishers then the XPub/XSub pattern will be of interest.
+[Pub/Sub](pub-sub.md)適用於多個訂閱者和單一發佈者，但是如果您需要多個發佈者，那麼XPub / XSub模式會比較有趣。
 
-XPub/XSub can also assist with the so-called _dynamic discovery problem_. From the [ZeroMQ guide](http://zguide.zeromq.org/page:all#The-Dynamic-Discovery-Problem):
+XPub / XSub還可以協助所謂的 _dynamic discovery problem_. From the [ZeroMQ guide](http://zguide.zeromq.org/page:all#The-Dynamic-Discovery-Problem):
 
 > One of the problems you will hit as you design larger distributed architectures is discovery. That is, how do pieces know about each other? It's especially difficult if pieces come and go, so we call this the "dynamic discovery problem".
 >
@@ -26,7 +26,7 @@ XPub/XSub can also assist with the so-called _dynamic discovery problem_. From t
 
 ## An Example
 
-So now that we have gone through why you would use XPub/XSub, lets now look at an example that follows the above description. It is broken down into three components:
+所以現在我們已經了解了為什麼要使用XPub / XSub，現在讓我們看一個依上述描述的範例。分為三個部分：
 
 + Publisher
 + Intermediary
@@ -34,7 +34,7 @@ So now that we have gone through why you would use XPub/XSub, lets now look at a
 
 ### Publisher
 
-It can be seen that the `PublisherSocket` connnects to the `XSubscriberSocket` address
+可以看到`PublisherSocket`連線到`XSubscriberSocket`的位址。
 
     :::csharp
     using (var pubSocket = new PublisherSocket(">tcp://127.0.0.1:5678"))
@@ -65,7 +65,7 @@ It can be seen that the `PublisherSocket` connnects to the `XSubscriberSocket` a
 
 ### Intermediary
 
-The intermediary is responsible for relaying the messages bidirectionally between the `XPublisherSocket` and the `XSubscriberSocket`. NetMQ provides a `Proxy` class which makes this simple.
+`Intermediary`負責在`XPublisherSocket`和`XSubscriberSocket`之間雙向地中繼訊息。`NetMQ`提供了一個使用簡單的代理類別。
 
     :::csharp
     using (var xpubSocket = new XPublisherSocket("@tcp://127.0.0.1:1234"))
@@ -83,7 +83,7 @@ The intermediary is responsible for relaying the messages bidirectionally betwee
 
 ### Subscriber
 
-It can be seen that the `SubscriberSocket` connects to the `XPublisherSocket` address:
+可以看到`SubscriberSocket`連線到`XPublisherSocket`的位址。
 
     :::csharp
     string topic = /* ... */; // one of "TopicA" or "TopicB"
@@ -103,8 +103,8 @@ It can be seen that the `SubscriberSocket` connects to the `XPublisherSocket` ad
     }
 
 
-When run, it should look something like this:
+執行時，可以看到如下列輸出：
 
 ![](Images/XPubXSubDemo.png)
 
-Unlike the [Pub/Sub](pub-sub.md) pattern, we can have an arbitrary number of publishers and subscribers.
+不像[Pub/Sub](pub-sub.md)模式，我們可以有不定數量的發佈者及訂閱者。


### PR DESCRIPTION
Hi,

I want to help the translation for the documents, but not sure in this way.

According to the http://docs.readthedocs.io/en/latest/localization.html#localization-of-documentation, it looks like I need to have a project there, then the main doc project https://netmq.readthedocs.io/en/latest/ can refer to other translated project, therefore I created an project in https://readthedocs.org/projects/netmq-traditional-chinese/.

Let me know if I done it in the wrong way, thanks.