### PR TITLE
Issue716

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -24,3 +24,4 @@ Contributors
 * Dale Brubaker &mdash; [@dalebrubaker](https://github.com/dalebrubaker)
 * Calin Pirtea &mdash; [@pcalin](https://github.com/pcalin)
 * Osiris Pedroso &mdash; [@opedroso](https://github.com/opedroso)
+* Mike Miller &mdash; [@mikepmiller](https://github.com/mikepmiller)

--- a/src/NetMQ/Core/Transports/Pgm/PgmSession.cs
+++ b/src/NetMQ/Core/Transports/Pgm/PgmSession.cs
@@ -68,7 +68,19 @@ namespace NetMQ.Core.Transports.Pgm
         public void BeginReceive()
         {
             m_data.Reset();
-            m_handle.Receive((byte[])m_data);
+            try 
+            { 
+                m_handle.Receive((byte[])m_data); 
+            } 
+            catch (SocketException ex) 
+            { 
+                // For a UDP datagram socket, this error would indicate that a previous  
+                // send operation resulted in an ICMP "Port Unreachable" message. 
+                if (ex.SocketErrorCode == SocketError.ConnectionReset) 
+                    Error(); 
+                else 
+                    throw NetMQException.Create(ex.SocketErrorCode, ex); 
+            } 
         }
 
         public void ActivateIn()


### PR DESCRIPTION
Error handling for receive call on PGM socket.  See the note at WSAECONNRESET at WSARecv function: For a UDP datagram socket, this error would indicate that a previous send operation resulted in an ICMP "Port Unreachable" message.