### PR TITLE
Remove .NET Standard 1.6 conditional code

### DIFF
--- a/src/NetMQ/Core/MonitorEvent.cs
+++ b/src/NetMQ/Core/MonitorEvent.cs
@@ -20,11 +20,7 @@ namespace NetMQ.Core
 
         static MonitorEvent()
         {
-#if NETSTANDARD1_6
-            s_sizeOfIntPtr = Marshal.SizeOf<IntPtr>();
-#else
             s_sizeOfIntPtr = Marshal.SizeOf(typeof(IntPtr));
-#endif
 
             if (s_sizeOfIntPtr > 4)
                 s_sizeOfIntPtr = 8;

--- a/src/NetMQ/Core/Transports/Pgm/PgmSocket.cs
+++ b/src/NetMQ/Core/Transports/Pgm/PgmSocket.cs
@@ -95,19 +95,16 @@ namespace NetMQ.Core.Transports.Pgm
             {
                 string xMsg = $"SocketException with SocketErrorCode={x.SocketErrorCode}, Message={x.Message}, in PgmSocket.Init, within AsyncSocket.Create(AddressFamily.InterNetwork, SocketType.Rdm, PGM_PROTOCOL_TYPE), {this}";
                 Debug.WriteLine(xMsg);
-                // If running on Microsoft Windows, suggest to the developer that he may need to install MSMQ in order to get PGM socket support.
 
-#if NETSTANDARD1_6
+                // If running on Microsoft Windows, suggest to the developer that he may need to install MSMQ in order to get PGM socket support.
+#if NETSTANDARD1_1_OR_GREATER
                 bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #else
-                PlatformID p = Environment.OSVersion.Platform;
                 bool isWindows = true;
-                switch (p)
+                switch (Environment.OSVersion.Platform)
                 {
                     case PlatformID.Win32NT:
-                        break;
                     case PlatformID.Win32S:
-                        break;
                     case PlatformID.Win32Windows:
                         break;
                     default:
@@ -122,6 +119,7 @@ namespace NetMQ.Core.Transports.Pgm
                 throw new FaultException(innerException: x, message: xMsg);
             }
 #endif
+
             Handle.ExclusiveAddressUse = false;
             Handle.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
         }

--- a/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpAddress.cs
@@ -102,11 +102,7 @@ namespace NetMQ.Core.Transports.Tcp
             }
             else if (!IPAddress.TryParse(addrStr, out ipAddress))
             {
-#if NETSTANDARD1_6
-                var availableAddresses = Dns.GetHostEntryAsync(addrStr).Result.AddressList;
-#else
                 var availableAddresses = Dns.GetHostEntry(addrStr).AddressList;
-#endif
 
                 ipAddress = ip4Only
                     ? availableAddresses.FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork)

--- a/src/NetMQ/Core/Utils/Clock.cs
+++ b/src/NetMQ/Core/Utils/Clock.cs
@@ -39,16 +39,13 @@ namespace NetMQ.Core.Utils
         /// </summary>
         private static long s_lastTime;
 
-#if !NETSTANDARD1_6
         /// <summary>
         /// This flag indicates whether the rdtsc instruction is supported on this platform.
         /// </summary>
         private static readonly bool s_rdtscSupported;
-#endif
 
         static Clock()
         {
-#if !NETSTANDARD1_6
             try
             {
                 if (Environment.OSVersion.Platform == PlatformID.Win32NT ||
@@ -66,7 +63,6 @@ namespace NetMQ.Core.Utils
             {
                 s_rdtscSupported = false;
             }
-#endif
         }
 
         /// <summary>
@@ -109,11 +105,7 @@ namespace NetMQ.Core.Utils
         /// </summary>
         public static long Rdtsc()
         {
-#if NETSTANDARD1_6
-            return 0;
-#else
             return s_rdtscSupported ? (long?)Opcode.Rdtsc?.Invoke() ?? 0 : 0;
-#endif
         }
     }
 }

--- a/src/NetMQ/Core/Utils/OpCode.cs
+++ b/src/NetMQ/Core/Utils/OpCode.cs
@@ -1,5 +1,4 @@
-﻿#if !NETSTANDARD1_6
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -174,4 +173,3 @@ namespace NetMQ.Core.Utils
         }
     }
 }
-#endif

--- a/src/NetMQ/Core/Utils/PollerBase.cs
+++ b/src/NetMQ/Core/Utils/PollerBase.cs
@@ -86,12 +86,8 @@ namespace NetMQ.Core.Utils
         {
             get
             {
-#if NETSTANDARD1_6
-                return Volatile.Read(ref m_load);
-#else
                 Thread.MemoryBarrier();
                 return m_load;
-#endif
             }
         }
 

--- a/src/NetMQ/NetMQBeacon.cs
+++ b/src/NetMQ/NetMQBeacon.cs
@@ -360,11 +360,7 @@ namespace NetMQ
 
                 try
                 {
-#if NETSTANDARD1_6
-                    return m_hostName = Dns.GetHostEntryAsync(boundTo).Result.HostName;
-#else
                     return m_hostName = Dns.GetHostEntry(boundTo).HostName;
-#endif
                 }
                 catch
                 {

--- a/src/NetMQ/NetMQException.cs
+++ b/src/NetMQ/NetMQException.cs
@@ -1,11 +1,7 @@
 using System;
 using System.Net.Sockets;
 using System.Runtime.Serialization;
-
-#if !NETSTANDARD1_6
 using System.Security.Permissions;
-#endif
-
 using NetMQ.Core;
 
 namespace NetMQ
@@ -13,9 +9,7 @@ namespace NetMQ
     /// <summary>
     /// Base class for custom exceptions within the NetMQ library.
     /// </summary>
-#if !NETSTANDARD1_6
     [Serializable]
-#endif
     public class NetMQException : Exception
     {
         /// <summary>
@@ -50,8 +44,6 @@ namespace NetMQ
             : base(message, innerException)
         {}
 
-#if !NETSTANDARD1_6
-
         /// <summary>Constructor for serialisation.</summary>
         protected NetMQException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -66,8 +58,6 @@ namespace NetMQ
             info.AddValue("ErrorCode", ErrorCode);
             base.GetObjectData(info, context);
         }
-
-#endif
 
         #endregion
 
@@ -182,9 +172,7 @@ namespace NetMQ
     /// <summary>
     /// AddressAlreadyInUseException is a NetMQException that is used within SocketBase.Bind to signal an address-conflict.
     /// </summary>
-#if !NETSTANDARD1_6
     [Serializable]
-#endif
     public class AddressAlreadyInUseException : NetMQException
     {
         /// <summary>
@@ -206,21 +194,17 @@ namespace NetMQ
         {
         }
 
-#if !NETSTANDARD1_6
         /// <summary>Constructor for serialisation.</summary>
         protected AddressAlreadyInUseException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
     /// EndpointNotFoundException is a NetMQException that is used within Ctx.FindEndpoint to signal a failure to find a specified address.
     /// </summary>
-#if !NETSTANDARD1_6
     [Serializable]
-#endif
     public class EndpointNotFoundException : NetMQException
     {
         /// <summary>
@@ -250,22 +234,18 @@ namespace NetMQ
         {
         }
 
-#if !NETSTANDARD1_6
         /// <summary>Constructor for serialisation.</summary>
         protected EndpointNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
     /// TerminatingException is a NetMQException that is used within SocketBase and Ctx to signal
     /// that you're making the mistake of trying to do further work after terminating the message-queueing system.
     /// </summary>
-#if !NETSTANDARD1_6
     [Serializable]
-#endif
     public class TerminatingException : NetMQException
     {
         /// <summary>
@@ -294,21 +274,18 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_6
+
         /// <summary>Constructor for serialisation.</summary>
         protected TerminatingException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
     /// InvalidException is a NetMQException that is used within the message-queueing system to signal invalid value errors.
     /// </summary>
-#if !NETSTANDARD1_6
     [Serializable]
-#endif
     public class InvalidException : NetMQException
     {
         /// <summary>
@@ -337,21 +314,18 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_6
+
         /// <summary>Constructor for serialisation.</summary>
         protected InvalidException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
     /// FaultException is a NetMQException that is used within the message-queueing system to signal general fault conditions.
     /// </summary>
-#if !NETSTANDARD1_6
     [Serializable]
-#endif
     public class FaultException : NetMQException
     {
         /// <summary>
@@ -380,22 +354,19 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_6
+
         /// <summary>Constructor for serialisation.</summary>
         protected FaultException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
     /// ProtocolNotSupportedException is a NetMQException that is used within the message-queueing system to signal
     /// mistakes in properly utilizing the communications protocols.
     /// </summary>
-#if !NETSTANDARD1_6
     [Serializable]
-#endif
     public class ProtocolNotSupportedException : NetMQException
     {
         /// <summary>
@@ -424,22 +395,19 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_6
+
         /// <summary>Constructor for serialisation.</summary>
         protected ProtocolNotSupportedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
     /// HostUnreachableException is an Exception that is used within the message-queueing system
     /// to signal failures to communicate with a host.
     /// </summary>
-#if !NETSTANDARD1_6
     [Serializable]
-#endif
     public class HostUnreachableException : NetMQException
     {
         /// <summary>
@@ -468,22 +436,19 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_6
+
         /// <summary>Constructor for serialisation.</summary>
         protected HostUnreachableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 
     /// <summary>
     /// FiniteStateMachineException is an Exception that is used within the message-queueing system
     /// to signal errors in the send/receive order with request/response sockets.
     /// </summary>
-#if !NETSTANDARD1_6
     [Serializable]
-#endif
     public class FiniteStateMachineException : NetMQException
     {
         /// <summary>
@@ -512,12 +477,11 @@ namespace NetMQ
             : this(null, null)
         {
         }
-#if !NETSTANDARD1_6
+
         /// <summary>Constructor for serialisation.</summary>
         protected FiniteStateMachineException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }


### PR DESCRIPTION
.NET Standard 1.6 support was removed in NetMQ 4.0.1.

* Remove unused conditional code for .NET Standard 1.6
* Keep `RuntimeInformation.IsOSPlatform` usage that only ran on .NET Standard 1.6 target