### PR TITLE
Avoid reading time stamp counter

### DIFF
--- a/src/NetMQ/Core/Utils/OpCode.cs
+++ b/src/NetMQ/Core/Utils/OpCode.cs
@@ -11,6 +11,8 @@ namespace NetMQ.Core.Utils
 
         public static bool Open()
         {
+            if (SocketOptions.DoNotUseRDTSC)
+                return false;
 #if NETSTANDARD1_1_OR_GREATER || NET471_OR_GREATER
             if (RuntimeInformation.ProcessArchitecture != Architecture.X86 &&
                 RuntimeInformation.ProcessArchitecture != Architecture.X64)

--- a/src/NetMQ/Core/Utils/OpCode.cs
+++ b/src/NetMQ/Core/Utils/OpCode.cs
@@ -11,7 +11,7 @@ namespace NetMQ.Core.Utils
 
         public static bool Open()
         {
-            //Look for an environment variable: "NETQM_SUPPRESS_RDTSC" with any value
+            // Look for an environment variable: "NETQM_SUPPRESS_RDTSC" with any value.
             // The application can set this environment variable when this code is running in a system where
             // it is not desirable to read the processor's time stamp counter.
             // While this is supported in modern CPUs, the technique used for allocating executable memory, copying OP Code

--- a/src/NetMQ/Core/Utils/OpCode.cs
+++ b/src/NetMQ/Core/Utils/OpCode.cs
@@ -11,13 +11,14 @@ namespace NetMQ.Core.Utils
 
         public static bool Open()
         {
-            //Look for an environment variable: "NETQM_SUPPRESS_RDTSC" with a value of "TRUE"
+            //Look for an environment variable: "NETQM_SUPPRESS_RDTSC" with any value
             // The application can set this environment variable when this code is running in a system where
             // it is not desirable to read the processor's time stamp counter.
             // While this is supported in modern CPUs, the technique used for allocating executable memory, copying OP Code
             // for the read of the time stamp and invoking the OP Code can be detected as Malware by some anti-virus vendors.
-            var val = Environment.GetEnvironmentVariable("NETQM_SUPPRESS_RDTSC");
-            if ("TRUE".Equals(val, StringComparison.OrdinalIgnoreCase))
+            // https://github.com/zeromq/netmq/issues/1071
+            string val = Environment.GetEnvironmentVariable("NETQM_SUPPRESS_RDTSC");
+            if (!string.IsNullOrEmpty(val))
                 return false;
 #if NETSTANDARD1_1_OR_GREATER || NET471_OR_GREATER
             if (RuntimeInformation.ProcessArchitecture != Architecture.X86 &&

--- a/src/NetMQ/Core/Utils/OpCode.cs
+++ b/src/NetMQ/Core/Utils/OpCode.cs
@@ -11,7 +11,13 @@ namespace NetMQ.Core.Utils
 
         public static bool Open()
         {
-            if (SocketOptions.DoNotUseRDTSC)
+            //Look for an environment variable: "NETQM_SUPPRESS_RDTSC" with a value of "TRUE"
+            // The application can set this environment variable when this code is running in a system where
+            // it is not desirable to read the processor's time stamp counter.
+            // While this is supported in modern CPUs, the technique used for allocating executable memory, copying OP Code
+            // for the read of the time stamp and invoking the OP Code can be detected as Malware by some anti-virus vendors.
+            var val = Environment.GetEnvironmentVariable("NETQM_SUPPRESS_RDTSC");
+            if ("TRUE".Equals(val, StringComparison.OrdinalIgnoreCase))
                 return false;
 #if NETSTANDARD1_1_OR_GREATER || NET471_OR_GREATER
             if (RuntimeInformation.ProcessArchitecture != Architecture.X86 &&

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -13,6 +13,16 @@ namespace NetMQ
     public class SocketOptions
     {
         /// <summary>
+        /// If set, the time stamp counter is not read directly through opcode injection,
+        /// rather <see cref="System.Diagnostics.Stopwatch.GetTimestamp"/> is used.
+        /// When false, the time stamp counter is read by allocating a few bytes on the heap with
+        /// read/write/execute privilege. OpCode is copied to this allocated memory and invoked to read
+        /// the time stamp counter, (which is a register available on most modern CPUs). While this is
+        /// an accurate way to read the time stamp counter, because it injects code onto the heap, this
+        /// can be detected as a malware technique by some anti-virus defenders.
+        /// </summary>
+        public static bool DoNotUseRDTSC;
+        /// <summary>
         /// The NetMQSocket that this SocketOptions is referencing.
         /// </summary>
         private readonly NetMQSocket m_socket;

--- a/src/NetMQ/SocketOptions.cs
+++ b/src/NetMQ/SocketOptions.cs
@@ -13,16 +13,6 @@ namespace NetMQ
     public class SocketOptions
     {
         /// <summary>
-        /// If set, the time stamp counter is not read directly through opcode injection,
-        /// rather <see cref="System.Diagnostics.Stopwatch.GetTimestamp"/> is used.
-        /// When false, the time stamp counter is read by allocating a few bytes on the heap with
-        /// read/write/execute privilege. OpCode is copied to this allocated memory and invoked to read
-        /// the time stamp counter, (which is a register available on most modern CPUs). While this is
-        /// an accurate way to read the time stamp counter, because it injects code onto the heap, this
-        /// can be detected as a malware technique by some anti-virus defenders.
-        /// </summary>
-        public static bool DoNotUseRDTSC;
-        /// <summary>
         /// The NetMQSocket that this SocketOptions is referencing.
         /// </summary>
         private readonly NetMQSocket m_socket;


### PR DESCRIPTION
The implementations using an environment variable rather than a static flag on an unrelated class.

Fixes #1071