### PR TITLE
Implement similar fix to issue #225 (fixed in #388) for V1Decoder

### DIFF
--- a/src/NetMQ/Core/Transports/V1Decoder.cs
+++ b/src/NetMQ/Core/Transports/V1Decoder.cs
@@ -121,18 +121,19 @@ namespace NetMQ.Core.Transports
 
             //  8-byte payload length is read. Allocate the buffer
             // for message body and read the message data into it.
-            long payloadLength = m_tmpbuf.GetLong(Endian, 0);
+            ulong payloadLength = m_tmpbuf.GetUnsignedLong(Endian, 0);
 
             // There has to be at least one byte (the flags) in the message).
             if (payloadLength == 0)
                 return DecodeResult.Error;
 
             // Message size must not exceed the maximum allowed size.
-            if (m_maxMessageSize >= 0 && payloadLength - 1 > m_maxMessageSize)
+            if (m_maxMessageSize >= 0 && payloadLength - 1 > (ulong)m_maxMessageSize)
                 return DecodeResult.Error;
 
+            // TODO: move this constant to a good place (0x7FFFFFC7)
             // Message size must fit within range of size_t data type.
-            if (payloadLength - 1 > int.MaxValue)
+            if (payloadLength - 1 > 0x7FFFFFC7)
                 return DecodeResult.Error;
 
             int msgSize = (int)(payloadLength - 1);


### PR DESCRIPTION
We have seen a customer suffer a crash with the following stack trace

```
Description: The process was terminated due to an unhandled exception.
Exception Info: System.OverflowException
   at NetMQ.GCBufferPool.Take(Int32)
   at NetMQ.Msg.InitPool(Int32)
   at NetMQ.Core.Transports.V1Decoder.EightByteSizeReady()
   at NetMQ.Core.Transports.V1Decoder.Next()
   at NetMQ.Core.Transports.DecoderBase.Decode(NetMQ.Core.Transports.ByteArraySegment, Int32, Int32 ByRef)
   at NetMQ.Core.Transports.StreamEngine.ProcessInput()
   at NetMQ.Core.Transports.StreamEngine.Handle(Action, System.Net.Sockets.SocketError, Int32)
   at NetMQ.Core.Transports.StreamEngine.FeedAction(Action, System.Net.Sockets.SocketError, Int32)
   at NetMQ.Core.Transports.StreamEngine.InCompleted(System.Net.Sockets.SocketError, Int32)
   at NetMQ.Core.IOObject.InCompleted(System.Net.Sockets.SocketError, Int32)
   at NetMQ.Core.Utils.Proactor.Loop()
   at System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
   at System.Threading.ThreadHelper.ThreadStart()
```

This was on version 4.0.1.6.
The crash is in our application which has a RouterSocket bound to "tcp://127.0.0.1:9202"

I tracked down issues #225 and #388 and believe this is the same problem.
I have so far failed to reproduce the issue using NetMQ or python zmq, it isn't clear to me how to send a large enough message.

I can provoke the crash with some contrived python code
```
import socket
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
s.connect(("127.0.0.1", 9202))
s.send(b'\xFF' * 9 + b'\x00' + b'\x42' * 1000000)
```

Taking the fix from #388 and applying to V1Decoder.cs prevents the above python code crashing NetMQ.
There is a comment in that PR - "Other decoders/encoders are worth checking out too I guess." - I assume this never happened?

Let me know your thoughts