### PR TITLE
fixes #829 issue with NetMqMonitor backward compatibility

### DIFF
--- a/src/NetMQ.sln.DotSettings
+++ b/src/NetMQ.sln.DotSettings
@@ -8,6 +8,9 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="m_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="s_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="s_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>

--- a/src/NetMQ.sln.DotSettings
+++ b/src/NetMQ.sln.DotSettings
@@ -8,9 +8,6 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="m_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="s_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="s_" Suffix="" Style="aaBb" /&gt;</s:String>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>

--- a/src/NetMQ/ISocketPollableCollection.cs
+++ b/src/NetMQ/ISocketPollableCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using JetBrains.Annotations;
 using NetMQ.Monitoring;
 
@@ -13,5 +14,6 @@ namespace NetMQ
     {
         void Add([NotNull] ISocketPollable socket);
         void Remove([NotNull] ISocketPollable socket);
+        void RemoveAndDispose<T>(T socket) where T : ISocketPollable, IDisposable;
     }
 }

--- a/src/NetMQ/ISocketPollableCollection.cs
+++ b/src/NetMQ/ISocketPollableCollection.cs
@@ -1,4 +1,3 @@
-using System;
 using JetBrains.Annotations;
 using NetMQ.Monitoring;
 
@@ -14,6 +13,5 @@ namespace NetMQ
     {
         void Add([NotNull] ISocketPollable socket);
         void Remove([NotNull] ISocketPollable socket);
-        void RemoveAndDispose<T>(T socket) where T : ISocketPollable, IDisposable;
     }
 }

--- a/src/NetMQ/Monitoring/NetMQMonitor.cs
+++ b/src/NetMQ/Monitoring/NetMQMonitor.cs
@@ -24,7 +24,7 @@ namespace NetMQ.Monitoring
     {
         [NotNull] private readonly NetMQSocket m_monitoringSocket;
         private readonly bool m_ownsMonitoringSocket;
-        [CanBeNull] private NetMQPoller m_attachedPoller;
+        [CanBeNull] private ISocketPollableCollection m_attachedPoller;
         private int m_cancel;
 
         private readonly ManualResetEvent m_isStoppedEvent = new ManualResetEvent(true);
@@ -216,7 +216,7 @@ namespace NetMQ.Monitoring
             }
         }
 
-        public void AttachToPoller([NotNull] NetMQPoller poller)
+        public void AttachToPoller<T>(T poller) where T : ISocketPollableCollection
         {
             if (poller == null)
                 throw new ArgumentNullException(nameof(poller));

--- a/src/NetMQ/Monitoring/NetMQMonitor.cs
+++ b/src/NetMQ/Monitoring/NetMQMonitor.cs
@@ -24,7 +24,7 @@ namespace NetMQ.Monitoring
     {
         [NotNull] private readonly NetMQSocket m_monitoringSocket;
         private readonly bool m_ownsMonitoringSocket;
-        [CanBeNull] private NetMQPoller m_attachedPoller;
+        [CanBeNull] private ISocketPollableCollection m_attachedPoller;
         private int m_cancel;
 
         private readonly ManualResetEvent m_isStoppedEvent = new ManualResetEvent(true);
@@ -208,7 +208,7 @@ namespace NetMQ.Monitoring
                 m_monitoringSocket.Disconnect(Endpoint);
             }
             catch (Exception)
-            {}
+            { }
             finally
             {
                 IsRunning = false;
@@ -216,7 +216,7 @@ namespace NetMQ.Monitoring
             }
         }
 
-        public void AttachToPoller([NotNull] NetMQPoller poller)
+        public void AttachToPoller<T>(T poller) where T : ISocketPollableCollection
         {
             if (poller == null)
                 throw new ArgumentNullException(nameof(poller));
@@ -233,12 +233,12 @@ namespace NetMQ.Monitoring
         {
             DetachFromPoller(false);
         }
-        
+
         private void DetachFromPoller(bool dispose)
         {
             if (m_attachedPoller == null)
                 throw new InvalidOperationException("Not attached to a poller");
-            
+
             if (dispose)
                 m_attachedPoller.RemoveAndDispose(m_monitoringSocket);
             else
@@ -324,7 +324,7 @@ namespace NetMQ.Monitoring
             if (!disposing)
                 return;
 
-            bool attachedToPoller = m_attachedPoller != null; 
+            bool attachedToPoller = m_attachedPoller != null;
 
             if (attachedToPoller)
             {

--- a/src/NetMQ/Monitoring/NetMQMonitor.cs
+++ b/src/NetMQ/Monitoring/NetMQMonitor.cs
@@ -24,7 +24,7 @@ namespace NetMQ.Monitoring
     {
         [NotNull] private readonly NetMQSocket m_monitoringSocket;
         private readonly bool m_ownsMonitoringSocket;
-        [CanBeNull] private ISocketPollableCollection m_attachedPoller;
+        [CanBeNull] private NetMQPoller m_attachedPoller;
         private int m_cancel;
 
         private readonly ManualResetEvent m_isStoppedEvent = new ManualResetEvent(true);
@@ -208,7 +208,7 @@ namespace NetMQ.Monitoring
                 m_monitoringSocket.Disconnect(Endpoint);
             }
             catch (Exception)
-            { }
+            {}
             finally
             {
                 IsRunning = false;
@@ -216,7 +216,7 @@ namespace NetMQ.Monitoring
             }
         }
 
-        public void AttachToPoller<T>(T poller) where T : ISocketPollableCollection
+        public void AttachToPoller([NotNull] NetMQPoller poller)
         {
             if (poller == null)
                 throw new ArgumentNullException(nameof(poller));
@@ -233,12 +233,12 @@ namespace NetMQ.Monitoring
         {
             DetachFromPoller(false);
         }
-
+        
         private void DetachFromPoller(bool dispose)
         {
             if (m_attachedPoller == null)
                 throw new InvalidOperationException("Not attached to a poller");
-
+            
             if (dispose)
                 m_attachedPoller.RemoveAndDispose(m_monitoringSocket);
             else
@@ -324,7 +324,7 @@ namespace NetMQ.Monitoring
             if (!disposing)
                 return;
 
-            bool attachedToPoller = m_attachedPoller != null;
+            bool attachedToPoller = m_attachedPoller != null; 
 
             if (attachedToPoller)
             {


### PR DESCRIPTION
fixes #829 issue with NetMqMonitor backward compatibility.
I had to add `void RemoveAndDispose<T> to ISocketPollableCollection,` so monitor can call this method by interface, thus avoiding coupling to concrete NetMqPoller class.