### PR TITLE
Upgrade net8.0 -> net10.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,30 +1,29 @@
 name: CI
 on: [push, pull_request]
-
 jobs:
   ununtu:
     runs-on: ubuntu-latest
     env:
       DOTNET_NOLOGO: true
     steps:
-    - uses: actions/checkout@v4.2.2
-    - uses: actions/setup-dotnet@v4.1.0
+    - uses: actions/checkout@v6
+    - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - run: dotnet restore src/NetMQ.sln
     - name: build 
       run: dotnet build src/NetMQ.sln /p:Configuration=Release /verbosity:minimal
-    - name: test net9.0
-      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net9.0 src/NetMQ.Tests/NetMQ.Tests.csproj
+    - name: test net10.0
+      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net10.0 src/NetMQ.Tests/NetMQ.Tests.csproj
   windows:
     runs-on: windows-latest
     env:
       DOTNET_NOLOGO: true
     steps:
-    - uses: actions/checkout@v4.2.2
-    - uses: actions/setup-dotnet@v4.1.0
+    - uses: actions/checkout@v6
+    - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - name: Install codecov
       run: |
         choco install opencover.portable 
@@ -32,11 +31,11 @@ jobs:
     - run: dotnet restore src/NetMQ.sln
     - name: build 
       run: dotnet build src/NetMQ.sln /p:Configuration=Release /verbosity:minimal
-    - name: test net9.0
-      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net9.0 src\NetMQ.Tests\NetMQ.Tests.csproj
+    - name: test net10.0
+      run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net10.0 src\NetMQ.Tests\NetMQ.Tests.csproj
     - name: test net472
       run: dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net472 src\NetMQ.Tests\NetMQ.Tests.csproj
     - name: coverage
       run: |
-        OpenCover.Console.exe -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test --no-build --configuration Release -f net6.0 --logger:trx;LogFileName=results.trx /p:DebugType=full src\NetMQ.Tests\NetMQ.Tests.csproj" -filter:"+[NetMQ*]* -[NetMQ.Tests*]*" -output:".\NetMQ_coverage.xml" -oldStyle
+        OpenCover.Console.exe -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test --no-build --configuration Release -f net10.0 --logger:trx;LogFileName=results.trx /p:DebugType=full src\NetMQ.Tests\NetMQ.Tests.csproj" -filter:"+[NetMQ*]* -[NetMQ.Tests*]*" -output:".\NetMQ_coverage.xml" -oldStyle
         codecov -f "NetMQ_coverage.xml"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,18 @@
 version: 4.0.0.{build}
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2026
 configuration: Release
-
 before_build:
   - choco install opencover.portable
   - choco install codecov
-
 build_script:
   - dotnet restore src/NetMQ.sln
   - dotnet build src/NetMQ.sln /p:Configuration=Release /p:PackageVersion=%APPVEYOR_BUILD_VERSION%-pre /p:Version=%APPVEYOR_BUILD_VERSION% /p:ContinuousIntegrationBuild=true /verbosity:minimal
   - dotnet pack src/NetMQ/NetMQ.csproj -c Release --no-build /p:PackageVersion=%APPVEYOR_BUILD_VERSION%-pre /p:Version=%APPVEYOR_BUILD_VERSION%
-
 test_script:
-  - dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f netcoreapp2.1 src\NetMQ.Tests\NetMQ.Tests.csproj
-  - dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net47 src\NetMQ.Tests\NetMQ.Tests.csproj
-  - OpenCover.Console.exe -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test --no-build --configuration Release -f netcoreapp2.1 --logger:trx;LogFileName=results.trx /p:DebugType=full src\NetMQ.Tests\NetMQ.Tests.csproj" -filter:"+[NetMQ*]* -[NetMQ.Tests*]*" -output:".\NetMQ_coverage.xml" -oldStyle
+  - dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net10.0 src\NetMQ.Tests\NetMQ.Tests.csproj
+  - dotnet test -v n -p:ParallelizeTestCollections=false --configuration Release --no-build -f net472 src\NetMQ.Tests\NetMQ.Tests.csproj
+  - OpenCover.Console.exe -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test --no-build --configuration Release -f net10.0 --logger:trx;LogFileName=results.trx /p:DebugType=full src\NetMQ.Tests\NetMQ.Tests.csproj" -filter:"+[NetMQ*]* -[NetMQ.Tests*]*" -output:".\NetMQ_coverage.xml" -oldStyle
   - codecov -f "NetMQ_coverage.xml"
-
 artifacts:
   - path: '**\*.nupkg'

--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -7,7 +7,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>net9.0;net472</TargetFrameworks>
+    <TargetFrameworks>net10.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -39,11 +39,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -54,8 +54,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 
 </Project>

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A 100% native C# port of the lightweight high performance messaging library ZeroMQ</Description>
     <Version>4.0.0.0</Version>
-    <TargetFrameworks>net8.0;net472;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net472;netstandard2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyOriginatorKeyFile>./NetMQ.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -39,13 +39,13 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 </Project>

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
     <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">

--- a/src/Performance/NetMQ.SimpleTests/NetMQ.SimpleTests.csproj
+++ b/src/Performance/NetMQ.SimpleTests/NetMQ.SimpleTests.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 
 </Project>

--- a/src/Performance/local_lat/local_lat.csproj
+++ b/src/Performance/local_lat/local_lat.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 
 </Project>

--- a/src/Performance/local_thr/local_thr.csproj
+++ b/src/Performance/local_thr/local_thr.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 
 </Project>

--- a/src/Performance/remote_lat/remote_lat.csproj
+++ b/src/Performance/remote_lat/remote_lat.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 
 </Project>

--- a/src/Performance/remote_thr/remote_thr.csproj
+++ b/src/Performance/remote_thr/remote_thr.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I think there is no reason to support net8.0 anymore, since the upgrade is trivial and the support is running out. There are still older NetMQ Packages for net8.0 available.