### PR TITLE
Fix design-time builds in VS

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Workaround for https://github.com/dotnet/sourcelink/issues/572 -->
+  <ItemGroup>
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
+  </ItemGroup>
+</Project>

--- a/src/NetMQ.sln
+++ b/src/NetMQ.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.travis.yml = ..\.travis.yml
 		..\appveyor.yml = ..\appveyor.yml
 		..\COPYING.LESSER = ..\COPYING.LESSER
+		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		..\mkdocs.yml = ..\mkdocs.yml
 		..\README.md = ..\README.md


### PR DESCRIPTION
Work around a bug seen as a result of producing deterministic builds.

The error was:

> SourceRoot items must include at least one top-level (not nested) item when DeterministicSourcePaths is true