### PR TITLE
Use Marshal.SizeOf<T> on UAP too

### DIFF
--- a/src/NetMQ/Core/MonitorEvent.cs
+++ b/src/NetMQ/Core/MonitorEvent.cs
@@ -20,7 +20,7 @@ namespace NetMQ.Core
 
         static MonitorEvent()
         {
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || UAP
             s_sizeOfIntPtr = Marshal.SizeOf<IntPtr>();
 #else
             s_sizeOfIntPtr = Marshal.SizeOf(typeof(IntPtr));


### PR DESCRIPTION
Like .NET Standard, UAP has also deprecated Marshal.SizeOf(typeof(T))
and recommends using Marshal.SizeOf<T>() instead.