### PR TITLE
Fix TrySendFrame if buffer is bigger than length

### DIFF
--- a/src/NetMQ.Tests/OutgoingSocketExtensionsTests.cs
+++ b/src/NetMQ.Tests/OutgoingSocketExtensionsTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace NetMQ.Tests
@@ -321,6 +323,23 @@ namespace NetMQ.Tests
             });
 
             Assert.False(socket.TrySignalOK());
+        }
+
+        [Fact]
+        public void TrySendFrameBiggerBufferThanLength()
+        {
+	        var buffer = new byte[64];
+	        var data = Encoding.ASCII.GetBytes("Hello there");
+	        data.CopyTo(buffer, 0);
+	        var socket = new MockOutgoingSocket((ref Msg msg, TimeSpan timeout, bool more) =>
+	        {
+		        Assert.Equal(TimeSpan.Zero, timeout);
+		        Assert.True(data.SequenceEqual(msg.ToArray()));
+		        Assert.False(more);
+		        return true;
+	        });
+
+	        Assert.True(socket.TrySendFrame(TimeSpan.Zero, buffer, data.Length));
         }
     }
 }

--- a/src/NetMQ/OutgoingSocketExtensions.cs
+++ b/src/NetMQ/OutgoingSocketExtensions.cs
@@ -104,7 +104,7 @@ namespace NetMQ
         {
             var msg = new Msg();
             msg.InitPool(length);
-            data.CopyTo(msg);
+            data.Slice(0, length).CopyTo(msg);
             if (!socket.TrySend(ref msg, timeout, more))
             {
                 msg.Close();


### PR DESCRIPTION
"TrySendFrame" thrown a System.ArgumentException if buffer was bigger than length