### PR TITLE
Support for Universal Windows Platform apps

### DIFF
--- a/src/NetMQ/Core/Transports/Pgm/PgmSocket.cs
+++ b/src/NetMQ/Core/Transports/Pgm/PgmSocket.cs
@@ -98,7 +98,7 @@ namespace NetMQ.Core.Transports.Pgm
                 Debug.WriteLine(xMsg);
                 // If running on Microsoft Windows, suggest to the developer that he may need to install MSMQ in order to get PGM socket support.
 
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || UAP
                 bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #else
                 PlatformID p = Environment.OSVersion.Platform;

--- a/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
@@ -102,7 +102,7 @@ namespace NetMQ.Core.Transports.Tcp
             }
             else if (!IPAddress.TryParse(addrStr, out ipAddress))
             {
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || UAP
                 var availableAddresses = Dns.GetHostEntryAsync(addrStr).Result.AddressList;
 #else
                 var availableAddresses = Dns.GetHostEntry(addrStr).AddressList;

--- a/src/NetMQ/Core/Utils/Clock.cs
+++ b/src/NetMQ/Core/Utils/Clock.cs
@@ -39,7 +39,7 @@ namespace NetMQ.Core.Utils
         /// </summary>
         private static long s_lastTime;
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
         /// <summary>
         /// This flag indicates whether the rdtsc instruction is supported on this platform.
         /// </summary>
@@ -48,7 +48,7 @@ namespace NetMQ.Core.Utils
 
         static Clock()
         {
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
             try
             {
                 if (Environment.OSVersion.Platform == PlatformID.Win32NT ||
@@ -109,7 +109,7 @@ namespace NetMQ.Core.Utils
         /// </summary>
         public static long Rdtsc()
         {
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || UAP
             return 0;
 #else
             return s_rdtscSupported ? (long)Opcode.Rdtsc() : 0;

--- a/src/NetMQ/Core/Utils/OpCode.cs
+++ b/src/NetMQ/Core/Utils/OpCode.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD1_3
+﻿#if !NETSTANDARD1_3 && !UAP
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;

--- a/src/NetMQ/Core/Utils/PollerBase.cs
+++ b/src/NetMQ/Core/Utils/PollerBase.cs
@@ -88,7 +88,7 @@ namespace NetMQ.Core.Utils
         {
             get
             {
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || UAP
                 return Volatile.Read(ref m_load);
 #else
                 Thread.MemoryBarrier();

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>NetMQ</AssemblyTitle>
     <VersionPrefix>4.0.0.0</VersionPrefix>
     <!--monoandroid60;xamarinios10-->
-    <TargetFrameworks>netstandard1.3;net35;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net35;net40;uap10.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>NetMQ</AssemblyName>
     <AssemblyOriginatorKeyFile>./NetMQ.snk</AssemblyOriginatorKeyFile>
@@ -19,11 +19,31 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/zeromq/netmq</RepositoryUrl>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.3.0</NetStandardImplicitPackageVersion>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'uap10.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'uap10.0' ">1.3.0</NetStandardImplicitPackageVersion>
 	<IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
+    <NugetTargetMoniker>UAP,Version=v10.0</NugetTargetMoniker>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetFrameworkIdentifier>.NETCore</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <DefineConstants>UAP</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0'">
+    <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
+    <None Include="project.json" />
+    <PackageReference Include="microsoft.netcore.UniversalWindowsPlatform">
+      <Version>5.3.3</Version>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AsyncIO" Version="0.1.26" />
@@ -36,6 +56,12 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.1.0" />
     <PackageReference Include="System.Threading" Version="4.0.11" />
     <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
+    <PackageReference Include="System.Net.NetworkInformation" Version="4.1.0" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.1.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
   </ItemGroup>

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -295,7 +295,7 @@ namespace NetMQ
 
                 try
                 {
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || UAP
                     return m_hostName = Dns.GetHostEntryAsync(boundTo).Result.HostName;
 #else
                     return m_hostName = Dns.GetHostEntry(boundTo).HostName;

--- a/src/NetMQ/NetMQException.cs
+++ b/src/NetMQ/NetMQException.cs
@@ -2,7 +2,7 @@ using System;
 using System.Net.Sockets;
 using System.Runtime.Serialization;
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
 using System.Security.Permissions;
 #endif
 
@@ -14,7 +14,7 @@ namespace NetMQ
     /// <summary>
     /// Base class for custom exceptions within the NetMQ library.
     /// </summary>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
     [Serializable]
 #endif
     public class NetMQException : Exception
@@ -36,7 +36,7 @@ namespace NetMQ
             : base(message, innerException)
         {}
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
 
         /// <summary>Constructor for serialisation.</summary>
         protected NetMQException(SerializationInfo info, StreamingContext context)
@@ -173,7 +173,7 @@ namespace NetMQ
     /// <summary>
     /// AddressAlreadyInUseException is a NetMQException that is used within SocketBase.Bind to signal an address-conflict.
     /// </summary>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
     [Serializable]
 #endif
     public class AddressAlreadyInUseException : NetMQException
@@ -197,7 +197,7 @@ namespace NetMQ
         {
         }
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
         /// <summary>Constructor for serialisation.</summary>
         protected AddressAlreadyInUseException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -209,7 +209,7 @@ namespace NetMQ
     /// <summary>
     /// EndpointNotFoundException is a NetMQException that is used within Ctx.FindEndpoint to signal a failure to find a specified address.
     /// </summary>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
     [Serializable]
 #endif
     public class EndpointNotFoundException : NetMQException
@@ -241,7 +241,7 @@ namespace NetMQ
         {
         }
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
         /// <summary>Constructor for serialisation.</summary>
         protected EndpointNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -254,7 +254,7 @@ namespace NetMQ
     /// TerminatingException is a NetMQException that is used within SocketBase and Ctx to signal
     /// that you're making the mistake of trying to do further work after terminating the message-queueing system.
     /// </summary>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
     [Serializable]
 #endif
     public class TerminatingException : NetMQException
@@ -281,7 +281,7 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
         /// <summary>Constructor for serialisation.</summary>
         protected TerminatingException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -293,7 +293,7 @@ namespace NetMQ
     /// <summary>
     /// InvalidException is a NetMQException that is used within the message-queueing system to signal invalid value errors.
     /// </summary>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
     [Serializable]
 #endif
     public class InvalidException : NetMQException
@@ -324,7 +324,7 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
         /// <summary>Constructor for serialisation.</summary>
         protected InvalidException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -336,7 +336,7 @@ namespace NetMQ
     /// <summary>
     /// FaultException is a NetMQException that is used within the message-queueing system to signal general fault conditions.
     /// </summary>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
     [Serializable]
 #endif
     public class FaultException : NetMQException
@@ -367,7 +367,7 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
         /// <summary>Constructor for serialisation.</summary>
         protected FaultException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -380,7 +380,7 @@ namespace NetMQ
     /// ProtocolNotSupportedException is a NetMQException that is used within the message-queueing system to signal
     /// mistakes in properly utilizing the communications protocols.
     /// </summary>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
     [Serializable]
 #endif
     public class ProtocolNotSupportedException : NetMQException
@@ -411,7 +411,7 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
         /// <summary>Constructor for serialisation.</summary>
         protected ProtocolNotSupportedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -424,7 +424,7 @@ namespace NetMQ
     /// HostUnreachableException is an Exception that is used within the message-queueing system
     /// to signal failures to communicate with a host.
     /// </summary>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
     [Serializable]
 #endif
     public class HostUnreachableException : NetMQException
@@ -455,7 +455,7 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
         /// <summary>Constructor for serialisation.</summary>
         protected HostUnreachableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -468,7 +468,7 @@ namespace NetMQ
     /// FiniteStateMachineException is an Exception that is used within the message-queueing system
     /// to signal errors in the send/receive order with request/response sockets.
     /// </summary>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
     [Serializable]
 #endif
     public class FiniteStateMachineException : NetMQException
@@ -499,7 +499,7 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_3
+#if !NETSTANDARD1_3 && !UAP
         /// <summary>Constructor for serialisation.</summary>
         protected FiniteStateMachineException(SerializationInfo info, StreamingContext context)
             : base(info, context)

--- a/src/NetMQ/TaskThread.cs
+++ b/src/NetMQ/TaskThread.cs
@@ -1,0 +1,124 @@
+﻿#if UAP
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+
+namespace System.Threading
+{
+    public delegate void ParameterizedThreadStart(object obj);
+    public delegate void ThreadStart();
+
+    public class ThreadStateException : Exception
+    {
+        public ThreadStateException(string message = "", Exception innerException = null)
+            : base(message, innerException)
+        { }
+    }
+
+
+    public class Thread
+    {
+        private Task _task;
+        private CancellationTokenSource _tokenSource = new CancellationTokenSource();
+
+        public string Name { get; set; }
+        public bool IsBackground { get; set; }
+        public bool IsAlive => _task != null && !(_task.IsCanceled || _task.IsCompleted || _task.IsFaulted);
+        public CultureInfo CurrentCulture => throw new NotImplementedException();
+        private static SemaphoreSlim _unavailable = new SemaphoreSlim(0, 1);
+
+        private enum StartType
+        {
+            Standard,
+            Parameterized
+        };
+
+        StartType _startType;
+        ParameterizedThreadStart _parameterizedStart;
+        ThreadStart _start;
+
+        public Thread(ParameterizedThreadStart threadStart, int maxStackSize = 0)
+        {
+            _startType = StartType.Parameterized;
+            _parameterizedStart = threadStart;
+        }
+
+        public Thread(ThreadStart threadStart, int maxStackSize = 0)
+        {
+            _startType = StartType.Standard;
+            _start = threadStart;
+        }
+
+        public void Start()
+        {
+            if (_startType == StartType.Parameterized)
+            {
+                throw new InvalidOperationException("Must supply argument for ParameterizedThreadStart!");
+            }
+
+            if (_task != null)
+            {
+                throw new ThreadStateException("Thread already started!");
+            }
+
+            _task = new Task(() => _start(), _tokenSource.Token, TaskCreationOptions.LongRunning);
+            if (IsBackground)
+            {
+                _task.Start();
+            }
+            else
+            {
+                _task.RunSynchronously();
+            }
+        }
+
+        public void Start(object obj)
+        {
+            if (_startType == StartType.Standard)
+            {
+                throw new InvalidOperationException("Must use parameterless Start() method instead!");
+            }
+
+            if (_task != null)
+            {
+                throw new ThreadStateException("Thread already started!");
+            }
+
+            _task = new Task(() => _parameterizedStart(obj), _tokenSource.Token, TaskCreationOptions.LongRunning);
+            if (IsBackground)
+            {
+                _task.Start();
+            }
+            else
+            {
+                _task.RunSynchronously();
+            }
+        }
+
+        public void Join()
+        {
+            _task.Wait();
+        }
+
+        public bool Join(Int32 milliseconds)
+        {
+            return _task.Wait(milliseconds);
+        }
+
+        public bool Join(TimeSpan timeout)
+        {
+            return _task.Wait(timeout);
+        }
+
+        public static void Sleep(int milliseconds)
+        {
+            _unavailable.Wait(milliseconds);
+        }
+
+        public static void Sleep(TimeSpan duration)
+        {
+            _unavailable.Wait(duration);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Microsoft cheated with the System.Threading.Thread library: while it
is claimed that UWP implements .NET Standard 1.4 [0], and per the
listing at [1], System.Threading.Thread claims to support .NET
Standard 1.3, in reality the System.Threading.Thread package will
fail to install on UWP targets, despite them being fully .NET
Standard 1.3 complaint. If this were anyone else, the package would
probably not have been allowed to claim .NET Standard 1.3 support
in the nuspec listing.

As a result of this mess, for NetMQ to be usable under Universal
Windows Platform (i.e. Windows 10 and Windows 10 phone runtimes),
it is necessary to drop the dependency on System.Threading.Thread,
at least for this target. As a result, a new target has been added
to the project indepedendent from .NET Standard 1.3 so that all
other targets can continue using the System.Threading.Thread package.

The new UAP target for NetMQ has a fake implementation of threads
that uses the System.Threading.Tasks class internally to create a
Thread class sufficiently-resembling the real deal to compile and run
without issue. The nuspec for the NetMQ package might also need
updating to create a new target specifically for UAP consumers,
it would be identical to the .NET Standard 1.3 target except
without the System.Threading.Thread dependency.

[0]: https://github.com/dotnet/standard/blob/master/docs/versions.md
[1]: https://www.nuget.org/packages/System.Threading.Thread/