### PR TITLE
Fix issue where message is assumed to contain correct length byte (leading to process exit)

### DIFF
--- a/src/NetMQ.Tests/MechanismTests.cs
+++ b/src/NetMQ.Tests/MechanismTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Text;
+using NetMQ.Core.Mechanisms;
+using Xunit;
+
+namespace NetMQ.Tests
+{
+    public class MechanismTests
+    {
+        private Msg CreateMsg(string data, int lengthDiff)
+        {
+            Assert.NotNull(data);
+            Assert.True(data.Length > 1);
+            var length = data.Length + lengthDiff;
+            Assert.True(length > 0);
+            Assert.True(length < byte.MaxValue - 1);
+            
+            var msg = new Msg();
+            msg.InitGC(new byte[data.Length + 1], 0, data.Length + 1);
+            msg.SetFlags(MsgFlags.Command);
+            msg.Put((byte)length);
+            msg.Put(Encoding.ASCII, data, 1);
+            return msg;
+        }
+
+        [Fact]
+        public void IsCommandShouldReturnTrueForValidCommand()
+        {
+            var mechanism = new NullMechanism(null, null);
+            var msg = CreateMsg("READY", 0);
+            Assert.True(mechanism.IsCommand("READY", ref msg));
+        }
+
+        [Fact]
+        public void IsCommandShouldReturnFalseForInvalidCommand()
+        {
+            var mechanism = new NullMechanism(null, null);
+            var msg = CreateMsg("READY", -1);
+            Assert.False(mechanism.IsCommand("READY", ref msg));
+            msg = CreateMsg("READY", 1);
+            Assert.False(mechanism.IsCommand("READY", ref msg));
+            // this test case would fail due to an exception being throw (in 4.0.1.10 and prior)
+            msg = CreateMsg("READY", 2);
+            Assert.False(mechanism.IsCommand("READY", ref msg));
+        }
+
+        // this test was used to validate the behavior prior to changing the validation logic in Mechanism.IsCommand
+        // [Fact]
+        // public void IsCommandShouldThrowWhenLengthByteExceedsSize()
+        // {
+        //     var mechanism = new NullMechanism(null, null);
+        //     var msg = CreateMsg("READY", 2);
+        //     Assert.Throws<ArgumentOutOfRangeException>(() => mechanism.IsCommand("READY", ref msg));
+        // }        
+    }
+}

--- a/src/NetMQ.Tests/MechanismTests.cs
+++ b/src/NetMQ.Tests/MechanismTests.cs
@@ -25,7 +25,7 @@ namespace NetMQ.Tests
         [Fact]
         public void IsCommandShouldReturnTrueForValidCommand()
         {
-            var mechanism = new NullMechanism(null, null);
+            var mechanism = new NullMechanism(null!, null!);
             var msg = CreateMsg("READY", 0);
             Assert.True(mechanism.IsCommand("READY", ref msg));
         }
@@ -33,7 +33,7 @@ namespace NetMQ.Tests
         [Fact]
         public void IsCommandShouldReturnFalseForInvalidCommand()
         {
-            var mechanism = new NullMechanism(null, null);
+            var mechanism = new NullMechanism(null!, null!);
             var msg = CreateMsg("READY", -1);
             Assert.False(mechanism.IsCommand("READY", ref msg));
             msg = CreateMsg("READY", 1);

--- a/src/NetMQ/Core/Mechanisms/Mechanism.cs
+++ b/src/NetMQ/Core/Mechanisms/Mechanism.cs
@@ -348,7 +348,7 @@ namespace NetMQ.Core.Mechanisms
             return true;
         }
         
-        protected bool IsCommand(string command, ref Msg msg)
+        internal protected bool IsCommand(string command, ref Msg msg)
         {
             if (msg.Size >= command.Length + 1 && msg[0] == command.Length)
             {

--- a/src/NetMQ/Core/Mechanisms/Mechanism.cs
+++ b/src/NetMQ/Core/Mechanisms/Mechanism.cs
@@ -350,12 +350,10 @@ namespace NetMQ.Core.Mechanisms
         
         protected bool IsCommand(string command, ref Msg msg)
         {
-            if (msg.Size >= command.Length + 1)
+            if (msg.Size >= command.Length + 1 && msg[0] == command.Length)
             {
-                string msgCommand = msg.GetString(Encoding.ASCII, 1, msg[0]);
-                return msgCommand == command && msg[0] == command.Length;
+                return msg.GetString(Encoding.ASCII, 1, msg[0]) == command;
             }
-
             return false;
         }
     }

--- a/src/NetMQ/Core/Utils/Proactor.cs
+++ b/src/NetMQ/Core/Utils/Proactor.cs
@@ -86,7 +86,6 @@ namespace NetMQ.Core.Utils
             item.Cancelled = true;
         }
 
-        /// <exception cref="ArgumentOutOfRangeException">The completionStatuses item must have a valid OperationType.</exception>
         private void Loop()
         {
             var completions = new CompletionStatus[CompletionStatusArraySize];
@@ -132,12 +131,13 @@ namespace NetMQ.Core.Utils
                                             completion.BytesTransferred);
                                         break;
                                     default:
-                                        throw new ArgumentOutOfRangeException();
+                                        // invalid completion (this would previously throw an ArgumentOutOfRangeException, terminate the loop and exit the process)
+                                        break;
                                 }
                             }
                         }
                     }
-                    catch (TerminatingException)
+                    catch //(TerminatingException)
                     { }
                 }
             }

--- a/src/NetMQ/Core/Utils/Proactor.cs
+++ b/src/NetMQ/Core/Utils/Proactor.cs
@@ -86,6 +86,7 @@ namespace NetMQ.Core.Utils
             item.Cancelled = true;
         }
 
+        /// <exception cref="ArgumentOutOfRangeException">The completionStatuses item must have a valid OperationType.</exception>
         private void Loop()
         {
             var completions = new CompletionStatus[CompletionStatusArraySize];
@@ -131,13 +132,12 @@ namespace NetMQ.Core.Utils
                                             completion.BytesTransferred);
                                         break;
                                     default:
-                                        // invalid completion (this would previously throw an ArgumentOutOfRangeException, terminate the loop and exit the process)
-                                        break;
+                                        throw new ArgumentOutOfRangeException();
                                 }
                             }
                         }
                     }
-                    catch //(TerminatingException)
+                    catch (TerminatingException)
                     { }
                 }
             }


### PR DESCRIPTION
Fixes #1049

The original code only verified the length after calling GetString, but never gets there if the subsequent call to encoding.GetString fails with an ArgumentOutOfRangeException. This change moves the verification to before the call to GetString.

The second commit modifies the Proactor.Loop method so that it does not trigger a process exit due to an unhandled exception when an error occurs. To this end, it no longer throws an ArgumentOutOfRangeException if an invalid completion status is encountered (incidentally, this is the same error thrown by the GetString method for the earlier bug), and it catches all exceptions to allow the loop to continue in case of a failure.