### PR TITLE
Poller.remove socket disposed fix

### DIFF
--- a/src/NetMQ.Tests/NetMQPollerTest.cs
+++ b/src/NetMQ.Tests/NetMQPollerTest.cs
@@ -455,7 +455,7 @@ namespace NetMQ.Tests
             var pubThread = Task.Run(pubAction);
 
             //allow a little time to run
-            await Task.Delay(5000);
+            await Task.Delay(2000);
 
             //now try to remove the sub from poller
             await patient.Remove(sub);
@@ -465,7 +465,7 @@ namespace NetMQ.Tests
             sub = null;
 
             //allow for poller to continue running
-            await Task.Delay(3000);
+            await Task.Delay(2000);
 
             patient.Stop();
             Assert.False(patient.IsRunning);

--- a/src/NetMQ.Tests/NetMQPollerTest.cs
+++ b/src/NetMQ.Tests/NetMQPollerTest.cs
@@ -401,7 +401,7 @@ namespace NetMQ.Tests
         }
 
         [Fact]
-        public async void RemoveAndDisposeSocket()
+        public async void DisposeSocketAfterRemoval()
         {
             //set up poller, start it
             var patient = new NetMQPoller();

--- a/src/NetMQ.Tests/NetMQPollerTest.cs
+++ b/src/NetMQ.Tests/NetMQPollerTest.cs
@@ -458,10 +458,11 @@ namespace NetMQ.Tests
             await Task.Delay(5000);
 
             //now try to remove the sub from poller
-            patient.Remove(sub);
+            await patient.Remove(sub);
 
             // dispose the sub (this will cause exception on poller's worker-thread) and it can't be caught!
             sub.Dispose();
+            sub = null;
 
             //allow for poller to continue running
             await Task.Delay(3000);
@@ -471,9 +472,9 @@ namespace NetMQ.Tests
 
             canceller.Cancel();
 
-            //patient?.Dispose();
             pub?.Dispose();
-            sub?.Dispose();
+            sub?.Dispose();// left here for dev testing when prior .Dispose() call may be commented out
+            patient?.Dispose();
         }
 
         [Fact]
@@ -499,7 +500,7 @@ namespace NetMQ.Tests
         }
 
         [Fact]
-        public void RemoveThrowsIfSocketAlreadyDisposed()
+        public async void RemoveThrowsIfSocketAlreadyDisposed()
         {
             var socket = new RouterSocket();
 
@@ -511,7 +512,7 @@ namespace NetMQ.Tests
             socket.Dispose();
 
             // Remove throws if the removed socket
-            var ex = Assert.Throws<ArgumentException>(() => poller.Remove(socket));
+            var ex = await Assert.ThrowsAsync<ArgumentException>(() => poller.Remove(socket));
 
             Assert.StartsWith("Must not be disposed.", ex.Message);
             Assert.Equal("socket", ex.ParamName);

--- a/src/NetMQ.Tests/NetMQPollerTest.cs
+++ b/src/NetMQ.Tests/NetMQPollerTest.cs
@@ -583,19 +583,8 @@ namespace NetMQ.Tests
             socket.Dispose();
 
             // Remove throws if the removed socket
-            //var ex = Assert.Throws<ArgumentException>(() => poller.Remove(socket));
+            var ex = Assert.Throws<ArgumentException>(() => poller.Remove(socket));
 
-            ArgumentException ex = null;
-
-            try
-            {
-                poller.Remove(socket);
-            }
-            catch (ArgumentException argEx)
-            {
-                ex = argEx;
-            }
-            Assert.NotNull(ex);
             Assert.StartsWith("Must not be disposed.", ex.Message);
             Assert.Equal("socket", ex.ParamName);
 

--- a/src/NetMQ.Tests/NetMQPollerTest.cs
+++ b/src/NetMQ.Tests/NetMQPollerTest.cs
@@ -458,7 +458,7 @@ namespace NetMQ.Tests
             await Task.Delay(2000);
 
             //now try to remove the sub from poller
-            await patient.Remove(sub);
+            patient.Remove(sub);
 
             // dispose the sub (this will cause exception on poller's worker-thread) and it can't be caught!
             sub.Dispose();
@@ -500,7 +500,7 @@ namespace NetMQ.Tests
         }
 
         [Fact]
-        public async void RemoveThrowsIfSocketAlreadyDisposed()
+        public void RemoveThrowsIfSocketAlreadyDisposed()
         {
             var socket = new RouterSocket();
 
@@ -512,8 +512,19 @@ namespace NetMQ.Tests
             socket.Dispose();
 
             // Remove throws if the removed socket
-            var ex = await Assert.ThrowsAsync<ArgumentException>(() => poller.Remove(socket));
+            //var ex = Assert.Throws<ArgumentException>(() => poller.Remove(socket));
 
+            ArgumentException ex = null;
+
+            try
+            {
+                poller.Remove(socket);
+            }
+            catch (ArgumentException argEx)
+            {
+                ex = argEx;
+            }
+            Assert.NotNull(ex);
             Assert.StartsWith("Must not be disposed.", ex.Message);
             Assert.Equal("socket", ex.ParamName);
 

--- a/src/NetMQ/ISocketPollableCollection.cs
+++ b/src/NetMQ/ISocketPollableCollection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using NetMQ.Monitoring;
 
@@ -13,7 +14,7 @@ namespace NetMQ
     public interface ISocketPollableCollection
     {
         void Add([NotNull] ISocketPollable socket);
-        void Remove([NotNull] ISocketPollable socket);
+        Task Remove([NotNull] ISocketPollable socket);
         void RemoveAndDispose<T>(T socket) where T : ISocketPollable, IDisposable;
     }
 }

--- a/src/NetMQ/ISocketPollableCollection.cs
+++ b/src/NetMQ/ISocketPollableCollection.cs
@@ -14,7 +14,7 @@ namespace NetMQ
     public interface ISocketPollableCollection
     {
         void Add([NotNull] ISocketPollable socket);
-        Task Remove([NotNull] ISocketPollable socket);
+        void Remove([NotNull] ISocketPollable socket);
         void RemoveAndDispose<T>(T socket) where T : ISocketPollable, IDisposable;
     }
 }

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -130,4 +130,22 @@
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.4" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <PackageReference Include="Microsoft.Bcl.Async">
+      <Version>1.0.168</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
+    <PackageReference Include="Microsoft.Bcl.Async">
+      <Version>1.0.168</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.Async">
+      <Version>1.0.168</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -269,28 +269,11 @@ namespace NetMQ
 
         public void RemoveAndDispose<T>(T socket) where T : ISocketPollable, IDisposable
         {
-            if (socket == null)
-                throw new ArgumentNullException(nameof(socket));
-            if (socket.IsDisposed)
-                throw new ArgumentException("Must not be disposed.", nameof(socket));
-            CheckDisposed();
+            //call the remove method
+            Remove(socket);
 
-            Run(() =>
-            {
-                // Ensure the socket wasn't disposed while this code was waiting to be run on the poller thread
-                if (socket.IsDisposed)
-                    throw new InvalidOperationException(
-                        $"{nameof(NetMQPoller)}.{nameof(RemoveAndDispose)} was called from a non-poller thread, " +
-                        "so ran asynchronously. " +
-                        $"The {socket.GetType().Name} being removed was disposed while the remove " +
-                        $"operation waited to start on the poller thread. When using {nameof(RemoveAndDispose)} " +
-                        "you should not dispose the pollable object .");
-
-                socket.Socket.EventsChanged -= OnSocketEventsChanged;
-                m_sockets.Remove(socket.Socket);
-                m_isPollSetDirty = true;
-                socket.Dispose();
-            });
+            //dispose of socket
+            socket.Dispose();
         }
 
         public void Remove([NotNull] NetMQTimer timer)

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -235,7 +235,7 @@ namespace NetMQ
             });
         }
 
-        public Task Remove(ISocketPollable socket)
+        public async void Remove(ISocketPollable socket)
         {
             if (socket == null)
                 throw new ArgumentNullException(nameof(socket));
@@ -243,7 +243,7 @@ namespace NetMQ
                 throw new ArgumentException("Must not be disposed.", nameof(socket));
             CheckDisposed();
 
-            return Run(() =>
+            await Run(() =>
             {
                 // Ensure the socket wasn't disposed while this code was waiting to be run on the poller thread
                 if (socket.IsDisposed)

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -284,7 +284,7 @@ namespace NetMQ
 
             timer.When = -1;
 
-            Run(() => m_timers.Remove(timer));
+            Run(() => m_timers.Remove(timer)).Wait();
         }
 
         public void Remove([NotNull] Socket socket)
@@ -297,7 +297,8 @@ namespace NetMQ
             {
                 m_pollinSockets.Remove(socket);
                 m_isPollSetDirty = true;
-            });
+            })
+            .Wait();
         }
 
         #endregion


### PR DESCRIPTION
This should fix #834 and a few other similar potential bugs in other versions of ```Remove()```, and ```RemoveAndDispose()```

See a few other comments on a couple of the tests and about throwing ```ArgumentException``` from ```Remove()``` when socket is disposed.  Those should be left to a future PR, though.