### PR TITLE
Feature/858 atomiccounter pooling

### DIFF
--- a/src/NetMQ.Tests/MockBufferPool.cs
+++ b/src/NetMQ.Tests/MockBufferPool.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace NetMQ.Tests
 {
+
     public sealed class MockBufferPool : IBufferPool
     {
         public int TakeCallCount { get; private set; }

--- a/src/NetMQ.Tests/MockCounterPool.cs
+++ b/src/NetMQ.Tests/MockCounterPool.cs
@@ -1,0 +1,37 @@
+﻿using NetMQ.Core.Utils;
+using System;
+
+namespace NetMQ.Tests
+{
+    public sealed class MockCounterPool : IAtomicCounterPool
+    {
+        public int TakeCallCount { get; private set; }        
+        public int ReturnCallCount { get; private set; }
+        
+        public MockCounterPool()
+        {
+            
+        }
+
+        public void Reset()
+        {
+            TakeCallCount = 0;
+            ReturnCallCount = 0;            
+        }
+
+        public AtomicCounter Take()
+        {
+            TakeCallCount++;
+            return new AtomicCounter();
+        }
+
+        public void Return(AtomicCounter counter)
+        {
+            ReturnCallCount++;
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+    }
+}

--- a/src/NetMQ.Tests/MsgTests.cs
+++ b/src/NetMQ.Tests/MsgTests.cs
@@ -189,15 +189,20 @@ namespace NetMQ.Tests
         {
             var pool = new MockBufferPool();
             BufferPool.SetCustomBufferPool(pool);
+            
+            var counterPool = new MockCounterPool();
+            AtomicCounterPool.SetCustomCounterPool(counterPool);
 
             var msg = new Msg();
 
             Assert.Equal(0, pool.TakeCallCount);
+            Assert.Equal(0, counterPool.TakeCallCount);
 
             msg.InitPool(100);
 
             Assert.Equal(1, pool.TakeCallCount);
             Assert.Equal(100, pool.TakeSize[0]);
+            Assert.Equal(1, counterPool.TakeCallCount);
 
             Assert.Equal(100, msg.Size);
             Assert.Equal(MsgType.Pool, msg.MsgType);
@@ -210,6 +215,7 @@ namespace NetMQ.Tests
             Assert.True(msg.IsInitialised);
 
             Assert.Equal(0, pool.ReturnCallCount);
+            Assert.Equal(0, counterPool.ReturnCallCount);
 
             var bytes = msg.UnsafeData;
 
@@ -217,6 +223,8 @@ namespace NetMQ.Tests
 
             Assert.Equal(1, pool.ReturnCallCount);
             Assert.Same(bytes, pool.ReturnBuffer[0]);
+
+            Assert.Equal(1, counterPool.ReturnCallCount);
 
             Assert.Equal(MsgType.Uninitialised, msg.MsgType);
             Assert.Null(msg.UnsafeData);
@@ -240,7 +248,10 @@ namespace NetMQ.Tests
         public void CopyPooled()
         {
             var pool = new MockBufferPool();
-            BufferPool.SetCustomBufferPool(pool);
+            BufferPool.SetCustomBufferPool(pool); 
+            
+            var counterPool = new MockCounterPool();            
+            AtomicCounterPool.SetCustomCounterPool(counterPool);
 
             var msg = new Msg();
             msg.InitPool(100);
@@ -256,12 +267,14 @@ namespace NetMQ.Tests
             msg.Close();
 
             Assert.Equal(0, pool.ReturnCallCount);
+            Assert.Equal(1, counterPool.ReturnCallCount);
             Assert.False(msg.IsInitialised);
-            Assert.Null(msg.UnsafeData);
+            Assert.Null(msg.UnsafeData);            
 
             copy.Close();
 
             Assert.Equal(1, pool.ReturnCallCount);
+            Assert.Equal(2, counterPool.ReturnCallCount);
             Assert.False(copy.IsInitialised);
             Assert.Null(copy.UnsafeData);
         }

--- a/src/NetMQ/AtomicCounterPool.cs
+++ b/src/NetMQ/AtomicCounterPool.cs
@@ -1,0 +1,128 @@
+﻿using JetBrains.Annotations;
+using NetMQ.Core.Utils;
+using System;
+using System.Threading;
+
+namespace NetMQ
+{
+    /// <summary>
+    /// The IBufferPool interface specifies two methods: Take, and Return.
+    /// These provide for taking atomic counters from a common pool, and returning them.
+    /// </summary>
+    public interface IAtomicCounterPool : IDisposable
+    {
+        /// <summary>
+        /// Take an AtomicCounter from the pool.
+        /// </summary>
+        /// <returns>an atomic counter</returns>
+        [NotNull]
+        AtomicCounter Take();
+
+        /// <summary>
+        /// Return the given atomic counter to the common pool.
+        /// </summary>
+        /// <param name="counter">the atomic counter to return to the buffer-pool</param>
+        void Return([NotNull] AtomicCounter counter);
+    }
+
+    /// <summary>
+    /// This simple implementation of <see cref="IAtomicCounterPool"/> does no pooling. Instead, it uses regular
+    /// .NET memory management to allocate a counter each time <see cref="Take"/> is called. Unused counters
+    /// passed to <see cref="Return"/> are simply left for the .NET garbage collector to deal with.
+    /// </summary>
+    public class GCAtomicCounterPool : IAtomicCounterPool
+    {
+        /// <summary>
+        /// Return a newly-allocated atomic counterfrom the pool.
+        /// </summary>
+        /// <returns>an atomic counter</returns>
+        public AtomicCounter Take()
+        {
+            return new AtomicCounter();
+        }
+
+        /// <summary>
+        /// The expectation of an actual pool is that this method returns the given counter to the manager pool.
+        /// This particular implementation does nothing.
+        /// </summary>
+        /// <param name="counter">a reference to the counter being returned</param>
+        public void Return(AtomicCounter counter)
+        { }
+
+        /// <summary>
+        /// The expectation of an actual pool is that the Dispose method will release the pools currently cached in this manager.
+        /// This particular implementation does nothing.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Release the counters currently cached in this manager (however in this case, this does nothing).
+        /// </summary>
+        /// <param name="disposing">true if managed resources are to be disposed</param>
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a singleton instance of <see cref="IAtomicCounterPool"/> used for allocating atomic counters
+    /// for <see cref="Msg"/> instances with type <see cref="MsgType.Pool"/>.
+    /// </summary>
+    /// <remarks>
+    /// Sending and receiving messages with pooling mode, requires the use of atomic counters. 
+    /// You can use the AtomicCounterPool class to pool counters for reuse, reducing allocation, deallocation and garbage collection.
+    /// <para/>
+    /// The default implementation is <see cref="GCAtomicCounterPool"/>.
+    /// <list type="bullet">
+    /// <item>Call <see cref="SetGCCounterPool"/> to reinstate the default <see cref="GCBufferPool"/>.</item>
+    /// <item>Call <see cref="SetCustomCounterPool"/> to substitute a custom implementation for the allocation and
+    /// deallocation of atomic counters.</item>
+    /// </list>
+    /// </remarks>
+    public static class AtomicCounterPool
+    {
+        private static IAtomicCounterPool s_counterPool = new GCAtomicCounterPool();
+
+        /// <summary>
+        /// Set BufferPool to use the <see cref="GCBufferPool"/> (which it does by default).
+        /// </summary>
+        public static void SetGCCounterPool()
+        {
+            SetCustomCounterPool(new GCAtomicCounterPool());
+        }
+
+        /// <summary>
+        /// Set BufferPool to use the specified IAtomicCounterPool implementation to manage the pool.
+        /// </summary>
+        /// <param name="counterPool">the implementation of <see cref="IAtomicCounterPool"/> to use</param>
+        public static void SetCustomCounterPool([NotNull] IAtomicCounterPool counterPool)
+        {
+            var prior = Interlocked.Exchange(ref s_counterPool, counterPool);
+
+            prior?.Dispose();
+        }
+
+        /// <summary>
+        /// Allocate an atomic counter from the current <see cref="IAtomicCounterPool"/>.
+        /// </summary>
+        /// <returns>an atomic counter</returns>
+        [NotNull]
+        public static AtomicCounter Take()
+        {
+            return s_counterPool.Take();
+        }
+
+        /// <summary>
+        /// Returns <paramref name="counter"/> to the <see cref="IAtomicCounterPool"/>.
+        /// </summary>
+        /// <param name="counter">The atomic counter to be returned to the pool.</param>
+        public static void Return([NotNull] AtomicCounter counter)
+        {
+            s_counterPool.Return(counter);
+        }
+    }
+}

--- a/src/NetMQ/BufferPool.cs
+++ b/src/NetMQ/BufferPool.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using JetBrains.Annotations;
 
 namespace NetMQ
-{
+{    
     /// <summary>
     /// The IBufferPool interface specifies two methods: Take, and Return.
     /// These provide for taking byte-array data from a common pool, and returning it.

--- a/src/NetMQ/Core/Utils/AtomicCounter.cs
+++ b/src/NetMQ/Core/Utils/AtomicCounter.cs
@@ -6,7 +6,7 @@ namespace NetMQ.Core.Utils
     /// This class simply provides a counter-value, which may be set, increased, and decremented.
     /// Increase and Decrement are both thread-safe operations.
     /// </summary>
-    internal sealed class AtomicCounter
+    public sealed class AtomicCounter
     {
         private int m_value;
 


### PR DESCRIPTION
Solves #858 by adding a pooling mechanism for `AtomicCounter` instances. In order to allow custom implementations of `IAtomicCounterPool`, I've had to make the `AtomicCounter` class visible publicly.