### PR TITLE
problem: Pub socket is not able to remove disconnected pipes

### DIFF
--- a/src/NetMQ/Core/Options.cs
+++ b/src/NetMQ/Core/Options.cs
@@ -36,8 +36,6 @@ namespace NetMQ.Core
         public Options()
         {
             Backlog = 100;
-            DelayOnClose = true;
-            DelayOnDisconnect = true;
             Endian = Endianness.Big;
             IPv4Only = true;
             Linger = -1;
@@ -82,21 +80,7 @@ namespace NetMQ.Core
         /// The default value is false.
         /// </summary>
         public bool DelayAttachOnConnect { get; set; }
-
-        /// <summary>
-        /// If true, session reads all the pending messages from the pipe and
-        /// sends them to the network when socket is closed.
-        /// The default value is true.
-        /// </summary>
-        public bool DelayOnClose { get; set; }
-
-        /// <summary>
-        /// If true, socket reads all the messages from the pipe and delivers
-        /// them to the user when the peer terminates.
-        /// The default value is true.
-        /// </summary>
-        public bool DelayOnDisconnect { get; set; }
-
+        
         /// <summary>
         /// Get or set the Endian-ness, which indicates whether the most-significant bits are placed higher or lower in memory.
         /// The default value is Endianness.Big.

--- a/src/NetMQ/Core/Patterns/Pub.cs
+++ b/src/NetMQ/Core/Patterns/Pub.cs
@@ -33,6 +33,15 @@ namespace NetMQ.Core.Patterns
             {}
         }
 
+        protected override void XAttachPipe(Pipe pipe, bool icanhasall)
+        {
+            // Don't delay pipe termination as there is no one
+            // to receive the delimiter.
+            pipe.SetNoDelay();
+            
+            base.XAttachPipe(pipe, icanhasall);
+        }
+
         public Pub([NotNull] Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {

--- a/src/NetMQ/Core/Patterns/Push.cs
+++ b/src/NetMQ/Core/Patterns/Push.cs
@@ -55,6 +55,11 @@ namespace NetMQ.Core.Patterns
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
             Debug.Assert(pipe != null);
+            
+            // Don't delay pipe termination as there is no one
+            // to receive the delimiter.
+            pipe.SetNoDelay();
+            
             m_loadBalancer.Attach(pipe);
         }
 

--- a/src/NetMQ/Core/Pipe.cs
+++ b/src/NetMQ/Core/Pipe.cs
@@ -151,7 +151,7 @@ namespace NetMQ.Core
         /// </remarks>
         private Pipe(
             [NotNull] ZObject parent, [NotNull] YPipe<Msg> inboundPipe, [NotNull] YPipe<Msg> outboundPipe,
-            int inHighWatermark, int outHighWatermark, int predefinedLowWatermark, bool delay)
+            int inHighWatermark, int outHighWatermark, int predefinedLowWatermark)
             : base(parent)
         {
             m_parent = parent;
@@ -167,7 +167,7 @@ namespace NetMQ.Core
             m_peer = null;
             m_sink = null;
             m_state = State.Active;
-            m_delay = delay;
+            m_delay = true;
         }
 
         /// <summary>
@@ -183,7 +183,7 @@ namespace NetMQ.Core
         /// terminates straight away.</param>
         /// <returns>A pipe pair for bi-directional transfer of messages. </returns>
         [NotNull]
-        public static Pipe[] PipePair([NotNull] ZObject[] parents, [NotNull] int[] highWaterMarks, [NotNull] int[] lowWaterMarks, [NotNull] bool[] delays)
+        public static Pipe[] PipePair([NotNull] ZObject[] parents, [NotNull] int[] highWaterMarks, [NotNull] int[] lowWaterMarks)
         {
             // Creates two pipe objects. These objects are connected by two ypipes,
             // each to pass messages in one direction.
@@ -193,8 +193,8 @@ namespace NetMQ.Core
 
             var pipes = new[]
             {
-                new Pipe(parents[0], upipe1, upipe2, highWaterMarks[1], highWaterMarks[0], lowWaterMarks[1], delays[0]),
-                new Pipe(parents[1], upipe2, upipe1, highWaterMarks[0], highWaterMarks[1], lowWaterMarks[0], delays[1])
+                new Pipe(parents[0], upipe1, upipe2, highWaterMarks[1], highWaterMarks[0], lowWaterMarks[1]),
+                new Pipe(parents[1], upipe2, upipe1, highWaterMarks[0], highWaterMarks[1], lowWaterMarks[0])
             };
 
             pipes[0].SetPeer(pipes[1]);
@@ -204,6 +204,14 @@ namespace NetMQ.Core
         }
 
         public bool Active => m_state == State.Active;
+
+        /// <summary>
+        /// Set the pipe to not delay termination, for sockets that don't process inbound messages, e.g PUSH, PUB
+        /// </summary>
+        public void SetNoDelay()
+        {
+            m_delay = false;
+        }
 
         /// <summary>
         /// <see cref="PipePair"/> uses this function to let us know about the peer pipe object.

--- a/src/NetMQ/Core/SessionBase.cs
+++ b/src/NetMQ/Core/SessionBase.cs
@@ -393,8 +393,7 @@ namespace NetMQ.Core
                 ZObject[] parents = { this, m_socket };
                 int[] highWaterMarks = { m_options.ReceiveHighWatermark, m_options.SendHighWatermark };
                 int[] lowWaterMarks = { m_options.ReceiveLowWatermark, m_options.SendLowWatermark };
-                bool[] delays = { m_options.DelayOnClose, m_options.DelayOnDisconnect };
-                Pipe[] pipes = Pipe.PipePair(parents, highWaterMarks, lowWaterMarks, delays);
+                Pipe[] pipes = Pipe.PipePair(parents, highWaterMarks, lowWaterMarks);
 
                 // Plug the local end of the pipe.
                 pipes[0].SetEventSink(this);

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -608,8 +608,7 @@ namespace NetMQ.Core
                 ZObject[] parents = { this, peer.Socket };
                 int[] highWaterMarks = { sndhwm, rcvhwm };
                 int[] lowWaterMarks = { sndlwm, rcvlwm };
-                bool[] delays = { m_options.DelayOnDisconnect, m_options.DelayOnClose };
-                Pipe[] pipes = Pipe.PipePair(parents, highWaterMarks, lowWaterMarks, delays);
+                Pipe[] pipes = Pipe.PipePair(parents, highWaterMarks, lowWaterMarks);
 
                 // Attach local end of the pipe to this socket object.
                 AttachPipe(pipes[0]);
@@ -704,8 +703,7 @@ namespace NetMQ.Core
                 ZObject[] parents = { this, session };
                 int[] hwms = { m_options.SendHighWatermark, m_options.ReceiveHighWatermark };
                 int[] lwms = { m_options.SendLowWatermark, m_options.ReceiveLowWatermark };
-                bool[] delays = { m_options.DelayOnDisconnect, m_options.DelayOnClose };
-                Pipe[] pipes = Pipe.PipePair(parents, hwms, lwms, delays);
+                Pipe[] pipes = Pipe.PipePair(parents, hwms, lwms);
 
                 // Attach local end of the pipe to the socket object.
                 AttachPipe(pipes[0], icanhasall);


### PR DESCRIPTION
Solution: Pub (and Push) sockets should not delay termination and wait for delimiter, as they are not processing msgs