### PR TITLE
Remove macOS Socket.Select workaround that caused Cleanup() to hang

### DIFF
--- a/src/NetMQ/Core/Utils/Poller.cs
+++ b/src/NetMQ/Core/Utils/Poller.cs
@@ -23,9 +23,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
-#if !NETFRAMEWORK
-using System.Runtime.InteropServices;
-#endif
 using System.Threading;
 
 namespace NetMQ.Core.Utils
@@ -281,22 +278,7 @@ namespace NetMQ.Core.Utils
                 try
                 {
                     timeout = timeout != 0 ? timeout * 1000 : -1;
-#if NETFRAMEWORK
                     Socket.Select(readList, null, errorList, timeout);
-#else
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                    {
-                        // Socket.Select does not work properly on macOS .NET Core when readList and errorList are passed
-                        // together. To avoid this problem, we call the Select function separately for errorList.
-                        // Please refer to this issue: https://github.com/dotnet/corefx/issues/39617
-                        SocketUtility.Select(readList, null, null, timeout);
-                        SocketUtility.Select(null, null, errorList, timeout);
-                    }
-                    else
-                    {
-                        Socket.Select(readList, null, errorList, timeout);
-                    }
-#endif
                 }
                 catch (SocketException)
                 {


### PR DESCRIPTION
## Summary

- Removes the macOS-specific `Socket.Select` workaround in `Poller.cs` that split the call into two separate invocations (one for `readList`, one for `errorList`)
- The second call blocked forever with infinite timeout, preventing the Reaper from processing `Stop` commands, causing `Cleanup()` to hang indefinitely
- The underlying .NET runtime bug ([dotnet/corefx#39617](https://github.com/dotnet/corefx/issues/39617)) was reported in 2019 and fixed in .NET 9 (2024), but the `Cleanup` hang indicates the workaround never worked as intended

See [#1040 (comment)](https://github.com/zeromq/netmq/issues/1040#issuecomment-4124131686) for a detailed root cause analysis.

Fixes #1040

## Test plan

- [x] Verified build succeeds on all target frameworks (`net8.0`, `net472`, `netstandard2.1`)
- [x] Verified on macOS (Apple Silicon) with .NET 10 that `Cleanup(block: false)` no longer hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)