### PR TITLE
Remove System.ServiceModel.Primitives dependency.

### DIFF
--- a/src/NetMQ.Tests/BufferPoolTests.cs
+++ b/src/NetMQ.Tests/BufferPoolTests.cs
@@ -1,0 +1,64 @@
+using System;
+using Xunit;
+
+namespace NetMQ.Tests
+{
+    public abstract class BufferPoolTests
+    {
+        protected int maxBufferSize = 2;
+        protected long maxBufferPoolSize = 100L;
+        protected IBufferPool pool;
+        
+        [Theory]
+        [InlineData(500)]
+        [InlineData(50000)]
+        [InlineData(5000000)]
+        [InlineData(500000000)]
+        public void Rent(int size)
+        {
+            var array = pool.Take(size);
+            Assert.Equal(size, array.Length);
+        }
+        
+        // This never happens.
+        // [Fact]
+        // public void RentTooBigBuffer()
+        // {
+        //     Assert.ThrowsAny<Exception>(() => pool.Take(900000000));
+        // }
+
+        [Fact]
+        public void Return() {
+          var array = pool.Take(10);
+          pool.Return(array);
+        }
+
+        [Fact]
+        public void ReturnUnknown() {
+          var array = new byte[100];
+          Assert.Throws<ArgumentException>(() => pool.Return(array));
+        }
+    }
+
+    public class ArrayBufferPoolTests : BufferPoolTests
+    {
+        public ArrayBufferPoolTests()
+        {
+            /* The sizes were chosen to be very small. It's not clear they
+             * constitute any bounds on the array sizes that can be
+             * requested. */
+            pool = new ArrayBufferPool(maxBufferPoolSize, maxBufferSize);
+        }
+    }
+
+    public class BufferManagerBufferPoolTests : BufferPoolTests
+    {
+        public BufferManagerBufferPoolTests()
+        {
+            /* The sizes were chosen to be very small. It's not clear they
+             * constitute any bounds on the array sizes that can be
+             * requested. */
+            pool = new BufferManagerBufferPool(maxBufferPoolSize, maxBufferSize);
+        }
+    }
+}

--- a/src/NetMQ.Tests/BufferPoolTests.cs
+++ b/src/NetMQ.Tests/BufferPoolTests.cs
@@ -1,3 +1,6 @@
+// See BufferPool.cs for explanation of USE_SERVICE_MODEL define.
+
+// #define USE_SERVICE_MODEL
 using System;
 using Xunit;
 
@@ -8,7 +11,7 @@ namespace NetMQ.Tests
         protected int maxBufferSize = 2;
         protected long maxBufferPoolSize = 100L;
         protected IBufferPool pool;
-        
+
         [Theory]
         [InlineData(500)]
         [InlineData(50000)]
@@ -16,11 +19,15 @@ namespace NetMQ.Tests
         [InlineData(500000000)]
         public void Rent(int size)
         {
+            /* The pool sizes were chosen to be very small. It's clear they do
+             * not constitute any bounds on the array sizes that can be
+             * requested. BufferManagerBufferPool has the same behavior
+             * though. */
             var array = pool.Take(size);
             Assert.Equal(size, array.Length);
         }
         
-        // This never happens.
+        // I was not able to provoke this to happen. Maybe with a long.
         // [Fact]
         // public void RentTooBigBuffer()
         // {
@@ -29,14 +36,14 @@ namespace NetMQ.Tests
 
         [Fact]
         public void Return() {
-          var array = pool.Take(10);
-          pool.Return(array);
+            var array = pool.Take(10);
+            pool.Return(array);
         }
 
         [Fact]
         public void ReturnUnknown() {
-          var array = new byte[100];
-          Assert.Throws<ArgumentException>(() => pool.Return(array));
+            var array = new byte[100];
+            Assert.Throws<ArgumentException>(() => pool.Return(array));
         }
     }
 
@@ -44,21 +51,17 @@ namespace NetMQ.Tests
     {
         public ArrayBufferPoolTests()
         {
-            /* The sizes were chosen to be very small. It's not clear they
-             * constitute any bounds on the array sizes that can be
-             * requested. */
             pool = new ArrayBufferPool(maxBufferPoolSize, maxBufferSize);
         }
     }
 
+#if USE_SERVICE_MODEL
     public class BufferManagerBufferPoolTests : BufferPoolTests
     {
         public BufferManagerBufferPoolTests()
         {
-            /* The sizes were chosen to be very small. It's not clear they
-             * constitute any bounds on the array sizes that can be
-             * requested. */
             pool = new BufferManagerBufferPool(maxBufferPoolSize, maxBufferSize);
         }
     }
+#endif
 }

--- a/src/NetMQ.Tests/BufferPoolTests.cs
+++ b/src/NetMQ.Tests/BufferPoolTests.cs
@@ -10,7 +10,10 @@ namespace NetMQ.Tests
     {
         protected int maxBufferSize = 2;
         protected long maxBufferPoolSize = 100L;
+        // Silence the non-nullable warning.
+#pragma warning disable 8618
         protected IBufferPool pool;
+#pragma warning restore 8618
 
         [Theory]
         [InlineData(500)]

--- a/src/NetMQ/BufferPool.cs
+++ b/src/NetMQ/BufferPool.cs
@@ -1,5 +1,10 @@
+// USE_SERVICE_MODEL requires the System.ServiceModel.Primitives package.
+// It has been substituted by the System.Buffers package. This define remains
+// merely to be able to exercise tests against both IBufferPool implementations.
+
+// #define USE_SERVICE_MODEL
 using System;
-#if ! FLAVOR_MINIMAL
+#if USE_SERVICE_MODEL
 using System.ServiceModel.Channels;
 #endif
 using System.Collections.Generic;
@@ -102,7 +107,7 @@ namespace NetMQ
         }
     }
 
-#if ! FLAVOR_MINIMAL
+#if USE_SERVICE_MODEL
     /// <summary>
     /// This implementation of <see cref="IBufferPool"/> uses WCF's <see cref="BufferManager"/>
     /// class to manage a pool of buffers.
@@ -252,10 +257,10 @@ namespace NetMQ
         /// <exception cref="ArgumentOutOfRangeException">Either maxBufferPoolSize or maxBufferSize was less than zero.</exception>
         public static void SetBufferManagerBufferPool(long maxBufferPoolSize, int maxBufferSize)
         {
-#if FLAVOR_MINIMAL
-            SetCustomBufferPool(new ArrayBufferPool(maxBufferPoolSize, maxBufferSize));
-#else
+#if USE_SERVICE_MODEL
             SetCustomBufferPool(new BufferManagerBufferPool(maxBufferPoolSize, maxBufferSize));
+#else
+            SetCustomBufferPool(new ArrayBufferPool(maxBufferPoolSize, maxBufferSize));
 #endif
         }
 

--- a/src/NetMQ/BufferPool.cs
+++ b/src/NetMQ/BufferPool.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ServiceModel.Channels;
 using System.Threading;
+using System.Buffers;
 
 namespace NetMQ
 {    
@@ -24,6 +25,65 @@ namespace NetMQ
         void Return(byte[] buffer);
     }
 
+    public class ArrayBufferPool : IBufferPool
+    {
+        private readonly ArrayPool<byte> m_arrayPool;
+
+        /// <summary>
+        /// Create a new ArrayBufferPool with the specified maximum buffer pool size
+        /// and a maximum size for each individual buffer in the pool.
+        /// </summary>
+        /// <param name="maxBufferPoolSize">the maximum size to allow for the buffer pool</param>
+        /// <param name="maxBufferSize">the maximum size to allow for each individual buffer in the pool</param>
+        /// <exception cref="InsufficientMemoryException">There was insufficient memory to create the requested buffer pool.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Either maxBufferPoolSize or maxBufferSize was less than zero.</exception>
+        public ArrayBufferPool(long maxBufferPoolSize, int maxBufferSize)
+        {
+          m_arrayPool = ArrayPool<byte>.Create(maxBufferSize, (int) maxBufferPoolSize);
+        }
+
+        /// <summary>
+        /// Return a byte-array buffer of at least the specified size from the pool.
+        /// </summary>
+        /// <param name="size">the size in bytes of the requested buffer</param>
+        /// <returns>a byte-array that is the requested size</returns>
+        /// <exception cref="ArgumentOutOfRangeException">size cannot be less than zero</exception>
+        public byte[] Take(int size)
+        {
+            return m_arrayPool.Rent(size);
+        }
+
+        /// <summary>
+        /// Return the given buffer to this manager pool.
+        /// </summary>
+        /// <param name="buffer">a reference to the buffer being returned</param>
+        /// <exception cref="ArgumentException">the Length of buffer does not match the pool's buffer length property</exception>
+        /// <exception cref="ArgumentNullException">the buffer reference cannot be null</exception>
+        public void Return(byte[] buffer)
+        {
+            m_arrayPool.Return(buffer);
+        }
+
+        /// <summary>
+        /// Release the buffers currently cached in this manager.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Release the buffers currently cached in this manager.
+        /// </summary>
+        /// <param name="disposing">true if managed resources are to be disposed</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing)
+                return;
+            // We don't have a means of clearing ArrayPool like BufferManager does.
+        }
+    }
     /// <summary>
     /// This implementation of <see cref="IBufferPool"/> uses WCF's <see cref="BufferManager"/>
     /// class to manage a pool of buffers.

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -37,16 +37,15 @@
     <PackageReference Include="AsyncIO" Version="0.1.69" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NaCl.Net" Version="0.1.13" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" Condition="'$(Flavor)'!='Minimal'"/>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" Condition="'$(Flavor)'!='Minimal'"/>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -22,21 +22,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
-    <Flavor>Standard</Flavor>
-    <!-- Set flavor to minimal to exclude dependencies where possible. Found to
-         useful when building for use with Unity3D. Can change here in .csproj
-         or by using the following command argument when building:
-
-         $ dotnet build -p:Flavor=Minimal
-    -->
-    <!-- <Flavor>Minimal</Flavor> -->
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Flavor)'=='Minimal'">
-    <DefineConstants>$(DefineConstants);FLAVOR_MINIMAL</DefineConstants>
-  </PropertyGroup>
-  
   <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.1' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -22,6 +22,19 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <Flavor>Standard</Flavor>
+    <!-- Set flavor to minimal to exclude dependencies where possible. Found to
+         useful when building for use with Unity3D. Can change here in .csproj
+         or by using the following command argument when building:
+
+         $ dotnet build -p:Flavor=Minimal
+    -->
+    <!-- <Flavor>Minimal</Flavor> -->
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Flavor)'=='Minimal'">
+    <DefineConstants>$(DefineConstants);FLAVOR_MINIMAL</DefineConstants>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.1' ">
@@ -40,13 +53,13 @@
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" Condition="'$(Flavor)'!='Minimal'"/>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" Condition="'$(Flavor)'!='Minimal'"/>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
In an effort to use NetMQ with Unity3D, one problem was trying to 
satisfy the dependencies for `System.ServiceModel.Primitives`. It
required also providing `System.ServiceModel.{Http,Duplex,NetTcp}` and
perhaps more before I gave up. These dependencies were only noticed
while Unity3D built the project. When using NetMQ in a regular dotnet
project, I've had no problems with the `System.ServiceModel.Primitives`
dependencies.

I added an alternative implementation of `IBufferPool` using the
`ArrayPool` from `System.Buffers` but it is unused. I instrumented the
build system to have a "Flavor" that by default is set to "Standard",
which changes nothing from before.

For my usecase, however, I set the flavor to "Minimal".

    $ dotnet build -p:Flavor=Minimal

This excludes "System.ServiceModel.Primitives" and defines a
preprocessor flag of `FLAVOR_MINIMAL` that excludes the
BufferManagerBufferPool class and uses the ArrayBufferPool instead.