### PR TITLE
Mitigating a FaultException in Mechanism.Encode.

### DIFF
--- a/src/NetMQ/Core/SessionBase.cs
+++ b/src/NetMQ/Core/SessionBase.cs
@@ -217,7 +217,7 @@ namespace NetMQ.Core
         /// <returns>true if the Msg is successfully sent</returns>
         public virtual PullMsgResult PullMsg(ref Msg msg)
         {
-            if (m_pipe == null || !m_pipe.Read(ref msg))
+            if (m_pipe == null || !m_pipe.Read(ref msg) || !msg.IsInitialised)
                 return PullMsgResult.Empty;
             m_incompleteIn = msg.HasMore;
 


### PR DESCRIPTION
On some circumstances Msg class throws NetMQ.FaultException in Mechanism.Encode method. The details are in https://github.com/zeromq/netmq/issues/1094

closes #1094