### PR TITLE
Corrected misunderstanding of the IsBackground property for TaskThread/UAP

### DIFF
--- a/src/NetMQ/TaskThread.cs
+++ b/src/NetMQ/TaskThread.cs
@@ -62,14 +62,7 @@ namespace System.Threading
             }
 
             _task = new Task(() => _start(), _tokenSource.Token, TaskCreationOptions.LongRunning);
-            if (IsBackground)
-            {
-                _task.Start();
-            }
-            else
-            {
-                _task.RunSynchronously();
-            }
+            _task.Start();
         }
 
         public void Start(object obj)
@@ -85,14 +78,7 @@ namespace System.Threading
             }
 
             _task = new Task(() => _parameterizedStart(obj), _tokenSource.Token, TaskCreationOptions.LongRunning);
-            if (IsBackground)
-            {
-                _task.Start();
-            }
-            else
-            {
-                _task.RunSynchronously();
-            }
+            _task.Start();
         }
 
         public void Join()


### PR DESCRIPTION
IsBackground does not affect whether the thread runs synchronously
or not. It merely specifies whether the application will wait for
the thread to finish executing before exiting (by default it does).

Due to the implementation of tasks under UAP, this doesn't seem to have affected the behavior of netmq, but it should definitely be corrected.