### PR TITLE
Handle SocketError.Shutdown

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,3 +25,4 @@ Contributors
 * Calin Pirtea &mdash; [@pcalin](https://github.com/pcalin)
 * Osiris Pedroso &mdash; [@opedroso](https://github.com/opedroso)
 * Mike Miller &mdash; [@mikepmiller](https://github.com/mikepmiller)
+* Miguel Labayen &mdash; [@milabtom](https://github.com/milabtom)

--- a/src/NetMQ/Core/Transports/StreamEngine.cs
+++ b/src/NetMQ/Core/Transports/StreamEngine.cs
@@ -1049,7 +1049,8 @@ namespace NetMQ.Core.Transports
                 socketError == SocketError.ConnectionAborted ||
                 socketError == SocketError.TimedOut ||
                 socketError == SocketError.ConnectionReset ||
-                socketError == SocketError.AccessDenied)
+                socketError == SocketError.AccessDenied || 
+                socketError == SocketError.Shutdown)
                 return -1;
 
             throw NetMQException.Create(socketError);


### PR DESCRIPTION
Hello all,

I had an exception attached occurring when using PUB/SUB messaging pattern. The exception only occurrs when I access the publisher through a VPN. 

After some debugging I found out that I was having a SocketError.Shutdown which was not being handled by NetMQ. I have added an extra check to overcome this issue.

[NetMQException.txt](https://github.com/zeromq/netmq/files/4863241/NetMQException.txt)



