### PR TITLE
Upgrade AsyncIO version to 0.1.61

### DIFF
--- a/src/NetMQ/NetMQ-unix.csproj
+++ b/src/NetMQ/NetMQ-unix.csproj
@@ -8,7 +8,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncIO" Version="0.1.40" />
+    <PackageReference Include="AsyncIO" Version="0.1.61" />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
   </ItemGroup>

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncIO" Version="0.1.40" />
+    <PackageReference Include="AsyncIO" Version="0.1.61" />
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Related to #767.
I upgrade AsyncIO version to 0.1.61. 
Unit tests seem to pass.