### PR TITLE
Some changes to poller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ _ReSharper*/
 
 #Ignore lock files
 *.lock.json
+.idea/

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -570,7 +570,7 @@ namespace NetMQ
         /// </remarks>
         public void Dispose()
         {
-            if (Interlocked.CompareExchange(ref m_disposeState, (int)DisposeState.Disposing, (int)DisposeState.Undisposed) == (int)DisposeState.Disposing)
+            if (Interlocked.CompareExchange(ref m_disposeState, (int)DisposeState.Disposing, (int)DisposeState.Undisposed) != (int)DisposeState.Undisposed)
                 return;
 
             // If this poller is already started, signal the polling thread to stop

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -572,6 +572,11 @@ namespace NetMQ
         /// </remarks>
         public void Dispose()
         {
+            // Attempting to dispose from the poller thread would cause a deadlock.
+            // Throw an exception to improve the debugging experience.
+            if (IsPollerThread)
+                throw new InvalidOperationException("Cannot dispose poller from the poller thread.");
+
             if (Interlocked.CompareExchange(ref m_disposeState, (int)DisposeState.Disposing, (int)DisposeState.Undisposed) != (int)DisposeState.Undisposed)
                 return;
 

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -296,8 +296,9 @@ namespace NetMQ
         #region Start / Stop
 
         /// <summary>
-        /// Runs the poller in a background thread, returning immediately.
+        /// Runs the poller in a background thread, returning once the poller has started.
         /// </summary>
+        /// <param name="threadName">The optional thread name to use. If unspecified, <c>"NetMQPollerThread"</c> is used.</param>
         public void RunAsync()
         {
             CheckDisposed();

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -158,6 +158,12 @@ namespace NetMQ
         /// </summary>
         public bool IsRunning => m_switch.Status;
 
+#if NET35
+        private bool IsPollerThread => m_pollerThread != Thread.CurrentThread;
+#else
+        private bool IsPollerThread => !m_isSchedulerThread.Value;
+#endif
+
         #region Add / Remove
 
         /// <summary>
@@ -475,11 +481,7 @@ namespace NetMQ
             m_stopSignaler.RequestStop();
 
             // If 'stop' was requested from the scheduler thread, we cannot block
-#if NET35
-            if (m_pollerThread != Thread.CurrentThread)
-#else
-            if (!m_isSchedulerThread.Value)
-#endif
+            if (IsPollerThread)
             {
                 m_switch.WaitForOff();
                 Debug.Assert(!IsRunning);

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -304,14 +304,25 @@ namespace NetMQ
         /// <summary>
         /// Runs the poller in a background thread, returning once the poller has started.
         /// </summary>
-        /// <param name="threadName">The optional thread name to use. If unspecified, <c>"NetMQPollerThread"</c> is used.</param>
+        /// <remarks>
+        /// The created thread is named <c>"NetMQPollerThread"</c>. Use <see cref="RunAsync(string)"/> to specify the thread name.
+        /// </remarks>
         public void RunAsync()
+        {
+            RunAsync("NetMQPollerThread");
+        }
+
+        /// <summary>
+        /// Runs the poller in a background thread, returning once the poller has started.
+        /// </summary>
+        /// <param name="threadName">The thread name to use.</param>
+        public void RunAsync(string threadName)
         {
             CheckDisposed();
             if (IsRunning)
                 throw new InvalidOperationException("NetMQPoller is already running");
 
-            var thread = new Thread(Run) { Name = "NetMQPollerThread" };
+            var thread = new Thread(Run) { Name = threadName };
             thread.Start();
 
             m_switch.WaitForOn();

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -565,6 +565,9 @@ namespace NetMQ
         /// <summary>
         /// Stops and disposes the poller. The poller may not be used once disposed.
         /// </summary>
+        /// <remarks>
+        /// Note that you cannot dispose the poller on the poller's thread. Doing so results in a deadlock.
+        /// </remarks>
         public void Dispose()
         {
             if (Interlocked.CompareExchange(ref m_disposeState, (int)DisposeState.Disposing, 0) == (int)DisposeState.Disposing)

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -570,7 +570,7 @@ namespace NetMQ
         /// </remarks>
         public void Dispose()
         {
-            if (Interlocked.CompareExchange(ref m_disposeState, (int)DisposeState.Disposing, 0) == (int)DisposeState.Disposing)
+            if (Interlocked.CompareExchange(ref m_disposeState, (int)DisposeState.Disposing, (int)DisposeState.Undisposed) == (int)DisposeState.Disposing)
                 return;
 
             // If this poller is already started, signal the polling thread to stop


### PR DESCRIPTION
- Update docs, as per #619 
- Throw if disposing poller from poller thread, as per #619 
- Ignore .idea folder
- Allow specifying thread name in new `NetMQPoller.RunAsync` overload
- Fix minor double-dispose bug in poller

Combined diff is hard to read. Individual diffs should be clear. Please review before merge. Happy to remove commits as needed.