### PR TITLE
update asyncIO 0.1.69 with netstandard2.0 support

### DIFF
--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncIO" Version="0.1.61" />
+    <PackageReference Include="AsyncIO" Version="0.1.69" />
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This should complete the work for https://github.com/zeromq/netmq/issues/768