### PR TITLE
fix: fixed error System.OverflowException: Array dimensions exceeded supported range.

### DIFF
--- a/src/NetMQ/Core/Transports/V1Decoder.cs
+++ b/src/NetMQ/Core/Transports/V1Decoder.cs
@@ -124,7 +124,7 @@ namespace NetMQ.Core.Transports
             long payloadLength = m_tmpbuf.GetLong(Endian, 0);
 
             // There has to be at least one byte (the flags) in the message).
-            if (payloadLength == 0)
+            if (payloadLength <= 0)
                 return DecodeResult.Error;
 
             // Message size must not exceed the maximum allowed size.


### PR DESCRIPTION
Solution to resolve this error:

System.OverflowException: Array dimensions exceeded supported range.
   at NetMQ.GCBufferPool.Take(Int32 size)
   at NetMQ.Msg.InitPool(Int32 size)
   at NetMQ.Core.Transports.V1Decoder.EightByteSizeReady()
   at NetMQ.Core.Transports.DecoderBase.Decode(ByteArraySegment data, Int32 size, Int32& bytesUsed)
   at NetMQ.Core.Transports.StreamEngine.ProcessInput()
   at NetMQ.Core.Transports.StreamEngine.FeedAction(Action action, SocketError socketError, Int32 bytesTransferred)
   at NetMQ.Core.Utils.Proactor.Loop()