### PR TITLE
avoid NRE on disposed timers

### DIFF
--- a/src/NetMQ/Core/IOObject.cs
+++ b/src/NetMQ/Core/IOObject.cs
@@ -125,8 +125,7 @@ namespace NetMQ.Core
         /// <param name="id">an integer used to identify the timer</param>
         public virtual void TimerEvent(int id)
         {
-            Assumes.NotNull(m_handler);
-            m_handler.TimerEvent(id);
+            m_handler?.TimerEvent(id);
         }
 
         public void AddTimer(long timeout, int id)


### PR DESCRIPTION
It looks like that using HeartbeatTimers causes a race condition so that timers gets disposed before execution, when it happens the whole process crashes, this only mitigates the problem, I still do not understand why it's happening, but it looks like complicated to debug.