### PR TITLE
Catch small buffer Exception Beacon

### DIFF
--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -294,7 +294,7 @@ namespace NetMQ
                 }
                 catch(SocketException ex)
 				{
-                    if (ex.SocketErrorCode != SocketError.NoBufferSpaceAvailable) { throw; }
+                    if (ex.SocketErrorCode != SocketError.MessageSize) { throw; }
                 }
                 peerName = peer.ToString();
 

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -293,7 +293,7 @@ namespace NetMQ
                     bytesRead = m_udpSocket.ReceiveFrom(buffer, ref peer);
                 }
                 catch(SocketException ex)
-				{
+                {
                     if (ex.SocketErrorCode != SocketError.MessageSize) { throw; }
                 }
                 peerName = peer.ToString();

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -199,7 +199,7 @@ namespace NetMQ
             {
                 Assumes.NotNull(m_pipe);
 
-                var frame = ReceiveUdpFrame(out string peerName);
+                if (!ReceiveUdpFrame(out NetMQFrame frame, out string peerName)) return;
 
                 // If filter is set, check that beacon matches it
                 var isValid = frame.MessageSize >= m_filter?.MessageSize && Compare(frame, m_filter, m_filter.MessageSize);
@@ -280,7 +280,7 @@ namespace NetMQ
                 }
             }
 
-            private NetMQFrame ReceiveUdpFrame(out string peerName)
+            private bool ReceiveUdpFrame(out NetMQFrame frame, out string peerName)
             {
                 Assumes.NotNull(m_udpSocket);
 
@@ -295,10 +295,14 @@ namespace NetMQ
                 catch(SocketException ex)
                 {
                     if (ex.SocketErrorCode != SocketError.MessageSize) { throw; }
+                    frame = new NetMQFrame("");
+                    peerName = "";
+                    return false;
                 }
                 peerName = peer.ToString();
+                frame = new NetMQFrame(buffer, bytesRead);
 
-                return new NetMQFrame(buffer, bytesRead);
+                return true;
             }
         }
 

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -287,7 +287,15 @@ namespace NetMQ
                 var buffer = new byte[UdpFrameMax];
                 EndPoint peer = new IPEndPoint(IPAddress.Any, 0);
 
-                var bytesRead = m_udpSocket.ReceiveFrom(buffer, ref peer);
+                int bytesRead = 0;
+                try
+                {
+                    bytesRead = m_udpSocket.ReceiveFrom(buffer, ref peer);
+                }
+                catch(SocketException ex)
+				{
+                    if (ex.SocketErrorCode != SocketError.NoBufferSpaceAvailable) { throw; }
+                }
                 peerName = peer.ToString();
 
                 return new NetMQFrame(buffer, bytesRead);

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -199,7 +199,7 @@ namespace NetMQ
             {
                 Assumes.NotNull(m_pipe);
 
-                if (!ReceiveUdpFrame(out NetMQFrame frame, out string peerName)) return;
+                if (!TryReceiveUdpFrame(out NetMQFrame frame, out string peerName)) return;
 
                 // If filter is set, check that beacon matches it
                 var isValid = frame.MessageSize >= m_filter?.MessageSize && Compare(frame, m_filter, m_filter.MessageSize);
@@ -280,7 +280,7 @@ namespace NetMQ
                 }
             }
 
-            private bool ReceiveUdpFrame(out NetMQFrame frame, out string peerName)
+            private bool TryReceiveUdpFrame(out NetMQFrame frame, out string peerName)
             {
                 Assumes.NotNull(m_udpSocket);
 


### PR DESCRIPTION
Catches exception that occurs when a UDP message larger than 255 appears on the beacon's port and ignores it.

Reproduce by sending a message on a given UDP port when the beacon is listening on it that is larger than 255 bytes.

FATAL { 2021-05-13 16:20:31,295 [NetMQActor-4640-3863] } - Fatal unhandled exception thrown, runtime terminating=True
System.Net.Sockets.SocketException (0x80004005): A message sent on a datagram socket was larger than the internal message buffer or some other network limit, or the buffer used to receive a datagram into was smaller than the datagram itself
   at System.Net.Sockets.Socket.ReceiveFrom(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags, EndPoint& remoteEP)
   at NetMQ.NetMQBeacon.Shim.ReceiveUdpFrame(String& peerName)
   at NetMQ.NetMQBeacon.Shim.OnUdpReady(Socket socket)
   at NetMQ.NetMQPoller.RunPoller()
   at NetMQ.NetMQPoller.Run(SynchronizationContext syncContext)
   at NetMQ.NetMQBeacon.Shim.Run(PairSocket shim)
   at NetMQ.NetMQActor.RunShim()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()