### PR TITLE
Make System.Diagnostics.Debug failures throw in unit tests

### DIFF
--- a/src/NetMQ.Tests/App.config
+++ b/src/NetMQ.Tests/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.diagnostics>
+    <trace>
+      <listeners>
+        <remove name="Default" />
+        <add name="ThrowingTraceListener" type="NetMQ.Tests.ThrowingTraceListener, NetMQ.Tests" />
+      </listeners>
+    </trace>
+  </system.diagnostics>
+</configuration>

--- a/src/NetMQ.Tests/ThrowingTraceListener.cs
+++ b/src/NetMQ.Tests/ThrowingTraceListener.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+
+namespace NetMQ.Tests
+{
+    public sealed class ThrowingTraceListener : TraceListener
+    {
+        public override void Fail(string message, string detailMessage)
+        {
+            throw new DebugAssertFailureException((message + Environment.NewLine + detailMessage).Trim());
+        }
+
+        public override void Write(string message)
+        {
+        }
+
+        public override void WriteLine(string message)
+        {
+        }
+
+        [Serializable]
+        public class DebugAssertFailureException : Exception
+        {
+            public DebugAssertFailureException()
+            {
+            }
+
+            public DebugAssertFailureException(string message) : base(message)
+            {
+            }
+
+            public DebugAssertFailureException(string message, Exception inner) : base(message, inner)
+            {
+            }
+
+            protected DebugAssertFailureException(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously, assertion failures while running unit tests would display a dialog box. This change causes an exception to be thrown instead.

This behaviour is beneficial on CI if debug builds are used.

The only downside is that locally it's a bit less convenient to investigate failures, as the 'retry' button allows quickly attaching a debugger with the offending frame in play.