### PR TITLE
NetMQPoller throws when inner socket disposed

### DIFF
--- a/src/NetMQ.Tests/NetMQPollerTest.cs
+++ b/src/NetMQ.Tests/NetMQPollerTest.cs
@@ -403,6 +403,28 @@ namespace NetMQ.Tests
         }
 
         [Test]
+        public void RemoveThrowsIfSocketAlreadyDisposed()
+        {
+            var socket = new RouterSocket();
+
+            var poller = new NetMQPoller { socket };
+
+            // Dispose the socket.
+            // It is incorrect to have a disposed socket in a poller.
+            // Disposed sockets can throw into the poller's thread.
+            socket.Dispose();
+
+            // Remove throws if the removed socket
+            var ex = Assert.Throws<ArgumentException>(() => poller.Remove(socket));
+
+            Assert.True(ex.Message.StartsWith("Must not be disposed."));
+            Assert.AreEqual("socket", ex.ParamName);
+
+            // Still dispose it. It throws after cleanup.
+            Assert.Throws<NetMQException>(() => poller.Dispose());
+        }
+
+        [Test]
         public void DisposeThrowsIfSocketAlreadyDisposed()
         {
             var socket = new RouterSocket();

--- a/src/NetMQ.Tests/NetMQPollerTest.cs
+++ b/src/NetMQ.Tests/NetMQPollerTest.cs
@@ -403,6 +403,24 @@ namespace NetMQ.Tests
         }
 
         [Test]
+        public void DisposeThrowsIfSocketAlreadyDisposed()
+        {
+            var socket = new RouterSocket();
+
+            var poller = new NetMQPoller { socket };
+
+            // Dispose the socket.
+            // It is incorrect to have a disposed socket in a poller.
+            // Disposed sockets can throw into the poller's thread.
+            socket.Dispose();
+
+            // Dispose throws if a polled socket is disposed
+            var ex = Assert.Throws<NetMQException>(() => poller.Dispose());
+
+            Assert.AreEqual("Invalid state detected: NetMQPoller contains a disposed NetMQSocket. Sockets must be either removed before being disposed, or disposed after the poller is disposed.", ex.Message);
+        }
+
+        [Test]
         public void SimpleTimer()
         {
             // TODO it is not really clear what this test is actually testing -- maybe split it into a few smaller tests

--- a/src/NetMQ.Tests/NetMQPollerTest.cs
+++ b/src/NetMQ.Tests/NetMQPollerTest.cs
@@ -403,6 +403,28 @@ namespace NetMQ.Tests
         }
 
         [Test]
+        public void AddThrowsIfSocketAlreadyDisposed()
+        {
+            var poller = new NetMQPoller();
+
+            var socket = new RouterSocket();
+
+            // Dispose the socket.
+            // It is incorrect to have a disposed socket in a poller.
+            // Disposed sockets can throw into the poller's thread.
+            socket.Dispose();
+
+            // Adding a disposed socket throws
+            var ex = Assert.Throws<ArgumentException>(() => poller.Add(socket));
+
+            Assert.True(ex.Message.StartsWith("Must not be disposed."));
+            Assert.AreEqual("socket", ex.ParamName);
+
+            // Still dispose it. It throws after cleanup.
+            Assert.Throws<NetMQException>(() => poller.Dispose());
+        }
+
+        [Test]
         public void RemoveThrowsIfSocketAlreadyDisposed()
         {
             var socket = new RouterSocket();

--- a/src/NetMQ/Core/Utils/StopSignaler.cs
+++ b/src/NetMQ/Core/Utils/StopSignaler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using NetMQ.Sockets;
 
 namespace NetMQ.Core.Utils
@@ -7,6 +8,7 @@ namespace NetMQ.Core.Utils
     {
         private readonly PairSocket m_writer;
         private readonly PairSocket m_reader;
+        private int m_isDisposed;
 
         public StopSignaler()
         {
@@ -24,8 +26,12 @@ namespace NetMQ.Core.Utils
 
         NetMQSocket ISocketPollable.Socket => m_reader;
 
+        public bool IsDisposed => m_isDisposed != 0;
+
         public void Dispose()
         {
+            if (Interlocked.CompareExchange(ref m_isDisposed, 1, 0) != 0)
+                return;
             m_reader.Dispose();
             m_writer.Dispose();
         }

--- a/src/NetMQ/ISocketPollable.cs
+++ b/src/NetMQ/ISocketPollable.cs
@@ -12,5 +12,10 @@ namespace NetMQ
         /// </summary>
         [NotNull]
         NetMQSocket Socket { get; }
+
+        /// <summary>
+        /// Gets whether the object has been disposed.
+        /// </summary>
+        bool IsDisposed { get; }
     }
 }

--- a/src/NetMQ/NetMQActor.cs
+++ b/src/NetMQ/NetMQActor.cs
@@ -140,6 +140,8 @@ namespace NetMQ
         private readonly EventDelegator<NetMQActorEventArgs> m_receiveEvent;
         private readonly EventDelegator<NetMQActorEventArgs> m_sendEvent;
 
+        private int m_isDisposed;
+
         #region Creating Actor
 
         private NetMQActor(PairSocket self, PairSocket shim, [NotNull] IShimHandler shimHandler)
@@ -302,9 +304,7 @@ namespace NetMQ
 
         #region Disposing
 
-        /// <summary>
-        /// Release any contained resources.
-        /// </summary>
+        /// <inheritdoc />
         public void Dispose()
         {
             Dispose(true);
@@ -317,6 +317,8 @@ namespace NetMQ
         /// <param name="disposing">true if managed resources are to be released</param>
         protected virtual void Dispose(bool disposing)
         {
+            if (Interlocked.CompareExchange(ref m_isDisposed, 1, 0) != 0)
+                return;
             if (!disposing)
                 return;
 
@@ -329,6 +331,9 @@ namespace NetMQ
             m_sendEvent.Dispose();
             m_receiveEvent.Dispose();
         }
+
+        /// <inheritdoc />
+        public bool IsDisposed => m_isDisposed != 0;
 
         #endregion
     }

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using JetBrains.Annotations;
 using NetMQ.Sockets;
 
@@ -246,6 +247,7 @@ namespace NetMQ
 
         [CanBeNull] private string m_boundTo;
         [CanBeNull] private string m_hostName;
+        private int m_isDisposed;
 
         /// <summary>
         /// Create a new NetMQBeacon.
@@ -459,11 +461,17 @@ namespace NetMQ
             return true;
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
+            if (Interlocked.CompareExchange(ref m_isDisposed, 1, 0) != 0)
+                return;
             m_actor.Dispose();
             m_receiveEvent.Dispose();
         }
+
+        /// <inheritdoc />
+        public bool IsDisposed => m_isDisposed != 0;
     }
 
     /// <summary>

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -600,6 +600,7 @@ namespace NetMQ
         /// <remarks>
         /// Note that you cannot dispose the poller on the poller's thread. Doing so results in a deadlock.
         /// </remarks>
+        /// <exception cref="NetMQException">A socket in the poller has been disposed.</exception>
         public void Dispose()
         {
             // Attempting to dispose from the poller thread would cause a deadlock.
@@ -625,7 +626,11 @@ namespace NetMQ
 #endif
 
             foreach (var socket in m_sockets)
+            {
+                if (socket.IsDisposed)
+                    throw new NetMQException($"Invalid state detected: {nameof(NetMQPoller)} contains a disposed {nameof(NetMQSocket)}. Sockets must be either removed before being disposed, or disposed after the poller is disposed.");
                 socket.EventsChanged -= OnSocketEventsChanged;
+            }
 
             m_disposeState = (int)DisposeState.Disposed;
         }

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -205,10 +205,21 @@ namespace NetMQ
         {
             if (socket == null)
                 throw new ArgumentNullException(nameof(socket));
+            if (socket.IsDisposed)
+                throw new ArgumentException("Must not be disposed.", nameof(socket));
             CheckDisposed();
 
             Run(() =>
             {
+                // Ensure the socket wasn't disposed while this code was waiting to be run on the poller thread
+                if (socket.IsDisposed)
+                    throw new InvalidOperationException(
+                        $"{nameof(NetMQPoller)}.{nameof(Remove)} was called from a non-poller thread, " +
+                        "so ran asynchronously. " +
+                        $"The {socket.GetType().Name} being removed was disposed while the remove " +
+                        $"operation waited to start on the poller thread. Use {nameof(RemoveAndDispose)} " +
+                        "instead, which will enqueue the remove and dispose to happen on the poller thread.");
+
                 socket.Socket.EventsChanged -= OnSocketEventsChanged;
                 m_sockets.Remove(socket.Socket);
                 m_isPollSetDirty = true;
@@ -219,10 +230,21 @@ namespace NetMQ
         {
             if (socket == null)
                 throw new ArgumentNullException(nameof(socket));
+            if (socket.IsDisposed)
+                throw new ArgumentException("Must not be disposed.", nameof(socket));
             CheckDisposed();
 
             Run(() =>
             {
+                // Ensure the socket wasn't disposed while this code was waiting to be run on the poller thread
+                if (socket.IsDisposed)
+                    throw new InvalidOperationException(
+                        $"{nameof(NetMQPoller)}.{nameof(RemoveAndDispose)} was called from a non-poller thread, " +
+                        "so ran asynchronously. " +
+                        $"The {socket.GetType().Name} being removed was disposed while the remove " +
+                        $"operation waited to start on the poller thread. When using {nameof(RemoveAndDispose)} " +
+                        "you should not dispose the pollable object .");
+
                 socket.Socket.EventsChanged -= OnSocketEventsChanged;
                 m_sockets.Remove(socket.Socket);
                 m_isPollSetDirty = true;

--- a/src/NetMQ/NetMQQueue.cs
+++ b/src/NetMQ/NetMQQueue.cs
@@ -62,6 +62,7 @@ namespace NetMQ
         }
 
         NetMQSocket ISocketPollable.Socket => m_reader;
+        public bool IsDisposed { get; }
 
         /// <summary>
         /// Try to dequeue an item from the queue. Dequeueing and item is not thread safe.

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -48,27 +48,27 @@ namespace NetMQ
 
             if (!string.IsNullOrEmpty(connectionString))
             {
-                var endpoints =
-                    connectionString.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
-                        .Select(a => a.Trim()).Where(a=> !string.IsNullOrEmpty(a));
+                var endpoints = connectionString
+                    .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(a => a.Trim())
+                    .Where(a => !string.IsNullOrEmpty(a));
 
-                foreach (string endpoint in endpoints)
+                foreach (var endpoint in endpoints)
                 {
-                    if (endpoint[0] == '@')
+                    switch (endpoint[0])
                     {
-                        Bind(endpoint.Substring(1));
-                    }
-                    else if (endpoint[0] == '>')
-                    {
-                        Connect(endpoint.Substring(1));
-                    }
-                    else if (defaultAction == DefaultAction.Connect)
-                    {
-                        Connect(endpoint);
-                    }
-                    else
-                    {
-                        Bind(endpoint);
+                        case '@':
+                            Bind(endpoint.Substring(1));
+                            break;
+                        case '>':
+                            Connect(endpoint.Substring(1));
+                            break;
+                        default:
+                            if (defaultAction == DefaultAction.Connect)
+                                Connect(endpoint);
+                            else
+                                Bind(endpoint);
+                            break;
                     }
                 }
             }

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using JetBrains.Annotations;
 using NetMQ.Core;
 #if NET40
@@ -22,7 +23,7 @@ namespace NetMQ
 
         private EventHandler<NetMQSocketEventArgs> m_receiveReady;
         private EventHandler<NetMQSocketEventArgs> m_sendReady;
-        private bool m_isClosed;
+        private int m_isClosed;
 
         internal enum DefaultAction
         {
@@ -244,10 +245,8 @@ namespace NetMQ
         /// <summary>Closes this socket, rendering it unusable. Equivalent to calling <see cref="Dispose()"/>.</summary>
         public void Close()
         {
-            if (m_isClosed)
+            if (Interlocked.CompareExchange(ref m_isClosed, 1, 0) != 0)
                 return;
-
-            m_isClosed = true;
 
             m_socketHandle.CheckDisposed();
             m_socketHandle.Close();
@@ -333,7 +332,7 @@ namespace NetMQ
         /// <param name="events">the given PollEvents that dictates when of the two events to raise</param>
         internal void InvokeEvents(object sender, PollEvents events)
         {
-            if (m_isClosed)
+            if (m_isClosed != 0)
                 return;
 
             m_socketEventArgs.Init(events);
@@ -528,6 +527,9 @@ namespace NetMQ
 
             Close();
         }
+
+        /// <inheritdoc />
+        public bool IsDisposed => m_isClosed != 0;
 
         #endregion
     }


### PR DESCRIPTION
This PR addresses #663. That issue discusses throwing when removing a disposed socket (both immediately and asynchronously). It is invalid for a disposed socket to exist within a poller at any time, so we can make additional checks.

There are three cases covered here:

- Remove a disposed ISocketPollable
- Add a disposed ISocketPollable (seems pretty unlikely, but it's cheap to check)
- Dispose a NetMQPoller that contains a disposed ISocketPollable

Corresponding unit tests have been added.