### PR TITLE
Only set AsyncSocket.NoDelay when not already set. Connected to #644

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -24,3 +24,4 @@ Contributors
 * Dale Brubaker &mdash; [@dalebrubaker](https://github.com/dalebrubaker)
 * Calin Pirtea &mdash; [@pcalin](https://github.com/pcalin)
 * Osiris Pedroso &mdash; [@opedroso](https://github.com/opedroso)
+* Anders Gustafsson &mdash; [@anders9ustafsson](https://github.com/anders9ustafsson)

--- a/src/NetMQ/Core/Transports/Tcp/TcpConnector.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpConnector.cs
@@ -246,7 +246,8 @@ namespace NetMQ.Core.Transports.Tcp
                 m_handleValid = false;
 
                 try {
-                    m_s.NoDelay = true;
+                    if (!m_s.NoDelay)
+                        m_s.NoDelay = true;
                 } catch (ArgumentException ex) {
                     // OSX sometime fail while the socket is still connecting
                 }

--- a/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
@@ -193,6 +193,7 @@ namespace NetMQ.Core.Transports.Tcp
                     // TODO: check TcpFilters
                     var acceptedSocket = m_handle.GetAcceptedSocket();
 
+                    if (!acceptedSocket.NoDelay)
                         acceptedSocket.NoDelay = true;
 
                     if (m_options.TcpKeepalive != -1)


### PR DESCRIPTION
Connected to Github issue #644, see comment [here](https://github.com/zeromq/netmq/issues/644#issuecomment-435871734).

Appears to be a necessary precondition for building NetMQ with the .NET native toolchain for UWP applications. Have not verified that the fix applies to the platforms originally mentioned in the issue report.

All unit tests succeed after updating the source code.