### PR TITLE
Fix Division by Zero in FairQueueing when m_active is 0

### DIFF
--- a/src/NetMQ/Core/Patterns/Utils/FairQueueing.cs
+++ b/src/NetMQ/Core/Patterns/Utils/FairQueueing.cs
@@ -122,7 +122,7 @@ namespace NetMQ.Core.Patterns.Utils
 
                     m_more = msg.HasMore;
                     if (!m_more)
-                        m_current = (m_current + 1) % m_active;
+                        m_current = m_active > 0 ? (m_current + 1) % m_active : 0;
                     return true;
                 }
 


### PR DESCRIPTION
### Problem

As detailed in issue [#1088](https://github.com/zeromq/netmq/issues/1088), the `FairQueueing` class in NetMQ is prone to a `DivideByZeroException` when all inbound pipes are deactivated and `m_active` becomes zero. This issue occurs during the round-robin selection process in the `RecvPipe` method.

### Solution

This pull request implements a conditional check to ensure that the modulo operation for round-robin scheduling is only performed when there is at least one active pipe (`m_active > 0`). This change prevents the system from attempting a division by zero, which can lead to an application crash under specific scenarios.

### Changes Made

- Modified the round-robin index update line in `RecvPipe` method to:
  ```csharp
  if (!m_more)
      m_current = m_active > 0 ? (m_current + 1) % m_active : 0;