### PR TITLE
Prevent duplicate CI runs on pull requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 jobs:
   ununtu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Scope push trigger to master branch only, so PRs no longer trigger both push and pull_request workflows simultaneously.