### PR TITLE
Fix cancellation in ReceiveFrameBytesAsync

### DIFF
--- a/src/NetMQ/AsyncReceiveExtensions.cs
+++ b/src/NetMQ/AsyncReceiveExtensions.cs
@@ -20,7 +20,7 @@ namespace NetMQ
         static Task<bool> s_trueTask = Task.FromResult(true);
         static Task<bool> s_falseTask = Task.FromResult(false);
 
-        #region Receiving frames as a multipart message
+#region Receiving frames as a multipart message
 
         /// <summary>
         /// Receive a single frame from <paramref name="socket"/>, asynchronously.
@@ -52,9 +52,9 @@ namespace NetMQ
             return message;
         }
 
-        #endregion
+#endregion
 
-        #region Receiving a frame as a byte array
+#region Receiving a frame as a byte array
 
         /// <summary>
         /// Receive a single frame from <paramref name="socket"/>, asynchronously.
@@ -85,8 +85,12 @@ namespace NetMQ
             }
 
             TaskCompletionSource<(byte[], bool)> source = new TaskCompletionSource<(byte[], bool)>();
+
             CancellationTokenRegistration? registration = null;
-            registration = cancellationToken.Register(PropagateCancel);
+            if (cancellationToken.CanBeCanceled) 
+            {
+                registration = cancellationToken.Register(PropagateCancel);
+            }
 
             void Listener(object sender, NetMQSocketEventArgs args)
             {
@@ -114,9 +118,9 @@ namespace NetMQ
             return source.Task;
         }
 
-        #endregion
+#endregion
 
-        #region Receiving a frame as a string
+#region Receiving a frame as a string
 
         /// <summary>
         /// Receive a single frame from <paramref name="socket"/>, asynchronously, and decode as a string using <see cref="SendReceiveConstants.DefaultEncoding"/>.
@@ -164,7 +168,12 @@ namespace NetMQ
             }
 
             TaskCompletionSource<(string, bool)> source = new TaskCompletionSource<(string,bool)>();
-            cancellationToken.Register(() => source.SetCanceled());
+
+            CancellationTokenRegistration? registration = null;
+            if (cancellationToken.CanBeCanceled) 
+            {
+                registration = cancellationToken.Register(PropagateCancel);
+            }
 
             void Listener(object sender, NetMQSocketEventArgs args)
             {
@@ -174,11 +183,19 @@ namespace NetMQ
                         ? msg.GetString(encoding)
                         : string.Empty;
                     bool more = msg.HasMore;
-
                     msg.Close();
+
                     socket.ReceiveReady -=  Listener;
-                    source.SetResult((str, more));
+                    registration?.Dispose();
+                    source.TrySetResult((str, more));
                 }
+            }
+
+            void PropagateCancel()
+            {
+                socket.ReceiveReady -= Listener;
+                registration?.Dispose();
+                source.TrySetCanceled();
             }
 
             socket.ReceiveReady += Listener;
@@ -186,16 +203,20 @@ namespace NetMQ
             return source.Task;
         }
 
-        #endregion
+#endregion
 
-        #region Skipping a message
+#region Skipping a message
 
         /// <summary>
         /// Receive a single frame from <paramref name="socket"/>, asynchronously, then ignore its content.
         /// </summary>
         /// <param name="socket">The socket to receive from.</param>
+        /// <param name="cancellationToken">The token used to propagate notification that this operation should be canceled.</param>
         /// <returns>Boolean indicate if another frame of the same message follows</returns>
-        public static Task<bool> SkipFrameAsync(this NetMQSocket socket)
+        public static Task<bool> SkipFrameAsync(
+            this NetMQSocket socket, 
+            CancellationToken cancellationToken = default(CancellationToken)
+        )
         {
             if (NetMQRuntime.Current == null)
                 throw new InvalidOperationException("NetMQRuntime must be created before calling async functions");
@@ -215,15 +236,30 @@ namespace NetMQ
 
             TaskCompletionSource<bool> source = new TaskCompletionSource<bool>();
 
+            CancellationTokenRegistration? registration = null;
+            if (cancellationToken.CanBeCanceled) 
+            {
+                registration = cancellationToken.Register(PropagateCancel);
+            }
+
             void Listener(object sender, NetMQSocketEventArgs args)
             {
                 if (socket.TryReceive(ref msg, TimeSpan.Zero))
                 {
                     bool more = msg.HasMore;
                     msg.Close();
+
                     socket.ReceiveReady -=  Listener;
-                    source.SetResult(more);
+                    registration?.Dispose();
+                    source.TrySetResult(more);
                 }
+            }
+
+            void PropagateCancel()
+            {
+                socket.ReceiveReady -= Listener;
+                registration?.Dispose();
+                source.TrySetCanceled();
             }
 
             socket.ReceiveReady += Listener;
@@ -232,9 +268,9 @@ namespace NetMQ
         }
 
 
-        #endregion
+#endregion
 
-        #region Skipping all frames of a multipart message
+#region Skipping all frames of a multipart message
 
         /// <summary>
         /// Receive all frames of the next message from <paramref name="socket"/>, asynchronously, then ignore their contents.
@@ -251,9 +287,9 @@ namespace NetMQ
         }
 
 
-        #endregion
+#endregion
 
-        #region Receiving a routing key
+#region Receiving a routing key
 
         /// <summary>
         /// Receive a routing-key from <paramref name="socket"/>, blocking until one arrives.
@@ -268,7 +304,7 @@ namespace NetMQ
             return (new RoutingKey(bytes), more);
         }
 
-        #endregion
+#endregion
     }
 }
 

--- a/src/NetMQ/AsyncReceiveExtensions.cs
+++ b/src/NetMQ/AsyncReceiveExtensions.cs
@@ -85,7 +85,8 @@ namespace NetMQ
             }
 
             TaskCompletionSource<(byte[], bool)> source = new TaskCompletionSource<(byte[], bool)>();
-            var registration = cancellationToken.Register(PropagateCancel);
+            CancellationTokenRegistration? registration = null;
+            registration = cancellationToken.Register(PropagateCancel);
 
             void Listener(object sender, NetMQSocketEventArgs args)
             {
@@ -96,7 +97,7 @@ namespace NetMQ
                     msg.Close();
 
                     socket.ReceiveReady -=  Listener;
-                    registration.Dispose();
+                    registration?.Dispose();
                     source.TrySetResult((data, more));
                 }
             }
@@ -104,7 +105,7 @@ namespace NetMQ
             void PropagateCancel()
             {
                 socket.ReceiveReady -= Listener;
-                registration.Dispose();
+                registration?.Dispose();
                 source.TrySetCanceled();
             }
 


### PR DESCRIPTION
This PR updates ReceiveFrameBytesAsync to detach competing listeners before finishing the TaskCompletionSource and call `TrySetResult` and `TrySetCanceled` instead of `SetResult` and `SetCanceled`.

Fixes #965.