### PR TITLE
Minor changes but vital for managing sudden network change…

### DIFF
--- a/src/NetMQ/Core/Patterns/Utils/ArrayExtensions.cs
+++ b/src/NetMQ/Core/Patterns/Utils/ArrayExtensions.cs
@@ -45,7 +45,8 @@ namespace NetMQ.Core.Patterns.Utils
 
         public static void Swap<T>([NotNull] this List<T> items, int index1, int index2) where T : class
         {
-            if (index1 == index2) { return; }
+            if (index1 == index2) 
+                return;
 
             T item1 = items[index1];
             T item2 = items[index2];

--- a/src/NetMQ/Core/Patterns/Utils/ArrayExtensions.cs
+++ b/src/NetMQ/Core/Patterns/Utils/ArrayExtensions.cs
@@ -45,8 +45,8 @@ namespace NetMQ.Core.Patterns.Utils
 
         public static void Swap<T>([NotNull] this List<T> items, int index1, int index2) where T : class
         {
-            if (index1 == index2)
-                return;
+            if (index1 == index2) { return; }
+            if (items.Count <= index1 || items.Count <= index2) { return; }
 
             T item1 = items[index1];
             T item2 = items[index2];

--- a/src/NetMQ/Core/Patterns/Utils/ArrayExtensions.cs
+++ b/src/NetMQ/Core/Patterns/Utils/ArrayExtensions.cs
@@ -46,7 +46,6 @@ namespace NetMQ.Core.Patterns.Utils
         public static void Swap<T>([NotNull] this List<T> items, int index1, int index2) where T : class
         {
             if (index1 == index2) { return; }
-            if (items.Count <= index1 || items.Count <= index2) { return; }
 
             T item1 = items[index1];
             T item2 = items[index2];

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -242,7 +242,19 @@ namespace NetMQ
 
             private void SendUdpFrame(NetMQFrame frame)
             {
-                m_udpSocket.SendTo(frame.Buffer, 0, frame.MessageSize, SocketFlags.None, m_broadcastAddress);
+                try
+                {
+                    m_udpSocket.SendTo(frame.Buffer, 0, frame.MessageSize, SocketFlags.None, m_broadcastAddress);
+                }
+                catch (SocketException ex)
+                {
+                    if (ex.SocketErrorCode != SocketError.AddressNotAvailable) { throw; }
+
+                    // Initiate Creation of new Udp here to solve issue related to 'sudden' network change.
+                    // On windows (7 OR 10) incorrect/previous ip address might still exist instead of new Ip 
+                    // due to network change which causes crash (if no try/catch and keep trying to send to incorrect/not available address.
+                    // This approach would solve the issue...
+                }
             }
 
             private NetMQFrame ReceiveUdpFrame(out string peerName)


### PR DESCRIPTION
Minor changes but vital for managing network change in graceful manner. Sudden network change can result in crash if no try/catch when trying to send udp message or no check for array element swapping.

When changing network during execution (runtime) application crashes due to either SocketExcpetion or OutOfRange for swapping elements. Both cases only occurs during sudden network change, (e.g. going from a subnet 192.168.131 to 192.168.132 with 24bit subnet mask). Adding these simple checks will prevent from crashing and "on next iteration" wokring proparly. 

Please not that I have not added the code for creating new Udp  after the if statement in the catch block. I am not familiar with NetMQ internals and as such would like to leave it to you to consider this. 