### PR TITLE
Configure codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  range: 65..95
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+        base: auto
+
+comment:
+  require_changes: true
+  layout: "diff, files"


### PR DESCRIPTION
In #849, it was suggested to use codecov as commit status. Therefore in this pull request, *codecov.yml*, codecov configuration file was added. After this pull request was merged, it expects to work well and to see it between commit statuses. All pull requests will become to increase code coverage.