### PR TITLE
Raise an error if removing a socket or timer from a stopped poller

### DIFF
--- a/src/NetMQ.Tests/NetMQPollerTest.cs
+++ b/src/NetMQ.Tests/NetMQPollerTest.cs
@@ -48,8 +48,6 @@ namespace NetMQ.Tests
 
                 Assert.Equal("World", req.ReceiveFrameString(out bool more2));
                 Assert.False(more2);
-
-                poller.Stop();
             }
         }
 
@@ -91,8 +89,6 @@ namespace NetMQ.Tests
                 Assert.True(listeningEvent.WaitOne(300));
                 Assert.True(connectedEvent.WaitOne(300));
                 Assert.True(acceptedEvent.WaitOne(300));
-
-                poller.Stop();
             }
         }
 

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -219,6 +219,7 @@ namespace NetMQ
             if (socket.IsDisposed)
                 throw new ArgumentException("Must not be disposed.", nameof(socket));
             CheckDisposed();
+            CheckCanRemove();
 
             Run(() =>
             {
@@ -244,6 +245,7 @@ namespace NetMQ
             if (socket.IsDisposed)
                 throw new ArgumentException("Must not be disposed.", nameof(socket));
             CheckDisposed();
+            CheckCanRemove();
 
             Run(() =>
             {
@@ -268,6 +270,7 @@ namespace NetMQ
             if (timer == null)
                 throw new ArgumentNullException(nameof(timer));
             CheckDisposed();
+            CheckCanRemove();
 
             timer.When = -1;
 
@@ -279,6 +282,7 @@ namespace NetMQ
             if (socket == null)
                 throw new ArgumentNullException(nameof(socket));
             CheckDisposed();
+            CheckCanRemove();
 
             Run(() =>
             {
@@ -603,6 +607,12 @@ namespace NetMQ
         {
             if (m_disposeState == (int)DisposeState.Disposed)
                 throw new ObjectDisposedException("NetMQPoller");
+        }
+
+        private void CheckCanRemove()
+        {
+            if (!IsRunning)
+                throw new InvalidOperationException("Cannot remove object - NetMQPoller is not running");
         }
 
         /// <summary>


### PR DESCRIPTION
I've been looking at a problem where my unit tests would lock up on a call to:

NetMQ.NetMQConfig.Cleanup(true);

The root cause is that my code was explicitly stopping the Poller before removing the sockets; therefore, the calls to Remove are never executed, and the Cleanup call waits forever.

I suggest raising an exception if this occurs, to make it more easy to detect this scenario.
