### PR TITLE
problem: ZMQ_HEARTBEAT is not useful without sending an hello message

### DIFF
--- a/src/NetMQ.Tests/SocketOptionsTests.cs
+++ b/src/NetMQ.Tests/SocketOptionsTests.cs
@@ -109,5 +109,43 @@ namespace NetMQ.Tests
 //                Assert.Equal(true, socket.Options.ManualPublisher);
             }
         }
+
+        [Fact]
+        public void HelloMsgTcp()
+        {
+            // Create a router
+            using var router = new RouterSocket();
+            router.Options.HelloMessage = new byte[] {(byte)'H'};
+            
+            // bind router
+            int port = router.BindRandomPort("tcp://*");
+            
+            // create a dealer
+            using var dealer = new DealerSocket();
+            dealer.Connect($"tcp://localhost:{port}");
+
+            var msg = dealer.ReceiveFrameString();
+            
+            Assert.Equal("H", msg);
+        }
+        
+        [Fact]
+        public void HelloMsgInproc()
+        {
+            // Create a router
+            using var router = new RouterSocket();
+            router.Options.HelloMessage = new byte[] {(byte)'H'};
+            
+            // bind router
+            router.Bind("inproc://inproc-hello-msg");
+            
+            // create a dealer
+            using var dealer = new DealerSocket();
+            dealer.Connect("inproc://inproc-hello-msg");
+
+            var msg = dealer.ReceiveFrameString();
+            
+            Assert.Equal("H", msg);
+        }
     }
 }

--- a/src/NetMQ/Core/HellloMsgSession.cs
+++ b/src/NetMQ/Core/HellloMsgSession.cs
@@ -1,0 +1,34 @@
+using JetBrains.Annotations;
+
+namespace NetMQ.Core
+{
+    class HelloMsgSession : SessionBase
+    {
+        bool m_newPipe;
+
+        public HelloMsgSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr) : 
+            base(ioThread, connect, socket, options, addr)
+        {
+            m_newPipe = true;
+        }
+
+        public override PullMsgResult PullMsg(ref Msg msg)
+        {
+            if (m_newPipe)
+            {
+                m_newPipe = false;
+                msg.InitPool(m_options.HelloMsg.Length);
+                msg.Put(m_options.HelloMsg, 0, m_options.HelloMsg.Length);
+                return PullMsgResult.Ok;
+            }
+
+            return base.PullMsg(ref msg);
+        }
+
+        protected override void Reset()
+        {
+            base.Reset();
+            m_newPipe = true;
+        }
+    }
+}

--- a/src/NetMQ/Core/Options.cs
+++ b/src/NetMQ/Core/Options.cs
@@ -64,6 +64,8 @@ namespace NetMQ.Core
             HeartbeatTtl = 0;
             HeartbeatInterval = 0;
             HeartbeatTimeout = -1;
+            HelloMsg = null;
+            CanSendHelloMsg = false;
         }
 
         /// <summary>
@@ -313,6 +315,15 @@ namespace NetMQ.Core
         /// </summary>
         public int HeartbeatTimeout { get; set; }
         
+        /// <summary>
+        /// Hello msg to send to peer upon connecting
+        /// </summary>
+        public byte[] HelloMsg { get; set; }
+        
+        /// <summary>
+        /// Indicate of socket can send an hello msg
+        /// </summary>
+        public bool CanSendHelloMsg { get; set; }
         
         /// <summary>
         /// Assign the given optionValue to the specified option.
@@ -491,6 +502,22 @@ namespace NetMQ.Core
                         throw new InvalidException("Curve key size must be 32 bytes");
                     Mechanism = MechanismType.Curve;
                     Buffer.BlockCopy(key, 0, CurveServerKey, 0, 32);
+                    break;
+                }
+
+                case ZmqSocketOption.HelloMessage:
+                {
+                    if (optionValue == null)
+                    {
+                        HelloMsg = null;
+                    }
+                    else
+                    {
+                        var helloMsg = (byte[]) optionValue;
+                        HelloMsg = new byte[helloMsg.Length];
+                    
+                        Buffer.BlockCopy(helloMsg, 0, HelloMsg, 0, helloMsg.Length);
+                    }
                     break;
                 }
                 

--- a/src/NetMQ/Core/Patterns/Dealer.cs
+++ b/src/NetMQ/Core/Patterns/Dealer.cs
@@ -32,24 +32,6 @@ namespace NetMQ.Core.Patterns
     internal class Dealer : SocketBase
     {
         /// <summary>
-        /// A DealerSession is a SessionBase subclass that is contained within the Dealer class.
-        /// </summary>
-        public class DealerSession : SessionBase
-        {
-            /// <summary>
-            /// Create a new DealerSession (which is just a SessionBase).
-            /// </summary>
-            /// <param name="ioThread">the I/O-thread to associate this with</param>
-            /// <param name="connect"></param>
-            /// <param name="socket"></param>
-            /// <param name="options"></param>
-            /// <param name="addr"></param>
-            public DealerSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
-        /// <summary>
         /// Messages are fair-queued from inbound pipes. And load-balanced to
         /// the outbound pipes.
         /// </summary>
@@ -64,6 +46,7 @@ namespace NetMQ.Core.Patterns
             : base(parent, threadId, socketId)
         {
             m_options.SocketType = ZmqSocketType.Dealer;
+            m_options.CanSendHelloMsg = true;
 
             m_fairQueueing = new FairQueueing();
             m_loadBalancer = new LoadBalancer();

--- a/src/NetMQ/Core/Patterns/Pair.cs
+++ b/src/NetMQ/Core/Patterns/Pair.cs
@@ -26,13 +26,6 @@ namespace NetMQ.Core.Patterns
 {
     internal sealed class Pair : SocketBase
     {
-        public class PairSession : SessionBase
-        {
-            public PairSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
         private Pipe m_pipe;
 
         public Pair([NotNull] Ctx parent, int threadId, int socketId)

--- a/src/NetMQ/Core/Patterns/Peer.cs
+++ b/src/NetMQ/Core/Patterns/Peer.cs
@@ -37,13 +37,6 @@ namespace NetMQ.Core.Patterns
     {
         private static readonly Random s_random = new Random();
 
-        public class PeerSession : SessionBase
-        {
-            public PeerSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            { }
-        }
-
         /// <summary>
         /// An instance of class Outpipe contains a Pipe and a boolean property Active.
         /// </summary>
@@ -114,6 +107,7 @@ namespace NetMQ.Core.Patterns
         {
             m_nextPeerId = s_random.Next();
             m_options.SocketType = ZmqSocketType.Peer;
+            m_options.CanSendHelloMsg = true;
             m_fairQueueing = new FairQueueing();      
             m_prefetchedMsg = new Msg();
             m_prefetchedMsg.InitEmpty();            

--- a/src/NetMQ/Core/Patterns/Pub.cs
+++ b/src/NetMQ/Core/Patterns/Pub.cs
@@ -26,13 +26,6 @@ namespace NetMQ.Core.Patterns
 {
     internal sealed class Pub : XPub
     {
-        public class PubSession : XPubSession
-        {
-            public PubSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
             // Don't delay pipe termination as there is no one

--- a/src/NetMQ/Core/Patterns/Pull.cs
+++ b/src/NetMQ/Core/Patterns/Pull.cs
@@ -27,13 +27,6 @@ namespace NetMQ.Core.Patterns
 {
     internal sealed class Pull : SocketBase
     {
-        public class PullSession : SessionBase
-        {
-            public PullSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
         /// <summary>
         /// Fair queueing object for inbound pipes.
         /// </summary>

--- a/src/NetMQ/Core/Patterns/Push.cs
+++ b/src/NetMQ/Core/Patterns/Push.cs
@@ -27,13 +27,6 @@ namespace NetMQ.Core.Patterns
 {
     internal sealed class Push : SocketBase
     {
-        public class PushSession : SessionBase
-        {
-            public PushSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
         /// <summary>
         /// Load balancer managing the outbound pipes.
         /// </summary>

--- a/src/NetMQ/Core/Patterns/Rep.cs
+++ b/src/NetMQ/Core/Patterns/Rep.cs
@@ -25,13 +25,6 @@ namespace NetMQ.Core.Patterns
 {
     internal sealed class Rep : Router
     {
-        public class RepSession : RouterSession
-        {
-            public RepSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
         /// <summary>
         /// If true, we are in process of sending the reply. If false we are
         /// in process of receiving a request.
@@ -51,6 +44,7 @@ namespace NetMQ.Core.Patterns
             m_requestBegins = true;
 
             m_options.SocketType = ZmqSocketType.Rep;
+            m_options.CanSendHelloMsg = false;
         }
 
         /// <summary>

--- a/src/NetMQ/Core/Patterns/Req.cs
+++ b/src/NetMQ/Core/Patterns/Req.cs
@@ -54,6 +54,7 @@ namespace NetMQ.Core.Patterns
             m_receivingReply = false;
             m_messageBegins = true;
             m_options.SocketType = ZmqSocketType.Req;
+            m_options.CanSendHelloMsg = false;
         }
 
         /// <summary>
@@ -172,7 +173,7 @@ namespace NetMQ.Core.Patterns
             return base.XHasOut();
         }
 
-        public class ReqSession : DealerSession
+        public class ReqSession : SessionBase
         {
             private enum State
             {

--- a/src/NetMQ/Core/Patterns/Router.cs
+++ b/src/NetMQ/Core/Patterns/Router.cs
@@ -36,13 +36,6 @@ namespace NetMQ.Core.Patterns
     {
         private static readonly Random s_random = new Random();
 
-        public class RouterSession : SessionBase
-        {
-            public RouterSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            { }
-        }
-
         /// <summary>
         /// An instance of class Outpipe contains a Pipe and a boolean property Active.
         /// </summary>
@@ -152,6 +145,7 @@ namespace NetMQ.Core.Patterns
         {
             m_nextPeerId = s_random.Next();
             m_options.SocketType = ZmqSocketType.Router;
+            m_options.CanSendHelloMsg = true;
             m_fairQueueing = new FairQueueing();
             m_prefetchedId = new Msg();
             m_prefetchedId.InitEmpty();

--- a/src/NetMQ/Core/Patterns/Stream.cs
+++ b/src/NetMQ/Core/Patterns/Stream.cs
@@ -33,13 +33,6 @@ namespace NetMQ.Core.Patterns
     {
         private static readonly Random s_random = new Random();
 
-        public class StreamSession : SessionBase
-        {
-            public StreamSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
         private class Outpipe
         {
             public Outpipe([NotNull] Pipe pipe, bool active)

--- a/src/NetMQ/Core/Patterns/Sub.cs
+++ b/src/NetMQ/Core/Patterns/Sub.cs
@@ -27,13 +27,6 @@ namespace NetMQ.Core.Patterns
 {
     internal sealed class Sub : XSub
     {
-        public class SubSession : XSubSession
-        {
-            public SubSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
         public Sub([NotNull] Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {

--- a/src/NetMQ/Core/Patterns/XPub.cs
+++ b/src/NetMQ/Core/Patterns/XPub.cs
@@ -30,13 +30,6 @@ namespace NetMQ.Core.Patterns
 {
     internal class XPub : SocketBase
     {
-        public class XPubSession : SessionBase
-        {
-            public XPubSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
         /// <summary>
         /// List of all subscriptions mapped to corresponding pipes.
         /// </summary>

--- a/src/NetMQ/Core/Patterns/XSub.cs
+++ b/src/NetMQ/Core/Patterns/XSub.cs
@@ -28,16 +28,6 @@ namespace NetMQ.Core.Patterns
     internal class XSub : SocketBase
     {
         /// <summary>
-        /// An XSubSession is a subclass of SessionBase that provides nothing more.
-        /// </summary>
-        public class XSubSession : SessionBase
-        {
-            public XSubSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
-                : base(ioThread, connect, socket, options, addr)
-            {}
-        }
-
-        /// <summary>
         /// Fair queueing object for inbound pipes.
         /// </summary>
         private readonly FairQueueing m_fairQueueing;

--- a/src/NetMQ/Core/SessionBase.cs
+++ b/src/NetMQ/Core/SessionBase.cs
@@ -130,29 +130,21 @@ namespace NetMQ.Core
                 case ZmqSocketType.Req:
                     return new Req.ReqSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Dealer:
-                    return new Dealer.DealerSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Rep:
-                    return new Rep.RepSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Router:
-                    return new Router.RouterSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Pub:
-                    return new Pub.PubSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Xpub:
-                    return new XPub.XPubSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Sub:
-                    return new Sub.SubSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Xsub:
-                    return new XSub.XSubSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Push:
-                    return new Push.PushSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Pull:
-                    return new Pull.PullSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Pair:
-                    return new Pair.PairSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Stream:
-                    return new Stream.StreamSession(ioThread, connect, socket, options, addr);
                 case ZmqSocketType.Peer:
-                    return new Peer.PeerSession(ioThread, connect, socket, options, addr);
+                    if (options.CanSendHelloMsg && options.HelloMsg != null)
+                        return new HelloMsgSession(ioThread, connect, socket, options, addr);
+                    else
+                        return new SessionBase(ioThread, connect, socket, options, addr);
                 default:
                     throw new InvalidException("SessionBase.Create called with invalid SocketType of " + options.SocketType);
             }
@@ -217,7 +209,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="msg">a reference to a Msg to put the message into</param>
         /// <returns>true if the Msg is successfully sent</returns>
-        public PullMsgResult PullMsg(ref Msg msg)
+        public virtual PullMsgResult PullMsg(ref Msg msg)
         {
             if (m_pipe == null || !m_pipe.Read(ref msg))
                 return PullMsgResult.Empty;

--- a/src/NetMQ/Core/SocketBase.cs
+++ b/src/NetMQ/Core/SocketBase.cs
@@ -636,6 +636,28 @@ namespace NetMQ.Core
                     Debug.Assert(written);
                     pipes[1].Flush();
                 }
+                
+                //  If set, send the hello msg of the local socket to the peer.
+                if (m_options.CanSendHelloMsg && m_options.HelloMsg != null)
+                {
+                    var helloMsg = new Msg();
+                    helloMsg.InitPool(m_options.HelloMsg.Length);
+                    helloMsg.Put(m_options.HelloMsg, 0, m_options.HelloMsg.Length);
+                    bool written = pipes[0].Write(ref helloMsg);
+                    Debug.Assert(written);
+                    pipes[0].Flush();
+                }
+
+                //  If set, send the hello msg of the peer to the local socket.
+                if (peer.Options.CanSendHelloMsg && peer.Options.HelloMsg != null) 
+                {
+                    var helloMsg = new Msg();
+                    helloMsg.InitPool(peer.Options.HelloMsg.Length);
+                    helloMsg.Put(peer.Options.HelloMsg, 0, peer.Options.HelloMsg.Length);
+                    bool written = pipes[1].Write(ref helloMsg);
+                    Debug.Assert(written);
+                    pipes[1].Flush();
+                }
 
                 // Attach remote end of the pipe to the peer socket. Note that peer's
                 // seqnum was incremented in find_endpoint function. We don't need it

--- a/src/NetMQ/Core/ZmqSocketOption.cs
+++ b/src/NetMQ/Core/ZmqSocketOption.cs
@@ -333,6 +333,11 @@ namespace NetMQ.Core
         HeartbeatTimeout = 56,
         
         /// <summary>
+        /// Hello Message to send to peer upon connecting
+        /// </summary>
+        HelloMessage = 57,
+        
+        /// <summary>
         /// Specifies the byte-order: big-endian, vs little-endian.
         /// </summary>
         Endian = 1000,

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -489,5 +489,13 @@ namespace NetMQ
             get => m_socket.GetSocketOptionTimeSpan(ZmqSocketOption.HeartbeatTimeout);
             set => m_socket.SetSocketOptionTimeSpan(ZmqSocketOption.HeartbeatTimeout, value);
         }
+
+        /// <summary>
+        /// Set message to send to peer upon connecting
+        /// </summary>
+        public byte[] HelloMessage
+        {
+            set => m_socket.SetSocketOption(ZmqSocketOption.HelloMessage, value);
+        }
     }
 }


### PR DESCRIPTION
When using ZMQ_HEARTBEAT one still needs to implement application-level heartbeat in order to know when to send a hello message.
For example, with the majordomo protocol, the worker needs to send a READY message when connecting to a broker. If the connection to the broker drops, and the heartbeat recognizes it the worker won't know about it and won't send the READY msg.
To solve that, the majordomo worker still has to implement heartbeat. With this new option, whenever the connection drops and reconnects the hello message will be sent, greatly simplify the majordomo protocol, as now READY and HEARTBEAT can be handled by zeromq.