### PR TITLE
Use a stable hash function for computing IPC port

### DIFF
--- a/src/NetMQ/Core/Transports/Ipc/IpcAddress.cs
+++ b/src/NetMQ/Core/Transports/Ipc/IpcAddress.cs
@@ -39,7 +39,7 @@ namespace NetMQ.Core.Transports.Ipc
         {
             m_name = name;
 
-            int hash = name.GetHashCode();
+            int hash = Strings.GetStableHashCode(name);
             if (hash < 0)
                 hash = -hash;
             hash = hash%55536;

--- a/src/NetMQ/Utils/Strings.cs
+++ b/src/NetMQ/Utils/Strings.cs
@@ -9,5 +9,42 @@ namespace NetMQ
 
         /// <inheritdoc cref="string.IsNullOrWhiteSpace(string)"/>
         public static bool IsNullOrWhiteSpace([NotNullWhen(returnValue: false)] string? s) => string.IsNullOrWhiteSpace(s);
+
+        /// <summary>
+        /// Gets a hash value from a string. This hash is stable across process invocations (doesn't use hash randomization) and across different .NET versions and platforms.
+        /// </summary>
+        /// <remarks>
+        /// The original code was taken from <c>string.GetHashCode()</c> with some minor changes
+        /// https://github.com/microsoft/referencesource/blob/master/mscorlib/system/string.cs
+        /// </remarks>
+        public static int GetStableHashCode(string str)
+        {
+            int hash1 = 5381;
+            int hash2 = hash1;
+
+            int i = 0;
+
+            while (i < str.Length)
+            {
+                char c = str[i];
+
+                hash1 = ((hash1 << 5) + hash1) ^ c;
+
+                i++;
+
+                if (i == str.Length)
+                {
+                    break;
+                }
+
+                c = str[i];
+
+                hash2 = ((hash2 << 5) + hash2) ^ c;
+
+                i++;
+            }
+
+            return hash1 + (hash2 * 1566083941);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1080

The previous code used String.GetHashCode, however in .NET 5 and later this value is not stable across process runs. The value intentionally varies due to "hash randomization", a security feature.

In this case, we need a stable value, and we need the same value irrespective of the version of .NET or the platform.

To ensure compatibility, we take the algorithm from .NET Framework.