### PR TITLE
Added details about dispose ordering

### DIFF
--- a/docs/poller.md
+++ b/docs/poller.md
@@ -221,6 +221,9 @@ rep1.ReceiveReady += (s, a) =>
     }
 };
 ```
+## Dispose
+
+Poller must be disposed before the socket(s) it contains. Otherwise a `System.ObjectDisposedException` will be thrown.
 
 ## Further Reading
 


### PR DESCRIPTION
I had to do some testing to find the right syntax, when instances are held instead of used in a using like the examples.