### PR TITLE
Shortened NetMQPoller thread name

### DIFF
--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -418,7 +418,7 @@ namespace NetMQ
         /// </remarks>
         public void RunAsync()
         {
-            RunAsync("NetMQPollerThread");
+            RunAsync("NetMQPoller");
         }
 
         /// <summary>


### PR DESCRIPTION
Thread names on Linux (.NET 5) have a max length of 16 chars.

![image](https://user-images.githubusercontent.com/1031306/78164470-b402cc80-7441-11ea-9fce-ff69c8dcb6d1.png)
