### PR TITLE
fix the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ script:
   - dotnet restore src/
 
   # testing only netcoreapp1.0 on linux and osx
-  - dotnet test src/NetMQ.Tests -f netcoreapp1.0 --labels=All
+  - dotnet test src/NetMQ.Tests/NetMQ.Tests.csproj -f netcoreapp1.0


### PR DESCRIPTION
`dotnet test` doesn't accept just a path to a project directory, [yet](https://github.com/Microsoft/vstest/issues/630). =D

Also, `--labels` isn't an option.