### PR TITLE
Annotate internal patterns, utils and some public API

### DIFF
--- a/src/NetMQ.Tests/MsgTests.cs
+++ b/src/NetMQ.Tests/MsgTests.cs
@@ -25,7 +25,7 @@ namespace NetMQ.Tests
             Assert.False(msg.IsDelimiter);
             Assert.False(msg.IsIdentity);
             Assert.False(msg.IsInitialised);
-            Assert.Throws<NullReferenceException>(() => msg[0] = 1);
+            Assert.ThrowsAny<Exception>(() => msg[0] = 1);
             Assert.Throws<FaultException>((Action)msg.Close);
         }
 

--- a/src/NetMQ/Core/Address.cs
+++ b/src/NetMQ/Core/Address.cs
@@ -18,10 +18,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Net;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core
 {
@@ -65,10 +62,10 @@ namespace NetMQ.Core
         /// </summary>
         public interface IZAddress
         {
-            void Resolve([NotNull] string name, bool ip4Only);
+            void Resolve(string name, bool ip4Only);
 
-            [CanBeNull] IPEndPoint Address { get; }
-            [NotNull] string Protocol { get; }
+            IPEndPoint? Address { get; }
+            string Protocol { get; }
         }
 
         /// <summary>
@@ -76,7 +73,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="protocol">the protocol of this Address - as in tcp, ipc, pgm</param>
         /// <param name="address">a text representation of the address</param>
-        public Address([NotNull] string protocol, [NotNull] string address)
+        public Address(string protocol, string address)
         {
             Protocol = protocol;
             AddressString = address;
@@ -87,7 +84,7 @@ namespace NetMQ.Core
         /// Create a new Address instance based upon the given endpoint, assuming a protocol of tcp.
         /// </summary>
         /// <param name="endpoint">the subclass of EndPoint to base this Address upon</param>
-        public Address([NotNull] EndPoint endpoint)
+        public Address(EndPoint endpoint)
         {
             Protocol = TcpProtocol;
 
@@ -126,16 +123,13 @@ namespace NetMQ.Core
                 return Protocol + "://" + AddressString;
             }
 
-            return null; //TODO: REVIEW - Although not explicitly prohibited, returning null from ToString seems sketchy; return string.Empty?
+            return base.ToString();
         }
 
-        [NotNull]
         public string Protocol { get; }
 
-        [NotNull]
         public string AddressString { get; }
 
-        [CanBeNull]
-        public IZAddress Resolved { get; set; }
+        public IZAddress? Resolved { get; set; }
     }
 }

--- a/src/NetMQ/Core/Command.cs
+++ b/src/NetMQ/Core/Command.cs
@@ -19,10 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
-using JetBrains.Annotations;
-
 namespace NetMQ.Core
 {
     /// <summary>
@@ -36,7 +32,7 @@ namespace NetMQ.Core
         /// <param name="destination">a ZObject that denotes the destination for this command</param>
         /// <param name="type">the CommandType of the new command</param>
         /// <param name="arg">an Object to comprise the argument for the command (optional)</param>
-        public Command([CanBeNull] ZObject destination, CommandType type, [CanBeNull] object arg = null) : this()
+        public Command(ZObject? destination, CommandType type, object? arg = null) : this()
         {
             Destination = destination;
             CommandType = type;
@@ -44,8 +40,7 @@ namespace NetMQ.Core
         }
 
         /// <summary>The destination to which the command should be applied.</summary>
-        [CanBeNull]
-        public ZObject Destination { get; }
+        public ZObject? Destination { get; }
 
         /// <summary>The type of this command.</summary>
         public CommandType CommandType { get; }
@@ -53,8 +48,7 @@ namespace NetMQ.Core
         /// <summary>
         /// Get the argument to this command.
         /// </summary>
-        [CanBeNull]
-        public object Arg { get; }
+        public object? Arg { get; }
 
         /// <summary>
         /// Override of ToString, which returns a string in the form [ command-type, destination ].

--- a/src/NetMQ/Core/CommandType.cs
+++ b/src/NetMQ/Core/CommandType.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace NetMQ.Core
 {
     /// <summary>

--- a/src/NetMQ/Core/Config.cs
+++ b/src/NetMQ/Core/Config.cs
@@ -19,8 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 namespace NetMQ.Core
 {
     /// <summary>

--- a/src/NetMQ/Core/ErrorHelper.cs
+++ b/src/NetMQ/Core/ErrorHelper.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Net.Sockets;
 
 namespace NetMQ.Core

--- a/src/NetMQ/Core/HellloMsgSession.cs
+++ b/src/NetMQ/Core/HellloMsgSession.cs
@@ -1,14 +1,10 @@
-#nullable disable
-
-using JetBrains.Annotations;
-
 namespace NetMQ.Core
 {
     class HelloMsgSession : SessionBase
     {
         bool m_newPipe;
 
-        public HelloMsgSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr) : 
+        public HelloMsgSession(IOThread ioThread, bool connect, SocketBase socket, Options options, Address addr) : 
             base(ioThread, connect, socket, options, addr)
         {
             m_newPipe = true;
@@ -18,6 +14,8 @@ namespace NetMQ.Core
         {
             if (m_newPipe)
             {
+                Assumes.NotNull(m_options.HelloMsg);
+
                 m_newPipe = false;
                 msg.InitPool(m_options.HelloMsg.Length);
                 msg.Put(m_options.HelloMsg, 0, m_options.HelloMsg.Length);

--- a/src/NetMQ/Core/IMailbox.cs
+++ b/src/NetMQ/Core/IMailbox.cs
@@ -1,12 +1,8 @@
-#nullable disable
-
-using JetBrains.Annotations;
-
 namespace NetMQ.Core
 {
     internal interface IMailbox
     {
-        void Send([NotNull] Command command);
+        void Send(Command command);
 
         bool TryRecv(int timeout, out Command command);
 

--- a/src/NetMQ/Core/IOObject.cs
+++ b/src/NetMQ/Core/IOObject.cs
@@ -19,12 +19,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Net.Sockets;
 using AsyncIO;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core
 {
@@ -35,16 +32,14 @@ namespace NetMQ.Core
     /// </summary>
     internal class IOObject : IProactorEvents
     {
-        [CanBeNull]
-        private IOThread m_ioThread;
-        [CanBeNull]
-        private IProactorEvents m_handler;
+        private IOThread? m_ioThread;
+        private IProactorEvents? m_handler;
 
         /// <summary>
         /// Create a new IOObject object and plug it into the given IOThread.
         /// </summary>
         /// <param name="ioThread">the IOThread to plug this new IOObject into.</param>
-        public IOObject([CanBeNull] IOThread ioThread)
+        public IOObject(IOThread? ioThread)
         {
             if (ioThread != null)
                 Plug(ioThread);
@@ -58,7 +53,7 @@ namespace NetMQ.Core
         /// When migrating an object from one I/O thread to another, first
         /// unplug it, then migrate it, then plug it to the new thread.
         /// </remarks>
-        public void Plug([NotNull] IOThread ioThread)
+        public void Plug(IOThread ioThread)
         {
             Debug.Assert(ioThread != null);
 
@@ -74,7 +69,7 @@ namespace NetMQ.Core
         /// </remarks>
         public void Unplug()
         {
-            Debug.Assert(m_ioThread != null);
+            Assumes.NotNull(m_ioThread);
 
             // Forget about old poller in preparation to be migrated
             // to a different I/O thread.
@@ -86,8 +81,9 @@ namespace NetMQ.Core
         /// Add the given socket to the Proactor.
         /// </summary>
         /// <param name="socket">the AsyncSocket to add</param>
-        public void AddSocket([NotNull] AsyncSocket socket)
+        public void AddSocket(AsyncSocket socket)
         {
+            Assumes.NotNull(m_ioThread);
             m_ioThread.Proactor.AddSocket(socket, this);
         }
 
@@ -95,8 +91,9 @@ namespace NetMQ.Core
         /// Remove the given socket from the Proactor.
         /// </summary>
         /// <param name="socket">the AsyncSocket to remove</param>
-        public void RemoveSocket([NotNull] AsyncSocket socket)
+        public void RemoveSocket(AsyncSocket socket)
         {
+            Assumes.NotNull(m_ioThread);
             m_ioThread.Proactor.RemoveSocket(socket);
         }
 
@@ -107,6 +104,7 @@ namespace NetMQ.Core
         /// <param name="bytesTransferred">the number of bytes that were transferred</param>
         public virtual void InCompleted(SocketError socketError, int bytesTransferred)
         {
+            Assumes.NotNull(m_handler);
             m_handler.InCompleted(socketError, bytesTransferred);
         }
 
@@ -117,6 +115,7 @@ namespace NetMQ.Core
         /// <param name="bytesTransferred">the number of bytes that were transferred</param>
         public virtual void OutCompleted(SocketError socketError, int bytesTransferred)
         {
+            Assumes.NotNull(m_handler);
             m_handler.OutCompleted(socketError, bytesTransferred);
         }
 
@@ -126,21 +125,24 @@ namespace NetMQ.Core
         /// <param name="id">an integer used to identify the timer</param>
         public virtual void TimerEvent(int id)
         {
+            Assumes.NotNull(m_handler);
             m_handler.TimerEvent(id);
         }
 
         public void AddTimer(long timeout, int id)
         {
+            Assumes.NotNull(m_ioThread);
             m_ioThread.Proactor.AddTimer(timeout, this, id);
         }
 
-        public void SetHandler([NotNull] IProactorEvents handler)
+        public void SetHandler(IProactorEvents handler)
         {
             m_handler = handler;
         }
 
         public void CancelTimer(int id)
         {
+            Assumes.NotNull(m_ioThread);
             m_ioThread.Proactor.CancelTimer(this, id);
         }
     }

--- a/src/NetMQ/Core/IOThread.cs
+++ b/src/NetMQ/Core/IOThread.cs
@@ -19,9 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
-using JetBrains.Annotations;
 using NetMQ.Core.Utils;
 
 namespace NetMQ.Core
@@ -50,7 +47,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="ctx">the Ctx (context) for this thread to live within</param>
         /// <param name="threadId">the integer thread-id for this new IOThread</param>
-        public IOThread([NotNull] Ctx ctx, int threadId)
+        public IOThread(Ctx ctx, int threadId)
             : base(ctx, threadId)
         {
             var name = "iothread-" + threadId;
@@ -62,7 +59,6 @@ namespace NetMQ.Core
 #endif
         }
 
-        [NotNull]
         internal Proactor Proactor => m_proactor;
 
         public void Start()
@@ -81,7 +77,6 @@ namespace NetMQ.Core
             SendStop();
         }
 
-        [NotNull]
         public IMailbox Mailbox => m_mailbox;
 
         public int Load => m_proactor.Load;
@@ -95,7 +90,10 @@ namespace NetMQ.Core
         {
             // Process all available commands.
             while (m_mailbox.TryRecv(out Command command))
+            {
+                Assumes.NotNull(command.Destination);
                 command.Destination.ProcessCommand(command);
+            }
         }
 
 #if DEBUG

--- a/src/NetMQ/Core/IPollEvents.cs
+++ b/src/NetMQ/Core/IPollEvents.cs
@@ -19,8 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 namespace NetMQ.Core
 {
     /// <summary>

--- a/src/NetMQ/Core/IProactorEvents.cs
+++ b/src/NetMQ/Core/IProactorEvents.cs
@@ -19,8 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Net.Sockets;
 
 namespace NetMQ.Core

--- a/src/NetMQ/Core/ITimerEvent.cs
+++ b/src/NetMQ/Core/ITimerEvent.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-namespace NetMQ.Core
+﻿namespace NetMQ.Core
 {
     /// <summary>
     /// The ITimerEvent interface mandates a TimerEvent( int id ) method,

--- a/src/NetMQ/Core/Mailbox.cs
+++ b/src/NetMQ/Core/Mailbox.cs
@@ -19,11 +19,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Net.Sockets;
-using JetBrains.Annotations;
 using NetMQ.Core.Utils;
 
 namespace NetMQ.Core
@@ -35,11 +32,11 @@ namespace NetMQ.Core
 
     internal class IOThreadMailbox : IMailbox
     {
-        [NotNull] private readonly Proactor m_proactor;
+        private readonly Proactor m_proactor;
 
-        [NotNull] private readonly IMailboxEvent m_mailboxEvent;
+        private readonly IMailboxEvent m_mailboxEvent;
 
-        [NotNull] private readonly YPipe<Command> m_commandPipe = new YPipe<Command>(Config.CommandPipeGranularity, "mailbox");
+        private readonly YPipe<Command> m_commandPipe = new YPipe<Command>(Config.CommandPipeGranularity, "mailbox");
 
         /// <summary>
         /// There's only one thread receiving from the mailbox, but there
@@ -47,16 +44,16 @@ namespace NetMQ.Core
         /// synchronised access on both of its endpoints, we have to synchronize
         /// the sending side.
         /// </summary>
-        [NotNull] private readonly object m_sync = new object();
+        private readonly object m_sync = new object();
 
 #if DEBUG
         /// <summary>Mailbox name. Only used for debugging.</summary>
-        [NotNull] private readonly string m_name;
+        private readonly string m_name;
 #endif
 
         private bool m_disposed;
 
-        public IOThreadMailbox([NotNull] string name, [NotNull] Proactor proactor, [NotNull] IMailboxEvent mailboxEvent)
+        public IOThreadMailbox(string name, Proactor proactor, IMailboxEvent mailboxEvent)
         {
             m_proactor = proactor;
             m_mailboxEvent = mailboxEvent;
@@ -146,14 +143,14 @@ namespace NetMQ.Core
 
 #if DEBUG
         /// <summary>Mailbox name. Only used for debugging.</summary>
-        [NotNull] private readonly string m_name;
+        private readonly string m_name;
 #endif
 
         /// <summary>
         /// Create a new Mailbox with the given name.
         /// </summary>
         /// <param name="name">the name to give this new Mailbox</param>
-        public Mailbox([NotNull] string name)
+        public Mailbox(string name)
         {
             // Get the pipe into passive state. That way, if the users starts by
             // polling on the associated file descriptor it will get woken up when
@@ -173,7 +170,6 @@ namespace NetMQ.Core
         /// <summary>
         /// Get the socket-handle contained by the Signaler.
         /// </summary>
-        [NotNull]
         public Socket Handle => m_signaler.Handle;
 
         /// <summary>

--- a/src/NetMQ/Core/MailboxSafe.cs
+++ b/src/NetMQ/Core/MailboxSafe.cs
@@ -1,9 +1,6 @@
-#nullable disable
-
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
-using JetBrains.Annotations;
 using NetMQ.Core.Utils;
 
 namespace NetMQ.Core
@@ -22,7 +19,7 @@ namespace NetMQ.Core
 
 #if DEBUG
         /// <summary>Mailbox name. Only used for debugging.</summary>
-        [NotNull] private readonly string m_name;
+        private readonly string m_name;
 #endif
 
         /// <summary>
@@ -30,7 +27,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="name">the name to give this new Mailbox</param>
         /// <param name="sync">Synchronize access to the mailbox from receivers and senders</param>
-        public MailboxSafe([NotNull] string name, object sync)
+        public MailboxSafe(string name, object sync)
         {
             m_sync = sync;
 

--- a/src/NetMQ/Core/MonitorEvent.cs
+++ b/src/NetMQ/Core/MonitorEvent.cs
@@ -1,9 +1,6 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using AsyncIO;
-using JetBrains.Annotations;
 using NetMQ.Core.Transports;
 
 namespace NetMQ.Core
@@ -15,7 +12,7 @@ namespace NetMQ.Core
 
         private readonly SocketEvents m_monitorEvent;
         private readonly string m_addr;
-        [CanBeNull] private readonly object m_arg;
+        private readonly object? m_arg;
         private readonly int m_flag;
 
         private static readonly int s_sizeOfIntPtr;
@@ -32,22 +29,22 @@ namespace NetMQ.Core
                 s_sizeOfIntPtr = 8;
         }
 
-        public MonitorEvent(SocketEvents monitorEvent, [NotNull] string addr, ErrorCode arg)
+        public MonitorEvent(SocketEvents monitorEvent, string addr, ErrorCode arg)
             : this(monitorEvent, addr, (int)arg)
         {
         }
 
-        public MonitorEvent(SocketEvents monitorEvent, [NotNull] string addr, int arg)
+        public MonitorEvent(SocketEvents monitorEvent, string addr, int arg)
             : this(monitorEvent, addr, (object)arg)
         {
         }
 
-        public MonitorEvent(SocketEvents monitorEvent, [NotNull] string addr, [NotNull] AsyncSocket arg)
+        public MonitorEvent(SocketEvents monitorEvent, string addr, AsyncSocket arg)
             : this(monitorEvent, addr, (object)arg)
         {
         }
 
-        private MonitorEvent(SocketEvents monitorEvent, [NotNull] string addr, [NotNull] object arg)
+        private MonitorEvent(SocketEvents monitorEvent, string addr, object? arg)
         {
             m_monitorEvent = monitorEvent;
             m_addr = addr;
@@ -61,15 +58,13 @@ namespace NetMQ.Core
                 m_flag = 0;
         }
 
-        [NotNull]
         public string Addr => m_addr;
 
-        [NotNull]
-        public object Arg => m_arg;
+        public object? Arg => m_arg;
 
         public SocketEvents Event => m_monitorEvent;
 
-        public void Write([NotNull] SocketBase s)
+        public void Write(SocketBase s)
         {
             int size = 4 + 1 + (m_addr?.Length ?? 0) + 1; // event + len(addr) + addr + flag
 
@@ -99,7 +94,7 @@ namespace NetMQ.Core
             buffer[pos++] = ((byte)m_flag);
             if (m_flag == ValueInteger)
             {
-                buffer.PutInteger(Endianness.Little, (int)m_arg, pos);
+                buffer.PutInteger(Endianness.Little, (int)m_arg!, pos);
             }
             else if (m_flag == ValueChannel)
             {
@@ -118,8 +113,7 @@ namespace NetMQ.Core
             s.TrySend(ref msg, TimeSpan.Zero, false);
         }
 
-        [NotNull]
-        public static MonitorEvent Read([NotNull] SocketBase s)
+        public static MonitorEvent Read(SocketBase s)
         {
             var msg = new Msg();
             msg.InitEmpty();
@@ -135,7 +129,7 @@ namespace NetMQ.Core
             string addr = data.GetString(len, pos);
             pos += len;
             var flag = (int)data[pos++];
-            object arg = null;
+            object? arg = null;
 
             if (flag == ValueInteger)
             {
@@ -148,7 +142,7 @@ namespace NetMQ.Core
                     : new IntPtr(data.GetLong(Endianness.Little, pos));
 
                 GCHandle handle = GCHandle.FromIntPtr(value);
-                AsyncSocket socket = null;
+                AsyncSocket? socket = null;
 
                 if (handle.IsAllocated)
                 {

--- a/src/NetMQ/Core/Options.cs
+++ b/src/NetMQ/Core/Options.cs
@@ -20,8 +20,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Text;
 
@@ -106,7 +104,7 @@ namespace NetMQ.Core
         /// Get or set the byte-array that represents the Identity.
         /// The initial value is null.
         /// </summary>
-        public byte[] Identity { get; set; }
+        public byte[]? Identity { get; set; }
 
         /// <summary>
         /// Get or set the size of the socket-identity byte-array.
@@ -122,7 +120,7 @@ namespace NetMQ.Core
             }
         }
         
-        public byte[] LastPeerRoutingId { get; set; }
+        public byte[]? LastPeerRoutingId { get; set; }
 
         /// <summary>
         /// Get or set whether this allows the use of IPv4 sockets only.
@@ -135,7 +133,7 @@ namespace NetMQ.Core
         /// Get or set the last socket endpoint resolved URI
         /// The initial value is null.
         /// </summary>
-        public string LastEndpoint { get; set; }
+        public string? LastEndpoint { get; set; }
 
         /// <summary>
         /// Get or set the Linger time, in milliseconds.
@@ -322,7 +320,7 @@ namespace NetMQ.Core
         /// <summary>
         /// Hello msg to send to peer upon connecting
         /// </summary>
-        public byte[] HelloMsg { get; set; }
+        public byte[]? HelloMsg { get; set; }
         
         /// <summary>
         /// Indicate of socket can send an hello msg
@@ -338,28 +336,30 @@ namespace NetMQ.Core
         /// <param name="option">a ZmqSocketOption that specifies what to set</param>
         /// <param name="optionValue">an Object that is the value to set that option to</param>
         /// <exception cref="InvalidException">The option and optionValue must be valid.</exception>
-        public void SetSocketOption(ZmqSocketOption option, object optionValue)
+        public void SetSocketOption(ZmqSocketOption option, object? optionValue)
         {
+            T Get<T>() => optionValue is T v ? v : throw new ArgumentException($"Value for option {option} have type {typeof(T).Name}.", nameof(optionValue));
+
             switch (option)
             {
                 case ZmqSocketOption.SendHighWatermark:
-                    SendHighWatermark = (int)optionValue;
+                    SendHighWatermark = Get<int>();
                     break;
 
                 case ZmqSocketOption.ReceiveHighWatermark:
-                    ReceiveHighWatermark = (int)optionValue;
+                    ReceiveHighWatermark = Get<int>();
                     break;
 
                 case ZmqSocketOption.SendLowWatermark:
-                    SendLowWatermark = (int)optionValue;
+                    SendLowWatermark = Get<int>();
                     break;
 
                 case ZmqSocketOption.ReceiveLowWatermark:
-                    ReceiveLowWatermark = (int)optionValue;
+                    ReceiveLowWatermark = Get<int>();
                     break;
 
                 case ZmqSocketOption.Affinity:
-                    Affinity = (long)optionValue;
+                    Affinity = Get<long>();
                     break;
 
                 case ZmqSocketOption.Identity:
@@ -379,112 +379,112 @@ namespace NetMQ.Core
                     break;
 
                 case ZmqSocketOption.Rate:
-                    Rate = (int)optionValue;
+                    Rate = Get<int>();
                     break;
 
                 case ZmqSocketOption.RecoveryIvl:
-                    RecoveryIvl = (int)optionValue;
+                    RecoveryIvl = Get<int>();
                     break;
 
                 case ZmqSocketOption.SendBuffer:
-                    SendBuffer = (int)optionValue;
+                    SendBuffer = Get<int>();
                     break;
 
                 case ZmqSocketOption.ReceiveBuffer:
-                    ReceiveBuffer = (int)optionValue;
+                    ReceiveBuffer = Get<int>();
                     break;
 
                 case ZmqSocketOption.Linger:
-                    Linger = (int)optionValue;
+                    Linger = Get<int>();
                     break;
 
                 case ZmqSocketOption.ReconnectIvl:
-                    var reconnectIvl = (int)optionValue;
+                    var reconnectIvl = Get<int>();
                     if (reconnectIvl < -1)
                         throw new InvalidException($"Options.SetSocketOption(ReconnectIvl, {reconnectIvl}) optionValue must be >= -1.");
                     ReconnectIvl = reconnectIvl;
                     break;
 
                 case ZmqSocketOption.ReconnectIvlMax:
-                    var reconnectIvlMax = (int)optionValue;
+                    var reconnectIvlMax = Get<int>();
                     if (reconnectIvlMax < 0)
                         throw new InvalidException($"Options.SetSocketOption(ReconnectIvlMax, {reconnectIvlMax}) optionValue must be non-negative.");
                     ReconnectIvlMax = reconnectIvlMax;
                     break;
 
                 case ZmqSocketOption.Backlog:
-                    Backlog = (int)optionValue;
+                    Backlog = Get<int>();
                     break;
 
                 case ZmqSocketOption.MaxMessageSize:
-                    MaxMessageSize = (long)optionValue;
+                    MaxMessageSize = Get<long>();
                     break;
 
                 case ZmqSocketOption.MulticastHops:
-                    MulticastHops = (int)optionValue;
+                    MulticastHops = Get<int>();
                     break;
 
                 case ZmqSocketOption.SendTimeout:
-                    SendTimeout = (int)optionValue;
+                    SendTimeout = Get<int>();
                     break;
 
                 case ZmqSocketOption.IPv4Only:
-                    IPv4Only = (bool)optionValue;
+                    IPv4Only = Get<bool>();
                     break;
 
                 case ZmqSocketOption.TcpKeepalive:
-                    var tcpKeepalive = (int)optionValue;
+                    var tcpKeepalive = Get<int>();
                     if (tcpKeepalive != -1 && tcpKeepalive != 0 && tcpKeepalive != 1)
                         throw new InvalidException($"Options.SetSocketOption(TcpKeepalive, {tcpKeepalive}) optionValue is neither -1, 0, nor 1.");
                     TcpKeepalive = tcpKeepalive;
                     break;
 
                 case ZmqSocketOption.DelayAttachOnConnect:
-                    DelayAttachOnConnect = (bool)optionValue;
+                    DelayAttachOnConnect = Get<bool>();
                     break;
 
                 case ZmqSocketOption.TcpKeepaliveIdle:
-                    TcpKeepaliveIdle = (int)optionValue;
+                    TcpKeepaliveIdle = Get<int>();
                     break;
 
                 case ZmqSocketOption.TcpKeepaliveIntvl:
-                    TcpKeepaliveIntvl = (int)optionValue;
+                    TcpKeepaliveIntvl = Get<int>();
                     break;
 
                 case ZmqSocketOption.Endian:
-                    Endian = (Endianness)optionValue;
+                    Endian = Get<Endianness>();
                     break;
 
                 case ZmqSocketOption.DisableTimeWait:
-                    DisableTimeWait = (bool)optionValue;
+                    DisableTimeWait = Get<bool>();
                     break;
 
                 case ZmqSocketOption.PgmMaxTransportServiceDataUnitLength:
-                    PgmMaxTransportServiceDataUnitLength = (int)optionValue;
+                    PgmMaxTransportServiceDataUnitLength = Get<int>();
                     break;
 
                 case ZmqSocketOption.HeartbeatInterval:
-                    HeartbeatInterval = (int) optionValue;
+                    HeartbeatInterval = Get<int>();
                     break;
 
                 case ZmqSocketOption.HeartbeatTtl:
                     // Convert this to deciseconds from milliseconds
-                    HeartbeatTtl = (int) optionValue;
+                    HeartbeatTtl = Get<int>();
                     HeartbeatTtl /= 100;
                     break;
 
                 case ZmqSocketOption.HeartbeatTimeout:
-                    HeartbeatTimeout = (int) optionValue;
+                    HeartbeatTimeout = Get<int>();
                     break;
 
                 case ZmqSocketOption.CurveServer:
-                    AsServer = (bool) optionValue;
+                    AsServer = Get<bool>();
                     Mechanism = AsServer ? MechanismType.Curve : MechanismType.Null;
                     break;
                 
                 case ZmqSocketOption.CurvePublicKey:
                 {
-                    var key = (byte[]) optionValue;
+                    var key = Get<byte[]>();
                     if (key.Length != 32)
                         throw new InvalidException("Curve key size must be 32 bytes");
                     Mechanism = MechanismType.Curve;
@@ -494,7 +494,7 @@ namespace NetMQ.Core
 
                 case ZmqSocketOption.CurveSecretKey:
                 {
-                    var key = (byte[]) optionValue;
+                    var key = Get<byte[]>();
                     if (key.Length != 32)
                         throw new InvalidException("Curve key size must be 32 bytes");
                     Mechanism = MechanismType.Curve;
@@ -504,7 +504,7 @@ namespace NetMQ.Core
 
                 case ZmqSocketOption.CurveServerKey:
                 {
-                    var key = (byte[]) optionValue;
+                    var key = Get<byte[]>();
                     if (key.Length != 32)
                         throw new InvalidException("Curve key size must be 32 bytes");
                     Mechanism = MechanismType.Curve;
@@ -520,7 +520,7 @@ namespace NetMQ.Core
                     }
                     else
                     {
-                        var helloMsg = (byte[]) optionValue;
+                        var helloMsg = Get<byte[]>();
                         HelloMsg = new byte[helloMsg.Length];
                     
                         Buffer.BlockCopy(helloMsg, 0, HelloMsg, 0, helloMsg.Length);
@@ -530,13 +530,13 @@ namespace NetMQ.Core
 
                 case ZmqSocketOption.Relaxed:
                     {
-                        Relaxed = (bool)optionValue;
+                        Relaxed = Get<bool>();
                         break;
                     }
 
                 case ZmqSocketOption.Correlate:
                     {
-                        Correlate = (bool)optionValue;
+                        Correlate = Get<bool>();
                         break;
                     }
                 
@@ -551,7 +551,7 @@ namespace NetMQ.Core
         /// <param name="option">a ZmqSocketOption that specifies what to get</param>
         /// <returns>an Object that is the value of that option</returns>
         /// <exception cref="InvalidException">A valid option must be specified.</exception>
-        public object GetSocketOption(ZmqSocketOption option)
+        public object? GetSocketOption(ZmqSocketOption option)
         {
             switch (option)
             {

--- a/src/NetMQ/Core/Own.cs
+++ b/src/NetMQ/Core/Own.cs
@@ -18,12 +18,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core
 {
@@ -36,7 +33,6 @@ namespace NetMQ.Core
         /// <summary>
         /// The Options of this Own.
         /// </summary>
-        [NotNull]
         protected readonly Options m_options;
 
         /// <summary>
@@ -59,8 +55,7 @@ namespace NetMQ.Core
         /// Socket owning this object. It's responsible for shutting down
         /// this object.
         /// </summary>
-        [CanBeNull]
-        private Own m_owner;
+        private Own? m_owner;
 
         /// <summary>
         /// List of all objects owned by this socket. We are responsible
@@ -82,7 +77,7 @@ namespace NetMQ.Core
         /// Note that the owner is unspecified in the constructor. It'll be assigned later on using <see cref="SetOwner"/>
         /// when the object is plugged in.
         /// </remarks>
-        protected Own([NotNull] Ctx parent, int threadId)
+        protected Own(Ctx parent, int threadId)
             : base(parent, threadId)
         {
             m_options = new Options();
@@ -97,7 +92,7 @@ namespace NetMQ.Core
         /// Note that the owner is unspecified in the constructor. It'll be assigned later on using <see cref="SetOwner"/>
         /// when the object is plugged in.
         /// </remarks>
-        protected Own([NotNull] IOThread ioThread, [NotNull] Options options)
+        protected Own(IOThread ioThread, Options options)
             : base(ioThread)
         {
             m_options = options;
@@ -121,7 +116,7 @@ namespace NetMQ.Core
         /// Set the owner of *this* Own object, to be the given owner.
         /// </summary>
         /// <param name="owner">the Own object to be our new owner</param>
-        private void SetOwner([NotNull] Own owner)
+        private void SetOwner(Own owner)
         {
             Debug.Assert(m_owner == null);
             m_owner = owner;
@@ -152,7 +147,7 @@ namespace NetMQ.Core
         /// Launch the supplied object and become its owner.
         /// </summary>
         /// <param name="obj">The object to be launched.</param>
-        protected void LaunchChild([NotNull] Own obj)
+        protected void LaunchChild(Own obj)
         {
             // Specify the owner of the object.
             obj.SetOwner(this);
@@ -167,7 +162,7 @@ namespace NetMQ.Core
         /// <summary>
         /// Terminate owned object.
         /// </summary>
-        protected void TermChild([NotNull] Own obj)
+        protected void TermChild(Own obj)
         {
             ProcessTermReq(obj);
         }

--- a/src/NetMQ/Core/Patterns/Client.cs
+++ b/src/NetMQ/Core/Patterns/Client.cs
@@ -1,7 +1,4 @@
-#nullable disable
-
 using System.Diagnostics;
-using JetBrains.Annotations;
 using NetMQ.Core.Patterns.Utils;
 
 namespace NetMQ.Core.Patterns
@@ -22,7 +19,7 @@ namespace NetMQ.Core.Patterns
         /// <summary>
         /// Create a new Dealer socket that holds the prefetched message.
         /// </summary>
-        public Client([NotNull] Ctx parent, int threadId, int socketId)
+        public Client(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId, true)
         {
             m_options.SocketType = ZmqSocketType.Client;
@@ -39,7 +36,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="icanhasall">not used</param>
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
-            Debug.Assert(pipe != null);
+            Assumes.NotNull(pipe);
             m_fairQueueing.Attach(pipe);
             m_loadBalancer.Attach(pipe);
         }

--- a/src/NetMQ/Core/Patterns/Dealer.cs
+++ b/src/NetMQ/Core/Patterns/Dealer.cs
@@ -19,10 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Diagnostics;
-using JetBrains.Annotations;
 using NetMQ.Core.Patterns.Utils;
 
 namespace NetMQ.Core.Patterns
@@ -44,7 +41,7 @@ namespace NetMQ.Core.Patterns
         /// <summary>
         /// Create a new Dealer socket that holds the prefetched message.
         /// </summary>
-        public Dealer([NotNull] Ctx parent, int threadId, int socketId)
+        public Dealer(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {
             m_options.SocketType = ZmqSocketType.Dealer;
@@ -61,7 +58,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="icanhasall">not used</param>
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
-            Debug.Assert(pipe != null);
+            Assumes.NotNull(pipe);
             m_fairQueueing.Attach(pipe);
             m_loadBalancer.Attach(pipe);
         }
@@ -82,7 +79,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="msg">the message to transmit</param>
         /// <param name="pipe">the pipe that the message was transmitted on (output)</param>
         /// <returns><c>true</c> if the message was sent successfully</returns>
-        protected bool XSendPipe(ref Msg msg, out Pipe pipe)
+        protected bool XSendPipe(ref Msg msg, out Pipe? pipe)
         {
             return m_loadBalancer.SendPipe(ref msg, out pipe);
         }
@@ -103,7 +100,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="msg">a Msg to receive the message into</param>
         /// <param name="pipe">a specific Pipe to receive on</param>
         /// <returns><c>true</c> if the message was received successfully, <c>false</c> if there were no messages to receive</returns>
-        protected bool XRecvPipe(ref Msg msg, out Pipe pipe)
+        protected bool XRecvPipe(ref Msg msg, out Pipe? pipe)
         {
             return m_fairQueueing.RecvPipe(ref msg, out pipe);
         }

--- a/src/NetMQ/Core/Patterns/Gather.cs
+++ b/src/NetMQ/Core/Patterns/Gather.cs
@@ -25,7 +25,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="icanhasall">not used</param>
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
-            Debug.Assert(pipe != null);
+            Assumes.NotNull(pipe);
             m_fairQueueing.Attach(pipe);
         }
 

--- a/src/NetMQ/Core/Patterns/Pair.cs
+++ b/src/NetMQ/Core/Patterns/Pair.cs
@@ -19,18 +19,15 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Diagnostics;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Patterns
 {
     internal sealed class Pair : SocketBase
     {
-        private Pipe m_pipe;
+        private Pipe? m_pipe;
 
-        public Pair([NotNull] Ctx parent, int threadId, int socketId)
+        public Pair(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {
             m_options.SocketType = ZmqSocketType.Pair;
@@ -43,7 +40,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="icanhasall">not used</param>
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
-            Debug.Assert(pipe != null);
+            Assumes.NotNull(pipe);
 
             // ZMQ_PAIR socket can only be connected to a single peer.
             // The socket rejects any further connection requests.

--- a/src/NetMQ/Core/Patterns/Pub.cs
+++ b/src/NetMQ/Core/Patterns/Pub.cs
@@ -19,10 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Patterns
 {
@@ -37,7 +34,7 @@ namespace NetMQ.Core.Patterns
             base.XAttachPipe(pipe, icanhasall);
         }
 
-        public Pub([NotNull] Ctx parent, int threadId, int socketId)
+        public Pub(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {
             m_options.SocketType = ZmqSocketType.Pub;

--- a/src/NetMQ/Core/Patterns/Pull.cs
+++ b/src/NetMQ/Core/Patterns/Pull.cs
@@ -19,10 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Diagnostics;
-using JetBrains.Annotations;
 using NetMQ.Core.Patterns.Utils;
 
 namespace NetMQ.Core.Patterns
@@ -34,7 +31,7 @@ namespace NetMQ.Core.Patterns
         /// </summary>
         private readonly FairQueueing m_fairQueueing;
 
-        public Pull([NotNull] Ctx parent, int threadId, int socketId)
+        public Pull(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {
             m_options.SocketType = ZmqSocketType.Pull;
@@ -49,7 +46,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="icanhasall">not used</param>
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
-            Debug.Assert(pipe != null);
+            Assumes.NotNull(pipe);
             m_fairQueueing.Attach(pipe);
         }
 

--- a/src/NetMQ/Core/Patterns/Push.cs
+++ b/src/NetMQ/Core/Patterns/Push.cs
@@ -19,10 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Diagnostics;
-using JetBrains.Annotations;
 using NetMQ.Core.Patterns.Utils;
 
 namespace NetMQ.Core.Patterns
@@ -34,7 +31,7 @@ namespace NetMQ.Core.Patterns
         /// </summary>
         private readonly LoadBalancer m_loadBalancer;
 
-        public Push([NotNull] Ctx parent, int threadId, int socketId)
+        public Push(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {
             m_options.SocketType = ZmqSocketType.Push;
@@ -49,8 +46,8 @@ namespace NetMQ.Core.Patterns
         /// <param name="icanhasall">not used</param>
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
-            Debug.Assert(pipe != null);
-            
+            Assumes.NotNull(pipe);
+
             // Don't delay pipe termination as there is no one
             // to receive the delimiter.
             pipe.SetNoDelay();

--- a/src/NetMQ/Core/Patterns/Rep.cs
+++ b/src/NetMQ/Core/Patterns/Rep.cs
@@ -19,10 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
-using JetBrains.Annotations;
-
 namespace NetMQ.Core.Patterns
 {
     internal sealed class Rep : Router
@@ -39,7 +35,7 @@ namespace NetMQ.Core.Patterns
         /// </summary>
         private bool m_requestBegins;
 
-        public Rep([NotNull] Ctx parent, int threadId, int socketId)
+        public Rep(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {
             m_sendingReply = false;

--- a/src/NetMQ/Core/Patterns/Req.cs
+++ b/src/NetMQ/Core/Patterns/Req.cs
@@ -20,11 +20,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Patterns
 {
@@ -65,7 +62,7 @@ namespace NetMQ.Core.Patterns
         /// <summary>
         /// specific pipe that we are expecting the reply to occur on, once we make a request.
         /// </summary>
-        private Pipe m_replyPipe;
+        private Pipe? m_replyPipe;
 
         /// <summary>
         /// Create a new Req (Request) socket with the given parent Ctx, thread and socket id.
@@ -73,7 +70,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="parent">the Ctx to contain this socket</param>
         /// <param name="threadId">an integer thread-id for this socket to execute on</param>
         /// <param name="socketId">the socket-id for this socket</param>
-        public Req([NotNull] Ctx parent, int threadId, int socketId)
+        public Req(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {
             m_receivingReply = false;
@@ -249,7 +246,7 @@ namespace NetMQ.Core.Patterns
         {
             while (true)
             {
-                if (!base.XRecvPipe(ref msg, out Pipe pipe)) return false; 
+                if (!base.XRecvPipe(ref msg, out Pipe? pipe)) return false; 
                 if ((m_replyPipe==null) || (pipe == m_replyPipe)) return true;
             }
         }
@@ -276,7 +273,7 @@ namespace NetMQ.Core.Patterns
             return base.XHasOut();
         }
 
-        protected override bool XSetSocketOption(ZmqSocketOption option, [CanBeNull] object optionValue)
+        protected override bool XSetSocketOption(ZmqSocketOption option, object? optionValue)
         {
             // bail if optionValue is a null or not a bool.
             if (optionValue == null || ((optionValue as bool?) == null))
@@ -311,7 +308,7 @@ namespace NetMQ.Core.Patterns
 
             private State m_state;
 
-            public ReqSession([NotNull] IOThread ioThread, bool connect, [NotNull] SocketBase socket, [NotNull] Options options, [NotNull] Address addr)
+            public ReqSession(IOThread ioThread, bool connect, SocketBase socket, Options options, Address addr)
                 : base(ioThread, connect, socket, options, addr)
             {
                 m_state = State.Bottom;

--- a/src/NetMQ/Core/Patterns/Server.cs
+++ b/src/NetMQ/Core/Patterns/Server.cs
@@ -67,8 +67,6 @@ namespace NetMQ.Core.Patterns
         /// <param name="icanhasall">not used</param>
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
-            Assumes.NotNull(pipe);
-
             uint routingId = m_nextRoutingId++;
             if (routingId == 0)
                 routingId = m_nextRoutingId++; //  Never use Routing ID zero

--- a/src/NetMQ/Core/Patterns/Server.cs
+++ b/src/NetMQ/Core/Patterns/Server.cs
@@ -1,9 +1,6 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using JetBrains.Annotations;
 using NetMQ.Core.Patterns.Utils;
 
 namespace NetMQ.Core.Patterns
@@ -20,13 +17,13 @@ namespace NetMQ.Core.Patterns
         /// </summary>
         private class Outpipe
         {
-            public Outpipe([NotNull] Pipe pipe, bool active)
+            public Outpipe(Pipe pipe, bool active)
             {
                 Pipe = pipe;
                 Active = active;
             }
 
-            [NotNull] public Pipe Pipe { get; }
+            public Pipe Pipe { get; }
 
             public bool Active;
         }
@@ -53,7 +50,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="parent">the Ctx that will contain this Router</param>
         /// <param name="threadId">the integer thread-id value</param>
         /// <param name="socketId">the integer socket-id value</param>
-        public Server([NotNull] Ctx parent, int threadId, int socketId)
+        public Server(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId, true)
         {
             m_nextRoutingId = (uint) s_random.Next();
@@ -70,7 +67,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="icanhasall">not used</param>
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
-            Debug.Assert(pipe != null);
+            Assumes.NotNull(pipe);
 
             uint routingId = m_nextRoutingId++;
             if (routingId == 0)
@@ -186,7 +183,7 @@ namespace NetMQ.Core.Patterns
             if (!received)
                 return false;
 
-            Debug.Assert(pipe != null);
+            Assumes.NotNull(pipe);
             msg.RoutingId = pipe.RoutingId;
 
             return true;

--- a/src/NetMQ/Core/Patterns/Sub.cs
+++ b/src/NetMQ/Core/Patterns/Sub.cs
@@ -19,17 +19,14 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Text;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Patterns
 {
     internal sealed class Sub : XSub
     {
-        public Sub([NotNull] Ctx parent, int threadId, int socketId)
+        public Sub(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {
             m_options.SocketType = ZmqSocketType.Sub;
@@ -45,7 +42,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="optionValue">the value to set the option to</param>
         /// <returns><c>true</c> if successful</returns>
         /// <exception cref="InvalidException">optionValue must be a String or a byte-array.</exception>
-        protected override bool XSetSocketOption(ZmqSocketOption option, object optionValue)
+        protected override bool XSetSocketOption(ZmqSocketOption option, object? optionValue)
         {
             // Only subscribe/unsubscribe options are supported
             if (option != ZmqSocketOption.Subscribe && option != ZmqSocketOption.Unsubscribe)

--- a/src/NetMQ/Core/Patterns/Utils/ArrayExtensions.cs
+++ b/src/NetMQ/Core/Patterns/Utils/ArrayExtensions.cs
@@ -1,8 +1,5 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Patterns.Utils
 {
@@ -16,8 +13,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// <param name="size">New size of array.</param>
         /// <param name="ended">If grow/shrink operation should be applied to the end of array.</param>
         /// <returns>Resized array.</returns>
-        [NotNull]
-        public static T[] Resize<T>([NotNull] this T[] src, int size, bool ended)
+        public static T[] Resize<T>(this T[] src, int size, bool ended)
         {
             T[] dest;
 
@@ -45,7 +41,7 @@ namespace NetMQ.Core.Patterns.Utils
             return dest;
         }
 
-        public static void Swap<T>([NotNull] this List<T> items, int index1, int index2) where T : class
+        public static void Swap<T>(this List<T> items, int index1, int index2) where T : class
         {
             if (index1 == index2) 
                 return;

--- a/src/NetMQ/Core/Patterns/Utils/Distribution.cs
+++ b/src/NetMQ/Core/Patterns/Utils/Distribution.cs
@@ -20,10 +20,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Collections.Generic;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Patterns.Utils
 {
@@ -72,7 +69,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// Adds the pipe to the distributor object.
         /// </summary>
         /// <param name="pipe"></param>
-        public void Attach([NotNull] Pipe pipe)
+        public void Attach(Pipe pipe)
         {
             // If we are in the middle of sending a message, we'll add new pipe
             // into the list of eligible pipes. Otherwise we add it to the list
@@ -97,7 +94,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// will send message also to this pipe.
         /// </summary>
         /// <param name="pipe"></param>
-        public void Match([NotNull] Pipe pipe)
+        public void Match(Pipe pipe)
         {
             int index = m_pipes.IndexOf(pipe);
 
@@ -126,7 +123,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// This gets called by ProcessPipeTermAck or XTerminated to respond to the termination of the given pipe from the distributor.
         /// </summary>
         /// <param name="pipe">the pipe that was terminated</param>
-        public void Terminated([NotNull] Pipe pipe)
+        public void Terminated(Pipe pipe)
         {
             // Remove the pipe from the list; adjust number of matching, active and/or
             // eligible pipes accordingly.
@@ -143,7 +140,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// Activates pipe that have previously reached high watermark.
         /// </summary>
         /// <param name="pipe"></param>
-        public void Activated([NotNull] Pipe pipe)
+        public void Activated(Pipe pipe)
         {
             // Move the pipe from passive to eligible state.
             m_pipes.Swap(m_pipes.IndexOf(pipe), m_eligible);
@@ -248,7 +245,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// Write the message to the pipe. Make the pipe inactive if writing
         /// fails. In such a case false is returned.
         /// </summary>
-        private bool Write([NotNull] Pipe pipe, ref Msg msg)
+        private bool Write(Pipe pipe, ref Msg msg)
         {
             if (!pipe.Write(ref msg))
             {

--- a/src/NetMQ/Core/Patterns/Utils/FairQueueing.cs
+++ b/src/NetMQ/Core/Patterns/Utils/FairQueueing.cs
@@ -20,10 +20,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NetMQ.Core.Patterns.Utils
 {
@@ -100,7 +99,7 @@ namespace NetMQ.Core.Patterns.Utils
             return RecvPipe(ref msg, out Pipe _);
         }
 
-        public bool RecvPipe(ref Msg msg, out Pipe pipe)
+        public bool RecvPipe(ref Msg msg, [NotNullWhen(returnValue: true)] out Pipe? pipe)
         {
             pipe = null;
 

--- a/src/NetMQ/Core/Patterns/Utils/LoadBalancer.cs
+++ b/src/NetMQ/Core/Patterns/Utils/LoadBalancer.cs
@@ -20,11 +20,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Diagnostics;
-using JetBrains.Annotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NetMQ.Core.Patterns.Utils
 {
@@ -56,7 +54,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// </summary>
         private bool m_dropping;
 
-        public void Attach([NotNull] Pipe pipe)
+        public void Attach(Pipe pipe)
         {
             m_pipes.Add(pipe);
             Activated(pipe);
@@ -66,7 +64,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// This gets called by ProcessPipeTermAck or XTerminated to respond to the termination of the given pipe.
         /// </summary>
         /// <param name="pipe">the pipe that was terminated</param>
-        public void Terminated([NotNull] Pipe pipe)
+        public void Terminated(Pipe pipe)
         {
             int index = m_pipes.IndexOf(pipe);
 
@@ -87,7 +85,7 @@ namespace NetMQ.Core.Patterns.Utils
             m_pipes.Remove(pipe);
         }
 
-        public void Activated([NotNull] Pipe pipe)
+        public void Activated(Pipe pipe)
         {
             // Move the pipe to the list of active pipes.
             m_pipes.Swap(m_pipes.IndexOf(pipe), m_active);
@@ -99,7 +97,7 @@ namespace NetMQ.Core.Patterns.Utils
             return SendPipe(ref msg, out Pipe _);
         }
 
-        public bool SendPipe(ref Msg msg, out Pipe pipe)
+        public bool SendPipe(ref Msg msg, out Pipe? pipe)
         {
             pipe = null;
 

--- a/src/NetMQ/Core/Patterns/XSub.cs
+++ b/src/NetMQ/Core/Patterns/XSub.cs
@@ -19,10 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Diagnostics;
-using JetBrains.Annotations;
 using NetMQ.Core.Patterns.Utils;
 
 namespace NetMQ.Core.Patterns
@@ -85,7 +82,7 @@ namespace NetMQ.Core.Patterns
             };
         }
 
-        public XSub([NotNull] Ctx parent, int threadId, int socketId)
+        public XSub(Ctx parent, int threadId, int socketId)
             : base(parent, threadId, socketId)
         {
             m_options.SocketType = ZmqSocketType.Xsub;
@@ -114,7 +111,7 @@ namespace NetMQ.Core.Patterns
         /// <param name="icanhasall">not used</param>
         protected override void XAttachPipe(Pipe pipe, bool icanhasall)
         {
-            Debug.Assert(pipe != null);
+            Assumes.NotNull(pipe);
             m_fairQueueing.Attach(pipe);
             m_distribution.Attach(pipe);
 

--- a/src/NetMQ/Core/Reaper.cs
+++ b/src/NetMQ/Core/Reaper.cs
@@ -18,11 +18,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Net.Sockets;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core
 {
@@ -36,17 +33,17 @@ namespace NetMQ.Core
         /// <summary>
         /// Reaper thread accesses incoming commands via this mailbox.
         /// </summary>
-        [NotNull] private readonly Mailbox m_mailbox;
+        private readonly Mailbox m_mailbox;
 
         /// <summary>
         /// This is a Socket, used as the handle associated with the mailbox's file descriptor.
         /// </summary>
-        [NotNull] private readonly Socket m_mailboxHandle;
+        private readonly Socket m_mailboxHandle;
 
         /// <summary>
         /// I/O multiplexing is performed using a poller object.
         /// </summary>
-        [NotNull] private readonly Utils.Poller m_poller;
+        private readonly Utils.Poller m_poller;
 
         /// <summary>
         /// Number of sockets being reaped at the moment.
@@ -65,7 +62,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="ctx">the Ctx for this to be in</param>
         /// <param name="threadId">an integer id to give to the thread this will live on</param>
-        public Reaper([NotNull] Ctx ctx, int threadId)
+        public Reaper(Ctx ctx, int threadId)
             : base(ctx, threadId)
         {
             m_sockets = 0;
@@ -93,7 +90,6 @@ namespace NetMQ.Core
         /// <summary>
         /// Get the Mailbox that this Reaper uses for communication with the rest of the message-queueing subsystem.
         /// </summary>
-        [NotNull]
         public Mailbox Mailbox => m_mailbox;
 
         /// <summary>
@@ -129,6 +125,8 @@ namespace NetMQ.Core
                 // Get the next command. If there is none, exit.
                 if (!m_mailbox.TryRecv(0, out Command command))
                     break;
+
+                Assumes.NotNull(command.Destination);
 
                 // Process the command.
                 command.Destination.ProcessCommand(command);

--- a/src/NetMQ/Core/Utils/AtomicCounter.cs
+++ b/src/NetMQ/Core/Utils/AtomicCounter.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System.Threading;
 
 namespace NetMQ.Core.Utils

--- a/src/NetMQ/Core/Utils/ByteArrayEqualityComparer.cs
+++ b/src/NetMQ/Core/Utils/ByteArrayEqualityComparer.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace NetMQ.Core.Utils
 {

--- a/src/NetMQ/Core/Utils/ByteArrayUtility.cs
+++ b/src/NetMQ/Core/Utils/ByteArrayUtility.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace NetMQ.Core.Utils
 {
     internal static class ByteArrayUtility

--- a/src/NetMQ/Core/Utils/Clock.cs
+++ b/src/NetMQ/Core/Utils/Clock.cs
@@ -18,8 +18,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 
@@ -114,7 +112,7 @@ namespace NetMQ.Core.Utils
 #if NETSTANDARD1_6
             return 0;
 #else
-            return s_rdtscSupported ? (long)Opcode.Rdtsc() : 0;
+            return s_rdtscSupported ? (long?)Opcode.Rdtsc?.Invoke() ?? 0 : 0;
 #endif
         }
     }

--- a/src/NetMQ/Core/Utils/OpCode.cs
+++ b/src/NetMQ/Core/Utils/OpCode.cs
@@ -1,10 +1,7 @@
-﻿#nullable disable
-
-#if !NETSTANDARD1_6
+﻿#if !NETSTANDARD1_6
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Utils
 {
@@ -72,7 +69,7 @@ namespace NetMQ.Core.Utils
             Type syscall = currentAssembly.GetType("Mono.Unix.Native.Syscall");
             Type utsname = currentAssembly.GetType("Mono.Unix.Native.Utsname");
             MethodInfo uname = syscall.GetMethod("uname");
-            object[] parameters = { null };
+            object?[] parameters = { null };
 
             var invokeResult = (int)uname.Invoke(null, parameters);
 
@@ -110,8 +107,7 @@ namespace NetMQ.Core.Utils
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         public delegate ulong RdtscDelegate();
 
-        [CanBeNull]
-        public static RdtscDelegate Rdtsc { get; private set; }
+        public static RdtscDelegate? Rdtsc { get; private set; }
 
         // unsigned __int64 __stdcall rdtsc() {
         //   return __rdtsc();

--- a/src/NetMQ/Core/Utils/Poller.cs
+++ b/src/NetMQ/Core/Utils/Poller.cs
@@ -19,8 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,7 +27,6 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 #endif
 using System.Threading;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Utils
 {
@@ -44,13 +41,11 @@ namespace NetMQ.Core.Utils
             /// <summary>
             /// Get the Socket that this PollSet contains.
             /// </summary>
-            [NotNull]
             public Socket Socket { get; }
 
             /// <summary>
             /// Get the IPollEvents object that has methods to signal when ready for reading or writing.
             /// </summary>
-            [NotNull]
             public IPollEvents Handler { get; }
 
             /// <summary>
@@ -63,7 +58,7 @@ namespace NetMQ.Core.Utils
             /// </summary>
             /// <param name="socket">the Socket to contain</param>
             /// <param name="handler">the IPollEvents to signal when ready for reading or writing</param>
-            public PollSet([NotNull] Socket socket, [NotNull] IPollEvents handler)
+            public PollSet(Socket socket, IPollEvents handler)
             {
                 Handler = handler;
                 Socket = socket;
@@ -100,7 +95,7 @@ namespace NetMQ.Core.Utils
         /// <summary>
         /// This is the background-thread that performs the polling-loop.
         /// </summary>
-        private Thread m_workerThread;
+        private Thread? m_workerThread;
 
         /// <summary>
         /// This is the name associated with this Poller.
@@ -126,7 +121,7 @@ namespace NetMQ.Core.Utils
         /// Create a new Poller object with the given name.
         /// </summary>
         /// <param name="name">a name to assign to this Poller</param>
-        public Poller([NotNull] string name)
+        public Poller(string name)
         {
             m_name = name;
         }
@@ -139,6 +134,8 @@ namespace NetMQ.Core.Utils
         {
             if (!m_stopped)
             {
+                Assumes.NotNull(this.m_workerThread);
+
                 try
                 {
                     m_workerThread.Join();
@@ -155,7 +152,7 @@ namespace NetMQ.Core.Utils
         /// </summary>
         /// <param name="handle">the Socket to add</param>
         /// <param name="events">the IPollEvents to include in the new PollSet to add</param>
-        public void AddHandle([NotNull] Socket handle, [NotNull] IPollEvents events)
+        public void AddHandle(Socket handle, IPollEvents events)
         {
             m_addList.Add(new PollSet(handle, events));
 
@@ -168,7 +165,7 @@ namespace NetMQ.Core.Utils
         /// Remove the given Socket from this Poller.
         /// </summary>
         /// <param name="handle">the System.Net.Sockets.Socket to remove</param>
-        public void RemoveHandle([NotNull] Socket handle)
+        public void RemoveHandle(Socket handle)
         {
             PollSet pollSet = m_addList.FirstOrDefault(p => p.Socket == handle);
 

--- a/src/NetMQ/Core/Utils/PollerBase.cs
+++ b/src/NetMQ/Core/Utils/PollerBase.cs
@@ -18,13 +18,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Utils
 {
@@ -50,7 +47,7 @@ namespace NetMQ.Core.Utils
             /// </summary>
             /// <param name="sink">an ITimerEvent that acts as a sink for when the timer expires</param>
             /// <param name="id">an integer id that identifies this timer</param>
-            public TimerInfo([NotNull] ITimerEvent sink, int id)
+            public TimerInfo(ITimerEvent sink, int id)
             {
                 Sink = sink;
                 Id = id;
@@ -59,7 +56,6 @@ namespace NetMQ.Core.Utils
             /// <summary>
             /// Get the ITimerEvent that serves as the event-sink.
             /// </summary>
-            [NotNull]
             public ITimerEvent Sink { get; }
 
             /// <summary>
@@ -118,7 +114,7 @@ namespace NetMQ.Core.Utils
         /// <param name="timeout">the timeout-period in milliseconds of the new timer</param>
         /// <param name="sink">the IProactorEvents to add for the sink of the new timer</param>
         /// <param name="id">the Id to assign to the new TimerInfo</param>
-        public void AddTimer(long timeout, [NotNull] IProactorEvents sink, int id)
+        public void AddTimer(long timeout, IProactorEvents sink, int id)
         {
             long expiration = Clock.NowMs() + timeout;
             var info = new TimerInfo(sink, id);
@@ -137,7 +133,7 @@ namespace NetMQ.Core.Utils
         /// <remarks>
         /// The complexity of this operation is O(n). We assume it is rarely used.
         /// </remarks>
-        public void CancelTimer([NotNull] ITimerEvent sink, int id)
+        public void CancelTimer(ITimerEvent sink, int id)
         {
             bool removed = false;
 

--- a/src/NetMQ/Core/Utils/Proactor.cs
+++ b/src/NetMQ/Core/Utils/Proactor.cs
@@ -1,10 +1,7 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using AsyncIO;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Utils
 {
@@ -16,20 +13,19 @@ namespace NetMQ.Core.Utils
         private readonly CompletionPort m_completionPort;
         private readonly string m_name;
 
-        private Thread m_worker;
+        private Thread? m_worker;
         private bool m_stopping;
         private bool m_stopped;
 
         private class Item
         {
-            public Item([NotNull] IProactorEvents proactorEvents) => ProactorEvents = proactorEvents;
+            public Item(IProactorEvents proactorEvents) => ProactorEvents = proactorEvents;
 
-            [NotNull]
             public IProactorEvents ProactorEvents { get; }
             public bool Cancelled { get; set; }
         }
 
-        public Proactor([NotNull] string name)
+        public Proactor(string name)
         {
             m_name = name;
             m_stopping = false;
@@ -55,6 +51,7 @@ namespace NetMQ.Core.Utils
             {
                 try
                 {
+                    Assumes.NotNull(m_worker);
                     m_worker.Join();
                 }
                 catch (Exception)

--- a/src/NetMQ/Core/Utils/Signaler.cs
+++ b/src/NetMQ/Core/Utils/Signaler.cs
@@ -18,23 +18,20 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Utils
 {
     internal sealed class Signaler
     {
         // Underlying write & read file descriptor.
-        [NotNull] private readonly Socket m_writeSocket;
-        [NotNull] private readonly Socket m_readSocket;
-        [NotNull] private readonly byte[] m_dummy;
-        [NotNull] private readonly byte[] m_receiveDummy;
+        private readonly Socket m_writeSocket;
+        private readonly Socket m_readSocket;
+        private readonly byte[] m_dummy;
+        private readonly byte[] m_receiveDummy;
 
         public Signaler()
         {
@@ -99,7 +96,6 @@ namespace NetMQ.Core.Utils
         // Creates a pair of file descriptors that will be used
         // to pass the signals.
 
-        [NotNull]
         public Socket Handle => m_readSocket;
 
         public void Send()

--- a/src/NetMQ/Core/Utils/SocketUtility.cs
+++ b/src/NetMQ/Core/Utils/SocketUtility.cs
@@ -1,8 +1,5 @@
-﻿#nullable disable
-
-using System.Collections;
+﻿using System.Collections;
 using System.Net.Sockets;
-using JetBrains.Annotations;
 
 namespace NetMQ.Core.Utils
 {
@@ -48,7 +45,7 @@ namespace NetMQ.Core.Utils
         /// </remarks>
         /// <exception cref="System.ArgumentNullException">none of the three lists of sockets may be null.</exception>
         /// <exception cref="SocketException">an error occurred when attempting to access the socket.</exception>
-        public static void Select([CanBeNull] IList checkRead, [CanBeNull] IList checkWrite, [CanBeNull] IList checkError, int microSeconds)
+        public static void Select(IList? checkRead, IList? checkWrite, IList? checkError, int microSeconds)
         {
 #if NET35
             // .NET 3.5 has a bug, such that -1 is not blocking the select call - therefore we use here instead the maximum integer value.

--- a/src/NetMQ/Core/Utils/SpanUtility.cs
+++ b/src/NetMQ/Core/Utils/SpanUtility.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Text;
 

--- a/src/NetMQ/Core/Utils/StopSignaler.cs
+++ b/src/NetMQ/Core/Utils/StopSignaler.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.Threading;
 using NetMQ.Sockets;
 

--- a/src/NetMQ/Core/Utils/StringLib.cs
+++ b/src/NetMQ/Core/Utils/StringLib.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Text;
 

--- a/src/NetMQ/Core/Utils/Switch.cs
+++ b/src/NetMQ/Core/Utils/Switch.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.Threading;
 
 namespace NetMQ.Core.Utils

--- a/src/NetMQ/Core/YPipe.cs
+++ b/src/NetMQ/Core/YPipe.cs
@@ -178,7 +178,7 @@ namespace NetMQ.Core
         /// Attempts to read an item from the pipe.
         /// </summary>
         /// <returns><c>true</c> if the read succeeded, otherwise <c>false</c>.</returns>
-        public bool TryRead([MaybeNull] out T value)
+        public bool TryRead([MaybeNullWhen(returnValue: false)] out T value)
         {
             // Try to prefetch a value.
             if (!CheckRead())

--- a/src/NetMQ/Core/YPipe.cs
+++ b/src/NetMQ/Core/YPipe.cs
@@ -19,9 +19,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using NetMQ.Core.Utils;
 
@@ -179,7 +178,7 @@ namespace NetMQ.Core
         /// Attempts to read an item from the pipe.
         /// </summary>
         /// <returns><c>true</c> if the read succeeded, otherwise <c>false</c>.</returns>
-        public bool TryRead(out T value)
+        public bool TryRead([MaybeNull] out T value)
         {
             // Try to prefetch a value.
             if (!CheckRead())

--- a/src/NetMQ/Core/ZObject.cs
+++ b/src/NetMQ/Core/ZObject.cs
@@ -19,10 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
-using JetBrains.Annotations;
 using NetMQ.Core.Transports;
 
 namespace NetMQ.Core
@@ -47,7 +44,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="ctx">the context for the new ZObject to live within</param>
         /// <param name="threadId">the integer thread-id for the new ZObject to be associated with</param>
-        protected ZObject([NotNull] Ctx ctx, int threadId)
+        protected ZObject(Ctx ctx, int threadId)
         {
             m_ctx = ctx;
             m_threadId = threadId;
@@ -57,7 +54,7 @@ namespace NetMQ.Core
         /// Create a new ZObject that has the same context and thread-id as the given parent-ZObject.
         /// </summary>
         /// <param name="parent">another ZObject that provides the context and thread-id for this one</param>
-        protected ZObject([NotNull] ZObject parent)
+        protected ZObject(ZObject parent)
             : this(parent.m_ctx, parent.m_threadId)
         {}
 
@@ -69,32 +66,30 @@ namespace NetMQ.Core
         /// <summary>
         /// Get the context that provides access to the global state.
         /// </summary>
-        [NotNull]
         protected Ctx Ctx => m_ctx;
 
-        protected bool RegisterEndpoint([NotNull] string addr, [NotNull] Ctx.Endpoint endpoint)
+        protected bool RegisterEndpoint(string addr, Ctx.Endpoint endpoint)
         {
             return m_ctx.RegisterEndpoint(addr, endpoint);
         }
 
-        protected bool UnregisterEndpoint([NotNull] string addr, [NotNull] SocketBase socket)
+        protected bool UnregisterEndpoint(string addr, SocketBase socket)
         {
             return m_ctx.UnregisterEndpoint(addr, socket);
         }
 
-        protected void UnregisterEndpoints([NotNull] SocketBase socket)
+        protected void UnregisterEndpoints(SocketBase socket)
         {
             m_ctx.UnregisterEndpoints(socket);
         }
 
         /// <exception cref="EndpointNotFoundException">The given address was not found in the list of endpoints.</exception>
-        [NotNull]
-        protected Ctx.Endpoint FindEndpoint([NotNull] string addr)
+        protected Ctx.Endpoint FindEndpoint(string addr)
         {
             return m_ctx.FindEndpoint(addr);
         }
 
-        protected void DestroySocket([NotNull] SocketBase socket)
+        protected void DestroySocket(SocketBase socket)
         {
             m_ctx.DestroySocket(socket);
         }
@@ -104,8 +99,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <paramref name="affinity">Which threads are eligible (0 = all).</paramref>
         /// <returns>The least busy thread, or <c>null</c> if none is available.</returns>
-        [CanBeNull]
-        protected IOThread ChooseIOThread(long affinity)
+        protected IOThread? ChooseIOThread(long affinity)
         {
             return m_ctx.ChooseIOThread(affinity);
         }
@@ -131,7 +125,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="destination">the Own to send the command to</param>
         /// <param name="incSeqnum">a flag that dictates whether to increment the sequence-number on the destination (optional - defaults to false)</param>
-        protected void SendPlug([NotNull] Own destination, bool incSeqnum = true)
+        protected void SendPlug(Own destination, bool incSeqnum = true)
         {
             if (incSeqnum)
                 destination.IncSeqnum();
@@ -144,7 +138,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="destination">the Own to send the command to</param>
         /// <param name="obj">the object to Own</param>
-        protected void SendOwn([NotNull] Own destination, [NotNull] Own obj)
+        protected void SendOwn(Own destination, Own obj)
         {
             destination.IncSeqnum();
             SendCommand(new Command(destination, CommandType.Own, obj));
@@ -156,7 +150,7 @@ namespace NetMQ.Core
         /// <param name="destination">the Own to send the command to</param>
         /// <param name="engine"></param>
         /// <param name="incSeqnum"></param>
-        protected void SendAttach([NotNull] SessionBase destination, [NotNull] IEngine engine, bool incSeqnum = true)
+        protected void SendAttach(SessionBase destination, IEngine engine, bool incSeqnum = true)
         {
             if (incSeqnum)
                 destination.IncSeqnum();
@@ -170,7 +164,7 @@ namespace NetMQ.Core
         /// <param name="destination"></param>
         /// <param name="pipe"></param>
         /// <param name="incSeqnum"></param>
-        protected void SendBind([NotNull] Own destination, [NotNull] Pipe pipe, bool incSeqnum = true)
+        protected void SendBind(Own destination, Pipe pipe, bool incSeqnum = true)
         {
             if (incSeqnum)
                 destination.IncSeqnum();
@@ -178,27 +172,27 @@ namespace NetMQ.Core
             SendCommand(new Command(destination, CommandType.Bind, pipe));
         }
 
-        protected void SendActivateRead([NotNull] Pipe destination)
+        protected void SendActivateRead(Pipe destination)
         {
             SendCommand(new Command(destination, CommandType.ActivateRead));
         }
 
-        protected void SendActivateWrite([NotNull] Pipe destination, long msgsRead)
+        protected void SendActivateWrite(Pipe destination, long msgsRead)
         {
             SendCommand(new Command(destination, CommandType.ActivateWrite, msgsRead));
         }
 
-        protected void SendHiccup([NotNull] Pipe destination, [NotNull] object pipe)
+        protected void SendHiccup(Pipe destination, object pipe)
         {
             SendCommand(new Command(destination, CommandType.Hiccup, pipe));
         }
 
-        protected void SendPipeTerm([NotNull] Pipe destination)
+        protected void SendPipeTerm(Pipe destination)
         {
             SendCommand(new Command(destination, CommandType.PipeTerm));
         }
 
-        protected void SendPipeTermAck([NotNull] Pipe destination)
+        protected void SendPipeTermAck(Pipe destination)
         {
             SendCommand(new Command(destination, CommandType.PipeTermAck));
         }
@@ -208,22 +202,22 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="destination"></param>
         /// <param name="obj"></param>
-        protected void SendTermReq([NotNull] Own destination, [NotNull] Own obj)
+        protected void SendTermReq(Own destination, Own obj)
         {
             SendCommand(new Command(destination, CommandType.TermReq, obj));
         }
 
-        protected void SendTerm([NotNull] Own destination, int linger)
+        protected void SendTerm(Own destination, int linger)
         {
             SendCommand(new Command(destination, CommandType.Term, linger));
         }
 
-        protected void SendTermAck([NotNull] Own destination)
+        protected void SendTermAck(Own destination)
         {
             SendCommand(new Command(destination, CommandType.TermAck));
         }
 
-        protected void SendReap([NotNull] SocketBase socket)
+        protected void SendReap(SocketBase socket)
         {
             SendCommand(new Command(m_ctx.GetReaper(), CommandType.Reap, socket));
         }
@@ -254,8 +248,9 @@ namespace NetMQ.Core
         /// Send the given Command, on that commands Destination thread.
         /// </summary>
         /// <param name="cmd">the Command to send</param>
-        private void SendCommand([NotNull] Command cmd)
+        private void SendCommand(Command cmd)
         {
+            Assumes.NotNull(cmd.Destination);
             m_ctx.SendCommand(cmd.Destination.ThreadId, cmd);
         }
 
@@ -263,8 +258,10 @@ namespace NetMQ.Core
 
         #region Command processing
 
-        public void ProcessCommand([NotNull] Command cmd)
+        public void ProcessCommand(Command cmd)
         {
+            T GetArg<T>() => cmd.Arg is T v ? v : throw new ArgumentException($"Command argument must be of type {typeof(T).Name}.");
+
             switch (cmd.CommandType)
             {
                 case CommandType.ActivateRead:
@@ -272,7 +269,7 @@ namespace NetMQ.Core
                     break;
 
                 case CommandType.ActivateWrite:
-                    ProcessActivateWrite((long)cmd.Arg);
+                    ProcessActivateWrite(GetArg<long>());
                     break;
 
                 case CommandType.Stop:
@@ -285,22 +282,22 @@ namespace NetMQ.Core
                     break;
 
                 case CommandType.Own:
-                    ProcessOwn((Own)cmd.Arg);
+                    ProcessOwn(GetArg<Own>());
                     ProcessSeqnum();
                     break;
 
                 case CommandType.Attach:
-                    ProcessAttach((IEngine)cmd.Arg);
+                    ProcessAttach(GetArg<IEngine>());
                     ProcessSeqnum();
                     break;
 
                 case CommandType.Bind:
-                    ProcessBind((Pipe)cmd.Arg);
+                    ProcessBind(GetArg<Pipe>());
                     ProcessSeqnum();
                     break;
 
                 case CommandType.Hiccup:
-                    ProcessHiccup(cmd.Arg);
+                    ProcessHiccup(GetArg<object>());
                     break;
 
                 case CommandType.PipeTerm:
@@ -312,11 +309,11 @@ namespace NetMQ.Core
                     break;
 
                 case CommandType.TermReq:
-                    ProcessTermReq((Own)cmd.Arg);
+                    ProcessTermReq(GetArg<Own>());
                     break;
 
                 case CommandType.Term:
-                    ProcessTerm((int)cmd.Arg);
+                    ProcessTerm(GetArg<int>());
                     break;
 
                 case CommandType.TermAck:
@@ -324,7 +321,7 @@ namespace NetMQ.Core
                     break;
 
                 case CommandType.Reap:
-                    ProcessReap((SocketBase)cmd.Arg);
+                    ProcessReap(GetArg<SocketBase>());
                     break;
 
                 case CommandType.Reaped:
@@ -363,13 +360,13 @@ namespace NetMQ.Core
         }
 
         /// <exception cref="NotSupportedException">Not supported on the ZObject class.</exception>
-        protected virtual void ProcessOwn([NotNull] Own obj)
+        protected virtual void ProcessOwn(Own obj)
         {
             throw new NotSupportedException();
         }
 
         /// <exception cref="NotSupportedException">Not supported on the ZObject class.</exception>
-        protected virtual void ProcessAttach([NotNull] IEngine engine)
+        protected virtual void ProcessAttach(IEngine engine)
         {
             throw new NotSupportedException();
         }
@@ -379,7 +376,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="pipe"></param>
         /// <exception cref="NotSupportedException">Not supported on the ZObject class.</exception>
-        protected virtual void ProcessBind([NotNull] Pipe pipe)
+        protected virtual void ProcessBind(Pipe pipe)
         {
             throw new NotSupportedException();
         }
@@ -406,7 +403,7 @@ namespace NetMQ.Core
         /// is no longer available for writing to.
         /// </remarks>
         /// <exception cref="NotSupportedException">No supported on the ZObject class.</exception>
-        protected virtual void ProcessHiccup([NotNull] object pipe)
+        protected virtual void ProcessHiccup(object pipe)
         {
             throw new NotSupportedException();
         }
@@ -434,7 +431,7 @@ namespace NetMQ.Core
         /// </summary>
         /// <param name="obj"></param>
         /// <exception cref="NotSupportedException">Not supported on the ZObject class.</exception>
-        protected virtual void ProcessTermReq([NotNull] Own obj)
+        protected virtual void ProcessTermReq(Own obj)
         {
             throw new NotSupportedException();
         }
@@ -458,7 +455,7 @@ namespace NetMQ.Core
             throw new NotSupportedException();
         }
 
-        protected virtual void ProcessReap([NotNull] SocketBase socket)
+        protected virtual void ProcessReap(SocketBase socket)
         {
             // Overridden by Reaper
             throw new NotSupportedException();

--- a/src/NetMQ/Core/ZmqSocketOption.cs
+++ b/src/NetMQ/Core/ZmqSocketOption.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 
 namespace NetMQ.Core
 {

--- a/src/NetMQ/Monitoring/NetMQMonitor.cs
+++ b/src/NetMQ/Monitoring/NetMQMonitor.cs
@@ -156,37 +156,39 @@ namespace NetMQ.Monitoring
         {
             var monitorEvent = MonitorEvent.Read(m_monitoringSocket.SocketHandle);
 
+            T GetArg<T>() => monitorEvent.Arg is T v ? v : throw new ArgumentException($"Command argument must be of type {typeof(T).Name}.");
+
             switch (monitorEvent.Event)
             {
                 case SocketEvents.Connected:
-                    InvokeEvent(Connected, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, (AsyncSocket)monitorEvent.Arg, SocketEvents.Connected));
+                    InvokeEvent(Connected, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Connected));
                     break;
                 case SocketEvents.ConnectDelayed:
-                    InvokeEvent(ConnectDelayed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, (ErrorCode)monitorEvent.Arg, SocketEvents.ConnectDelayed));
+                    InvokeEvent(ConnectDelayed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, GetArg<ErrorCode>(), SocketEvents.ConnectDelayed));
                     break;
                 case SocketEvents.ConnectRetried:
-                    InvokeEvent(ConnectRetried, new NetMQMonitorIntervalEventArgs(this, monitorEvent.Addr, (int)monitorEvent.Arg, SocketEvents.ConnectRetried));
+                    InvokeEvent(ConnectRetried, new NetMQMonitorIntervalEventArgs(this, monitorEvent.Addr, GetArg<int>(), SocketEvents.ConnectRetried));
                     break;
                 case SocketEvents.Listening:
-                    InvokeEvent(Listening, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, (AsyncSocket)monitorEvent.Arg, SocketEvents.Listening));
+                    InvokeEvent(Listening, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Listening));
                     break;
                 case SocketEvents.BindFailed:
-                    InvokeEvent(BindFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, (ErrorCode)monitorEvent.Arg, SocketEvents.BindFailed));
+                    InvokeEvent(BindFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, GetArg<ErrorCode>(), SocketEvents.BindFailed));
                     break;
                 case SocketEvents.Accepted:
-                    InvokeEvent(Accepted, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, (AsyncSocket)monitorEvent.Arg, SocketEvents.Accepted));
+                    InvokeEvent(Accepted, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Accepted));
                     break;
                 case SocketEvents.AcceptFailed:
-                    InvokeEvent(AcceptFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, (ErrorCode)monitorEvent.Arg, SocketEvents.AcceptFailed));
+                    InvokeEvent(AcceptFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, GetArg<ErrorCode>(), SocketEvents.AcceptFailed));
                     break;
                 case SocketEvents.Closed:
-                    InvokeEvent(Closed, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, (AsyncSocket)monitorEvent.Arg, SocketEvents.Closed));
+                    InvokeEvent(Closed, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Closed));
                     break;
                 case SocketEvents.CloseFailed:
-                    InvokeEvent(CloseFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, (ErrorCode)monitorEvent.Arg, SocketEvents.CloseFailed));
+                    InvokeEvent(CloseFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, GetArg<ErrorCode>(), SocketEvents.CloseFailed));
                     break;
                 case SocketEvents.Disconnected:
-                    InvokeEvent(Disconnected, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, (AsyncSocket)monitorEvent.Arg, SocketEvents.Disconnected));
+                    InvokeEvent(Disconnected, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Disconnected));
                     break;
                 default:
                     throw new Exception("unknown event " + monitorEvent.Event);

--- a/src/NetMQ/Monitoring/NetMQMonitor.cs
+++ b/src/NetMQ/Monitoring/NetMQMonitor.cs
@@ -164,7 +164,7 @@ namespace NetMQ.Monitoring
                     InvokeEvent(Connected, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Connected));
                     break;
                 case SocketEvents.ConnectDelayed:
-                    InvokeEvent(ConnectDelayed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, GetArg<ErrorCode>(), SocketEvents.ConnectDelayed));
+                    InvokeEvent(ConnectDelayed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, (ErrorCode)GetArg<int>(), SocketEvents.ConnectDelayed));
                     break;
                 case SocketEvents.ConnectRetried:
                     InvokeEvent(ConnectRetried, new NetMQMonitorIntervalEventArgs(this, monitorEvent.Addr, GetArg<int>(), SocketEvents.ConnectRetried));
@@ -173,19 +173,19 @@ namespace NetMQ.Monitoring
                     InvokeEvent(Listening, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Listening));
                     break;
                 case SocketEvents.BindFailed:
-                    InvokeEvent(BindFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, GetArg<ErrorCode>(), SocketEvents.BindFailed));
+                    InvokeEvent(BindFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, (ErrorCode)GetArg<int>(), SocketEvents.BindFailed));
                     break;
                 case SocketEvents.Accepted:
                     InvokeEvent(Accepted, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Accepted));
                     break;
                 case SocketEvents.AcceptFailed:
-                    InvokeEvent(AcceptFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, GetArg<ErrorCode>(), SocketEvents.AcceptFailed));
+                    InvokeEvent(AcceptFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, (ErrorCode)GetArg<int>(), SocketEvents.AcceptFailed));
                     break;
                 case SocketEvents.Closed:
                     InvokeEvent(Closed, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Closed));
                     break;
                 case SocketEvents.CloseFailed:
-                    InvokeEvent(CloseFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, GetArg<ErrorCode>(), SocketEvents.CloseFailed));
+                    InvokeEvent(CloseFailed, new NetMQMonitorErrorEventArgs(this, monitorEvent.Addr, (ErrorCode)GetArg<int>(), SocketEvents.CloseFailed));
                     break;
                 case SocketEvents.Disconnected:
                     InvokeEvent(Disconnected, new NetMQMonitorSocketEventArgs(this, monitorEvent.Addr, GetArg<AsyncSocket>(), SocketEvents.Disconnected));

--- a/src/NetMQ/NetMQPoller.cs
+++ b/src/NetMQ/NetMQPoller.cs
@@ -508,9 +508,6 @@ namespace NetMQ
         /// </summary>
         private void RunPoller()
         {
-            Assumes.NotNull(m_pollSet);
-            Assumes.NotNull(m_pollact);
-
             try
             {
                 // Recalculate all timers now
@@ -558,6 +555,8 @@ namespace NetMQ
 
                     var isItemAvailable = false;
 
+                    Assumes.NotNull(m_pollSet);
+
                     if (m_pollSet.Length != 0)
                     {
                         isItemAvailable = m_netMqSelector.Select(m_pollSet, m_pollSet.Length, timeout);
@@ -596,6 +595,8 @@ namespace NetMQ
 
                         if (item.Socket != null)
                         {
+                            Assumes.NotNull(m_pollact);
+
                             NetMQSocket socket = m_pollact[i];
 
                             if (item.ResultEvent.HasError())

--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using NetMQ.Core;
@@ -471,6 +472,7 @@ namespace NetMQ
         /// <returns>an object of the given type, that is the value of that option</returns>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
         /// <exception cref="ObjectDisposedException">This object is already disposed.</exception>
+        [return: MaybeNull]
         internal T GetSocketOptionX<T>(ZmqSocketOption option)
         {
             m_socketHandle.CheckDisposed();

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -393,7 +393,7 @@ namespace NetMQ
         /// <summary>
         /// Get the last PEER allocated routing id
         /// </summary>
-        public byte[] LastPeerRoutingId => m_socket.GetSocketOptionX<byte[]>(ZmqSocketOption.LastPeerRoutingId);
+        public byte[]? LastPeerRoutingId => m_socket.GetSocketOptionX<byte[]>(ZmqSocketOption.LastPeerRoutingId);
 
         /// <summary>
         /// Controls the maximum datagram size for PGM.
@@ -442,7 +442,8 @@ namespace NetMQ
         /// This key must have been generated together with the server's secret key.
         /// To generate a public/secret key pair, use <see cref="NetMQCertificate"/>.
         /// </summary>
-        public byte[] CurveServerKey
+        [DisallowNull]
+        public byte[]? CurveServerKey
         {
             get => m_socket.GetSocketOptionX<byte[]>(ZmqSocketOption.CurveServerKey);
             set => m_socket.SetSocketOption(ZmqSocketOption.CurveServerKey, value);

--- a/src/NetMQ/Sockets/PeerSocket.cs
+++ b/src/NetMQ/Sockets/PeerSocket.cs
@@ -38,7 +38,9 @@ namespace NetMQ.Sockets
         public byte[] ConnectPeer(string address)
         {
             Connect(address);
-            return GetSocketOptionX<byte[]>(ZmqSocketOption.LastPeerRoutingId);
+            byte[]? routingId = GetSocketOptionX<byte[]>(ZmqSocketOption.LastPeerRoutingId);
+            Assumes.NotNull(routingId);
+            return routingId;
         }
     }
 }

--- a/src/NetMQ/ThreafSafeSocketOptions.cs
+++ b/src/NetMQ/ThreafSafeSocketOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using NetMQ.Core;
 
 namespace NetMQ
@@ -68,6 +69,7 @@ namespace NetMQ
         /// <returns>an object of the given type, that is the value of that option</returns>
         /// <exception cref="TerminatingException">The socket has been stopped.</exception>
         /// <exception cref="ObjectDisposedException">This object is already disposed.</exception>
+        [return: MaybeNull]
         internal T GetSocketOptionX<T>(ZmqSocketOption option)
         {
             m_socket.CheckDisposed();
@@ -349,7 +351,8 @@ namespace NetMQ
         /// This key must have been generated together with the server's secret key.
         /// To generate a public/secret key pair, use <see cref="NetMQCertificate"/>.
         /// </summary>
-        public byte[] CurveServerKey
+        [DisallowNull]
+        public byte[]? CurveServerKey
         {
             get => GetSocketOptionX<byte[]>(ZmqSocketOption.CurveServerKey);
             set => SetSocketOption(ZmqSocketOption.CurveServerKey, value);

--- a/src/NetMQ/Utils/Assumes.cs
+++ b/src/NetMQ/Utils/Assumes.cs
@@ -9,7 +9,7 @@ namespace NetMQ
         [Conditional("DEBUG")]
         public static void NotNull<T>([NotNull] T o) where T : class?
         {
-            Debug.Assert(o is object);
+            Debug.Assert(o is object, $"Unexpected null of type {typeof(T).Name}");
         }
 #pragma warning restore CS8777 // Parameter must have a non-null value when exiting.
     }


### PR DESCRIPTION
Please especially review the few public API changes towards the end.

Note that `Assumes.NotNull` is `[Conditional("DEBUG")]` so has no runtime cost in release builds. I try to avoid using `!` where possible, and new code should be designed such that `Assumes.NotNull` isn't needed either. It's not reasonable to change the design on existing code to address all warnings, so adding these debug-only checks seems like a good tradeoff to me.