### PR TITLE
Change NetMQSynchronizationContext.Post exception handling

### DIFF
--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -693,7 +693,7 @@ namespace NetMQ
         #region Synchronisation context
 
 #if !NET35
-        private sealed class NetMQSynchronizationContext : SynchronizationContext
+        internal sealed class NetMQSynchronizationContext : SynchronizationContext
         {
             private readonly NetMQPoller m_poller;
 


### PR DESCRIPTION
See #697 and the added unit test.

I have an alternative implementation using two queues at c5c9aee0062f8b900fb6961e24543e5fa94fa7e7, but I suspect that this implementation here (using a single queue and a union type) has better performance due to avoiding the overhead of polling an additional queue socket (but I don't really know).