### PR TITLE
Try catch for blocking recieve which can throw

### DIFF
--- a/src/NetMQ/Core/Mailbox.cs
+++ b/src/NetMQ/Core/Mailbox.cs
@@ -19,6 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System;
 using System.Diagnostics;
 using System.Net.Sockets;
 using NetMQ.Core.Utils;
@@ -208,8 +209,17 @@ namespace NetMQ.Core
                     return true;
 
                 // If there are no more commands available, switch into passive state.
-                m_active = false;
-                m_signaler.Recv();
+                try
+                {
+                    m_active = false;
+                    m_signaler.Recv();
+                }
+                catch
+                {
+                    m_active = true;
+                    command = default(Command);
+                    return false;
+                }
             }
 
             // Wait for signal from the command sender.


### PR DESCRIPTION
If DNS is not accessible we get the poller throwing:

```
Unhandled exception. System.Net.Sockets.SocketException (11): Resource temporarily unavailable
   at System.Net.Sockets.Socket.Receive(Byte[] buffer)
   at NetMQ.Core.Utils.Signaler.Recv()
   at NetMQ.Core.Mailbox.TryRecv(Int32 timeout, Command& command)
   at NetMQ.Core.SocketBase.ProcessCommands(Int32 timeout, Boolean throttle, CancellationToken cancellationToken)
   at NetMQ.Core.SocketBase.GetSocketOption(ZmqSocketOption option)
   at NetMQ.NetMQSelector.Select(Item[] items, Int32 itemsCount, Int64 timeout)
   at NetMQ.NetMQPoller.RunPoller()
   at NetMQ.NetMQPoller.Run(SynchronizationContext syncContext)
   at NetMQ.NetMQPoller.Run()
   at System.Threading.Thread.StartCallback()
```