### PR TITLE
Mark TaskThread implementation as internal

### DIFF
--- a/src/NetMQ/TaskThread.cs
+++ b/src/NetMQ/TaskThread.cs
@@ -5,18 +5,17 @@ using System.Threading.Tasks;
 
 namespace System.Threading
 {
-    public delegate void ParameterizedThreadStart(object obj);
-    public delegate void ThreadStart();
+    internal delegate void ParameterizedThreadStart(object obj);
+    internal delegate void ThreadStart();
 
-    public class ThreadStateException : Exception
+    internal class ThreadStateException : Exception
     {
         public ThreadStateException(string message = "", Exception innerException = null)
             : base(message, innerException)
         { }
     }
 
-
-    public class Thread
+    internal class Thread
     {
         private Task _task;
         private CancellationTokenSource _tokenSource = new CancellationTokenSource();


### PR DESCRIPTION
TaskThread is also available as a NuGet project for UAP clients [0],
NetMQ includes the same source so as to not have an external dependency.
The NetMQ version should be internal as it does not offer a stable
interface and is not for consumption outside of NetMQ.