### PR TITLE
NetMQConfig tweaks

### DIFF
--- a/src/NetMQ/NetMQConfig.cs
+++ b/src/NetMQ/NetMQConfig.cs
@@ -25,8 +25,14 @@ namespace NetMQ
         {
             get
             {
+                // Optimise for the case where the value is non-null, and we don't need to acquire the lock
+                var c = s_ctx;
+                if (c != null)
+                    return c;
+
                 lock (s_sync)
                 {
+                    // Check again whether it's null now that we have the lock
                     if (s_ctx == null)
                     {
                         s_ctx = new Ctx();

--- a/src/NetMQ/NetMQConfig.cs
+++ b/src/NetMQ/NetMQConfig.cs
@@ -68,9 +68,11 @@ namespace NetMQ
         /// </summary>
         /// <remarks>
         /// This also affects the termination of the socket's context.
+        /// <para />
         /// -1: Specifies infinite linger period. Pending messages shall not be discarded after the socket is closed;
         /// attempting to terminate the socket's context shall block until all pending messages have been sent to a peer.
-        /// 0: The default value of 0 specifies an no linger period. Pending messages shall be discarded immediately when the socket is closed.
+        /// <para />
+        /// 0: The default value of <see cref="TimeSpan.Zero"/> specifies no linger period. Pending messages shall be discarded immediately when the socket is closed.
         /// Positive values specify an upper bound for the linger period. Pending messages shall not be discarded after the socket is closed;
         /// attempting to terminate the socket's context shall block until either all pending messages have been sent to a peer,
         /// or the linger period expires, after which any pending messages shall be discarded.
@@ -163,11 +165,10 @@ namespace NetMQ
         [Obsolete("Use Cleanup method")]
         public static void ContextTerminate(bool block = true)
         {
-
         }
 
         /// <summary>
-        /// /// Method is obsolete, context created automatically
+        /// Method is obsolete, context created automatically
         /// </summary>
         [Obsolete("Context is created automatically")]
         public static void ContextCreate(bool block = false)

--- a/src/NetMQ/NetMQConfig.cs
+++ b/src/NetMQ/NetMQConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 using NetMQ.Core;
 
 namespace NetMQ
@@ -9,7 +10,7 @@ namespace NetMQ
     {
         private static TimeSpan s_linger;
 
-        private static Ctx s_ctx;
+        [CanBeNull] private static Ctx s_ctx;
         private static int s_threadPoolSize = Ctx.DefaultIOThreads;
         private static int s_maxSockets = Ctx.DefaultMaxSockets;
         private static readonly object s_sync;


### PR DESCRIPTION
- Annotate nullable field
- Avoid lock (double checked locking)
- Documentation tweaks

One question that might improve this PR. What is the expected `TimeSpan` value for infinite linger? The `System.Threading.Timeout` class has `InfiniteTimeSpan = new TimeSpan(0, 0, 0, 0, Timeout.Infinite)`, which basically is a `TimeSpan` with -1 milliseconds. This constant is not available in `net35`, but at least our docs should explain how to pass `-1` in `TimeSpan` form.

If someone can verify this is correct I'll update the PR.