### PR TITLE
problem: developing peer to peer with current socket is hard

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
 image: Visual Studio 2017
 configuration: Release
 before_build:
-  appveyor-retry dotnet restore src
+  appveyor-retry dotnet restore src/NetMQ.sln
 build:
   project: src/NetMQ.sln
   parallel: true

--- a/src/NetMQ-unix.sln
+++ b/src/NetMQ-unix.sln
@@ -1,0 +1,50 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.9
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetMQ-unix", "NetMQ\NetMQ-unix.csproj", "{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetMQ.Tests-unix", "NetMQ.Tests\NetMQ.Tests-unix.csproj", "{E95F0358-E822-47E5-9B11-541A44C2EF15}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Debug|x64.ActiveCfg = Debug|x64
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Debug|x64.Build.0 = Debug|x64
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Debug|x86.ActiveCfg = Debug|x86
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Debug|x86.Build.0 = Debug|x86
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Release|x64.ActiveCfg = Release|x64
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Release|x64.Build.0 = Release|x64
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Release|x86.ActiveCfg = Release|x86
+		{02FF50EC-2D3B-4864-AF33-F4D3D54F2490}.Release|x86.Build.0 = Release|x86
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Debug|x64.ActiveCfg = Debug|x64
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Debug|x64.Build.0 = Debug|x64
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Debug|x86.ActiveCfg = Debug|x86
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Debug|x86.Build.0 = Debug|x86
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Release|x64.ActiveCfg = Release|x64
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Release|x64.Build.0 = Release|x64
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Release|x86.ActiveCfg = Release|x86
+		{E95F0358-E822-47E5-9B11-541A44C2EF15}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+	EndGlobalSection
+EndGlobal

--- a/src/NetMQ.Tests/NetMQ.Tests-unix.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests-unix.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp20</TargetFramework>
+    <AssemblyName>NetMQ.Tests</AssemblyName>
+    <RootNamespace>NetMQ.Tests</RootNamespace>
+    <AssemblyOriginatorKeyFile>../NetMQ/NetMQ.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NetMQ\NetMQ-unix.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/NetMQ.Tests/PeerTests.cs
+++ b/src/NetMQ.Tests/PeerTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Xunit;
+using System.Text;
+using System.Threading;
+using NetMQ.Sockets;
+
+namespace NetMQ.Tests
+{    
+    public class PeerTests : IClassFixture<CleanupAfterFixture>
+    {
+        [Fact]
+        public void SendReceive()
+        {                        
+            using (var peer1 = new PeerSocket("@inproc://peer"))
+            using (var peer2 = new PeerSocket())
+            {
+                var peer1Identity = peer2.ConnectPeer("inproc://peer");
+
+                peer2.SendMoreFrame(peer1Identity);
+                peer2.SendFrame("Hello");
+
+                // peer2 identity
+                var peer2Identity = peer1.ReceiveFrameBytes();
+                var msg = peer1.ReceiveFrameString();
+                
+                Assert.Equal(msg, "Hello");
+                
+                peer1.SendMoreFrame(peer2Identity);
+                peer1.SendFrame("World");
+                
+                peer2.ReceiveFrameBytes();
+                msg = peer2.ReceiveFrameString();
+                
+                Assert.Equal(msg, "World");
+            }
+        }
+
+        [Fact]
+        public void ExceptionWhenSendingToPeerWhichDoesnExist()
+        {
+            using (var peer1 = new PeerSocket("@inproc://peer"))
+            {
+                Assert.Throws<HostUnreachableException>(() =>
+                {
+                    peer1.SendMoreFrame("hello"); //unexist peer
+                    peer1.SendFrame("World");
+                });
+            }
+        }
+        
+        
+        [Fact]
+        public void DropMultipartMessages()
+        {
+            using (var peer1 = new PeerSocket("@inproc://peer"))
+            using (var dealer = new DealerSocket(">inproc://peer"))
+            {
+                dealer.SendMoreFrame("This should be dropped");
+                dealer.SendFrame("This as well");
+                dealer.SendFrame("Hello");
+
+                peer1.ReceiveFrameBytes();
+                var message = peer1.ReceiveFrameString();
+
+                Assert.Equal(message, "Hello");
+            }
+        }
+        
+    }
+}

--- a/src/NetMQ/Core/Options.cs
+++ b/src/NetMQ/Core/Options.cs
@@ -115,6 +115,8 @@ namespace NetMQ.Core
         /// The initial value is 0, until the Identity property is set.
         /// </summary>
         public byte IdentitySize { get; set; }
+        
+        public byte[] LastPeerRoutingId { get; set; }
 
         /// <summary>
         /// Get or set whether this allows the use of IPv4 sockets only.
@@ -493,6 +495,9 @@ namespace NetMQ.Core
 
                 case ZmqSocketOption.DisableTimeWait:
                     return DisableTimeWait;
+                    
+                case ZmqSocketOption.LastPeerRoutingId:
+                    return LastPeerRoutingId;
 
                 default:
                     throw new InvalidException("GetSocketOption called with invalid ZmqSocketOption of " + option);

--- a/src/NetMQ/Core/Patterns/Peer.cs
+++ b/src/NetMQ/Core/Patterns/Peer.cs
@@ -1,0 +1,340 @@
+/*
+    Copyright (c) 2012 iMatix Corporation
+    Copyright (c) 2009-2011 250bpm s.r.o.
+    Copyright (c) 2011 VMware, Inc.
+    Copyright (c) 2007-2015 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using JetBrains.Annotations;
+using NetMQ.Core.Patterns.Utils;
+using NetMQ.Core.Utils;
+
+namespace NetMQ.Core.Patterns
+{
+    /// <summary>
+    /// A Router is a subclass of SocketBase
+    /// </summary>
+    internal class Peer : SocketBase
+    {
+        private static readonly Random s_random = new Random();
+
+        public class PeerSession : SessionBase
+        {
+            public PeerSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
+                : base(ioThread, connect, socket, options, addr)
+            { }
+        }
+
+        /// <summary>
+        /// An instance of class Outpipe contains a Pipe and a boolean property Active.
+        /// </summary>
+        private class Outpipe
+        {
+            public Outpipe([NotNull] Pipe pipe, bool active)
+            {
+                Pipe = pipe;
+                Active = active;
+            }
+
+            [NotNull]
+            public Pipe Pipe { get; }
+
+            public bool Active;
+        };
+        
+        enum State
+        {
+            RoutingId,
+            Data
+        }
+
+        /// <summary>
+        /// Fair queueing object for inbound pipes.
+        /// </summary>
+        private readonly FairQueueing m_fairQueueing;
+    
+        /// <summary>
+        /// Holds the prefetched message.
+        /// </summary>
+        private Msg m_prefetchedMsg;
+        
+        /// <summary>
+        /// Outbound pipes indexed by the peer IDs.
+        /// </summary>
+        private readonly Dictionary<byte[], Outpipe> m_outpipes;
+
+        /// <summary>
+        /// The pipe we are currently writing to.
+        /// </summary>
+        private Pipe m_currentOut;  
+             
+        /// <summary>
+        /// State of the recv operation
+        /// </summary>
+        private State m_receivingState;
+        
+        /// <summary>
+        /// State of the sending operation
+        /// </summary>
+        private State m_sendingState;
+
+        /// <summary>
+        /// Peer ID are generated. It's a simple increment and wrap-over
+        /// algorithm. This value is the next ID to use (if not used already).
+        /// </summary>
+        private int m_nextPeerId;
+        
+        /// <summary>
+        /// Create a new Router instance with the given parent-Ctx, thread-id, and socket-id.
+        /// </summary>
+        /// <param name="parent">the Ctx that will contain this Router</param>
+        /// <param name="threadId">the integer thread-id value</param>
+        /// <param name="socketId">the integer socket-id value</param>
+        public Peer([NotNull] Ctx parent, int threadId, int socketId)
+            : base(parent, threadId, socketId)
+        {
+            m_nextPeerId = s_random.Next();
+            m_options.SocketType = ZmqSocketType.Peer;
+            m_fairQueueing = new FairQueueing();      
+            m_prefetchedMsg = new Msg();
+            m_prefetchedMsg.InitEmpty();            
+            m_outpipes = new Dictionary<byte[], Outpipe>(new ByteArrayEqualityComparer());
+            m_sendingState = State.RoutingId;
+            m_receivingState = State.RoutingId;            
+        }
+   
+        public override void Destroy()
+        {
+            base.Destroy();            
+            m_prefetchedMsg.Close();
+        }
+
+        /// <summary>
+        /// Register the pipe with this socket.
+        /// </summary>
+        /// <param name="pipe">the Pipe to attach</param>
+        /// <param name="icanhasall">not used</param>
+        protected override void XAttachPipe(Pipe pipe, bool icanhasall)
+        {
+            Debug.Assert(pipe != null);
+
+            byte[] routingId = BitConverter.GetBytes(m_nextPeerId);
+                        
+            pipe.RoutingId = routingId;
+            m_outpipes.Add(routingId, new Outpipe(pipe, true));
+            m_fairQueueing.Attach(pipe);
+            
+            // As this exposed to the user we make a copy to avoid an issue
+            m_options.LastPeerRoutingId = BitConverter.GetBytes(m_nextPeerId);
+            
+            m_nextPeerId++;
+        }      
+
+        /// <summary>
+        /// This is an override of the abstract method that gets called to signal that the given pipe is to be removed from this socket.
+        /// </summary>
+        /// <param name="pipe">the Pipe that is being removed</param>
+        protected override void XTerminated(Pipe pipe)
+        {           
+            m_outpipes.TryGetValue(pipe.RoutingId, out Outpipe old);
+            m_outpipes.Remove(pipe.RoutingId);
+
+            Debug.Assert(old != null);
+
+            m_fairQueueing.Terminated(pipe);
+            if (pipe == m_currentOut)
+                m_currentOut = null;
+        }
+
+        /// <summary>
+        /// Indicate the given pipe as being ready for reading by this socket.
+        /// </summary>
+        /// <param name="pipe">the <c>Pipe</c> that is now becoming available for reading</param>
+        protected override void XReadActivated(Pipe pipe)
+        {            
+            m_fairQueueing.Activated(pipe);            
+        }
+
+        /// <summary>
+        /// Indicate the given pipe as being ready for writing to by this socket.
+        /// This gets called by the WriteActivated method.
+        /// </summary>
+        /// <param name="pipe">the <c>Pipe</c> that is now becoming available for writing</param>
+        protected override void XWriteActivated(Pipe pipe)
+        {
+            Outpipe outpipe = null;
+
+            foreach (var it in m_outpipes)
+            {
+                if (it.Value.Pipe == pipe)
+                {
+                    Debug.Assert(!it.Value.Active);
+                    it.Value.Active = true;
+                    outpipe = it.Value;
+                    break;
+                }
+            }
+
+            Debug.Assert(outpipe != null);
+        }
+
+        /// <summary>
+        /// Transmit the given message. The <c>Send</c> method calls this to do the actual sending.
+        /// </summary>
+        /// <param name="msg">the message to transmit</param>
+        /// <returns><c>true</c> if the message was sent successfully</returns>
+        /// <exception cref="HostUnreachableException">The receiving host must be identifiable.</exception>
+        protected override bool XSend(ref Msg msg)
+        {
+            // If this is the first part of the message it's the ID of the
+            // peer to send the message to.
+            if (m_sendingState == State.RoutingId)
+            {
+                Debug.Assert(m_currentOut == null);
+
+                // If we have malformed message (prefix with no subsequent message)
+                // then just silently ignore it.                
+                if (msg.HasMore)
+                {
+                    m_sendingState = State.Data;
+                    
+                    // Find the pipe associated with the routingId stored in the prefix.                    
+                    var routingId = msg.Size == msg.Data.Length
+                        ? msg.Data
+                        : msg.CloneData();
+
+                    if (m_outpipes.TryGetValue(routingId, out Outpipe op))
+                    {
+                        m_currentOut = op.Pipe;
+                        if (!m_currentOut.CheckWrite())
+                        {
+                            m_sendingState = State.RoutingId;
+                            op.Active = false;
+                            m_currentOut = null;
+
+                            if (!op.Pipe.Active)
+                                throw new HostUnreachableException("In Peer.XSend");
+
+                            return false;
+                        }
+                    }
+                    else
+                        throw new HostUnreachableException("In Peer.XSend");
+                }
+
+                // Detach the message from the data buffer.
+                msg.Close();
+                msg.InitEmpty();
+
+                return true;
+            }                        
+    
+            //  Peer sockets do not allow multipart data (ZMQ_SNDMORE)
+            if (msg.HasMore) 
+                throw new InvalidException();
+                                    
+            // Push the message into the pipe. If there's no out pipe, just drop it.
+            if (m_currentOut != null)
+            {                
+                bool ok = m_currentOut.Write(ref msg);
+                
+                if (ok)                
+                    m_currentOut.Flush();
+
+                m_currentOut = null;
+            }
+            else
+            {
+                msg.Close();
+            }
+
+            // Detach the message from the data buffer.
+            msg.InitEmpty();
+
+            return true;
+        }
+
+        /// <summary>
+        /// Receive a message. The <c>Recv</c> method calls this lower-level method to do the actual receiving.
+        /// </summary>
+        /// <param name="msg">the <c>Msg</c> to receive the message into</param>
+        /// <returns><c>true</c> if the message was received successfully, <c>false</c> if there were no messages to receive</returns>
+        protected override bool XRecv(ref Msg msg)
+        {
+            if (m_receivingState == State.Data)
+            {                
+                msg.Move(ref m_prefetchedMsg);
+                m_receivingState = State.RoutingId;
+                                              
+                return true;
+            }
+
+            var pipe = new Pipe[1];
+
+            bool isMessageAvailable = m_fairQueueing.RecvPipe(pipe, ref msg);
+
+            // Drop any messages with more flag
+            while (isMessageAvailable && msg.HasMore)
+            {
+                // drop all frames of the current multi-frame message
+                isMessageAvailable = m_fairQueueing.RecvPipe(pipe, ref msg);
+
+                while (isMessageAvailable && msg.HasMore)
+                    isMessageAvailable = m_fairQueueing.RecvPipe(pipe, ref msg);
+                
+                // get the new message
+                isMessageAvailable = m_fairQueueing.RecvPipe(pipe, ref msg);
+            }
+
+            if (!isMessageAvailable)            
+                return false;            
+
+            Debug.Assert(pipe[0] != null);
+           
+            // We are at the beginning of a message.
+            // Keep the message part we have in the prefetch buffer
+            // and return the ID of the peer instead.
+            m_prefetchedMsg.Move(ref msg);
+            
+            byte[] routingId = pipe[0].RoutingId;
+            msg.InitPool(routingId.Length);
+            msg.Put(routingId, 0, routingId.Length);
+            msg.SetFlags(MsgFlags.More);
+            m_receivingState = State.Data;
+                       
+            return true;
+        }     
+
+        protected override bool XHasIn()
+        {
+            return m_fairQueueing.HasIn();           
+        }
+
+        protected override bool XHasOut()
+        {
+            // In theory, PEER socket is always ready for writing. Whether actual
+            // attempt to write succeeds depends on which pipe the message is going
+            // to be routed to.
+            return true;
+        }   
+    }
+}

--- a/src/NetMQ/Core/Pipe.cs
+++ b/src/NetMQ/Core/Pipe.cs
@@ -231,6 +231,12 @@ namespace NetMQ.Core
         /// </summary>
         [CanBeNull]
         public byte[] Identity { get; set; }
+        
+        /// <summary>
+        /// Get or set the byte-array that comprises the routing id of this Pipe.
+        /// </summary>
+        [CanBeNull]
+        public byte[] RoutingId { get; set; }
 
         /// <summary>
         /// Checks if there is at least one message to read in the pipe.

--- a/src/NetMQ/Core/SessionBase.cs
+++ b/src/NetMQ/Core/SessionBase.cs
@@ -148,6 +148,8 @@ namespace NetMQ.Core
                     return new Pair.PairSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Stream:
                     return new Stream.StreamSession(ioThread, connect, socket, options, addr);
+                case ZmqSocketType.Peer:
+                    return new Peer.PeerSession(ioThread, connect, socket, options, addr);
                 default:
                     throw new InvalidException("SessionBase.Create called with invalid SocketType of " + options.SocketType);
             }
@@ -550,7 +552,8 @@ namespace NetMQ.Core
             // For delayed connect situations, terminate the pipe
             // and reestablish later on
             if (m_pipe != null && m_options.DelayAttachOnConnect
-                && m_addr.Protocol != Address.PgmProtocol && m_addr.Protocol != Address.EpgmProtocol)
+                && m_addr.Protocol != Address.PgmProtocol && m_addr.Protocol != Address.EpgmProtocol && 
+                m_options.SocketType != ZmqSocketType.Peer)
             {
                 m_pipe.Hiccup();
                 m_pipe.Terminate(false);

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -183,6 +183,8 @@ namespace NetMQ.Core
                     return new XSub(parent, threadId, socketId);
                 case ZmqSocketType.Stream:
                     return new Stream(parent, threadId, socketId);
+                case ZmqSocketType.Peer:
+                    return new Peer(parent, threadId, socketId);
                 default:
                     throw new InvalidException("SocketBase.Create called with invalid type of " + type);
             }
@@ -696,7 +698,7 @@ namespace NetMQ.Core
             bool icanhasall = protocol == Address.PgmProtocol || protocol == Address.EpgmProtocol;
             Pipe newPipe = null;
 
-            if (!m_options.DelayAttachOnConnect || icanhasall)
+            if (!m_options.DelayAttachOnConnect || icanhasall || m_options.SocketType == ZmqSocketType.Peer)
             {
                 // Create a bi-directional pipe.
                 ZObject[] parents = { this, session };
@@ -1284,7 +1286,7 @@ namespace NetMQ.Core
 
         public void Hiccuped(Pipe pipe)
         {
-            if (m_options.DelayAttachOnConnect)
+            if (m_options.DelayAttachOnConnect && m_options.SocketType != ZmqSocketType.Peer)
                 pipe.Terminate(false);
             else
                 // Notify derived sockets of the hiccup
@@ -1531,6 +1533,8 @@ namespace NetMQ.Core
                     return "PULL";
                 case ZmqSocketType.Push:
                     return "PUSH";
+                case ZmqSocketType.Peer:
+                    return "PEER";
                 default:
                     return "UNKNOWN";
             }

--- a/src/NetMQ/Core/ZmqSocketOption.cs
+++ b/src/NetMQ/Core/ZmqSocketOption.cs
@@ -277,9 +277,16 @@ namespace NetMQ.Core
         RouterHandover = 48,
 
         /// <summary>
+        /// Returns the last peer routing id connect to the PEER socket
+        /// </summary>
+        LastPeerRoutingId = 49,
+        
+        /// <summary>
         /// Specifies the byte-order: big-endian, vs little-endian.
         /// </summary>
         Endian = 1000,
+        
+        
 
         /// <summary>
         /// Specifies the max datagram size for PGM.

--- a/src/NetMQ/NetMQ-unix.csproj
+++ b/src/NetMQ/NetMQ-unix.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp20</TargetFramework>
+    <AssemblyName>NetMQ</AssemblyName>
+    <RootNamespace>NetMQ</RootNamespace>
+    <AssemblyOriginatorKeyFile>NetMQ.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AsyncIO" Version="0.1.26" />
+    <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
+  </ItemGroup>
+</Project>

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -385,6 +385,11 @@ namespace NetMQ
         }
 
         /// <summary>
+        /// Get the last PEER allocated routing id
+        /// </summary>
+        public byte[] LastPeerRoutingId => m_socket.GetSocketOptionX<byte[]>(ZmqSocketOption.LastPeerRoutingId);
+
+        /// <summary>
         /// Controls the maximum datagram size for PGM.
         /// </summary>
         public int PgmMaxTransportServiceDataUnitLength

--- a/src/NetMQ/Sockets/PeerSocket.cs
+++ b/src/NetMQ/Sockets/PeerSocket.cs
@@ -1,0 +1,44 @@
+﻿using NetMQ.Core;
+using NetMQ.Core.Patterns;
+
+namespace NetMQ.Sockets
+{
+    /// <summary>
+    /// Peer socket, the first message is always the identity of the sender
+    /// </summary>
+    public class PeerSocket : NetMQSocket
+    {
+        /// <summary>
+        /// Create a new PeerSocket and attach socket to zero or more endpoints.
+        /// </summary>
+        /// <param name="connectionString">List of NetMQ endpoints, separated by commas and prefixed by '@' (to bind the socket) or '>' (to connect the socket).
+        /// Default action is connect (if endpoint doesn't start with '@' or '>')</param>
+        /// <example><code>var socket = new PeerSocket(">tcp://127.0.0.1:5555,>127.0.0.1:55556");</code></example>
+        public PeerSocket(string connectionString = null) : base(ZmqSocketType.Peer, connectionString, DefaultAction.Connect)
+        {
+        }
+
+        /// <summary>
+        /// Create a new PeerSocket based upon the given SocketBase.
+        /// </summary>
+        /// <param name="socketHandle">the SocketBase to create the new socket from</param>
+        internal PeerSocket(SocketBase socketHandle) : base(socketHandle)
+        {
+        }
+
+        /// <summary>
+        /// Connect the peer socket to <paramref name="address"/>.
+        /// </summary>
+        /// <param name="address">a string denoting the address to connect this socket to</param>
+        /// <returns>The peer allocated routing id</returns>
+        /// <exception cref="ObjectDisposedException">thrown if the socket was already disposed</exception>
+        /// <exception cref="TerminatingException">The socket has been stopped.</exception>
+        /// <exception cref="NetMQException">No IO thread was found.</exception>
+        /// <exception cref="AddressAlreadyInUseException">The specified address is already in use.</exception>
+        public byte[] ConnectPeer(string address)
+        {
+            Connect(address);
+            return GetSocketOptionX<byte[]>(ZmqSocketOption.LastPeerRoutingId);
+        }    
+    }
+}

--- a/src/NetMQ/ZmqSocketType.cs
+++ b/src/NetMQ/ZmqSocketType.cs
@@ -69,6 +69,8 @@
         /// <summary>
         /// This denotes a Stream socket - which is a parent-class to the other socket types.
         /// </summary>
-        Stream = 11
+        Stream = 11,
+        
+        Peer = 19
     }
 }


### PR DESCRIPTION
you have to use a dealer socket for every connection you made.

With peer socket type, you can get routing id of the peer you just connected to and use one socket both for incoming connections and outgoing connections.