### PR TITLE
Fix bug in NetMQQueue.GetEnumerator

### DIFF
--- a/src/NetMQ/NetMQQueue.cs
+++ b/src/NetMQ/NetMQQueue.cs
@@ -141,7 +141,7 @@ namespace NetMQ
         /// <inheritdoc />
         public IEnumerator<T> GetEnumerator() => m_queue.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator() { yield return GetEnumerator(); }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         #endregion
 


### PR DESCRIPTION
This problem only existed in the non-generic interface implementation.