### PR TITLE
Fix ARM architecture detection for aarch64

### DIFF
--- a/src/NetMQ/Core/Utils/OpCode.cs
+++ b/src/NetMQ/Core/Utils/OpCode.cs
@@ -95,7 +95,7 @@ namespace NetMQ.Core.Utils
 
             var currentValues = parameters[0];
             var machineValue = (string)(utsname!.GetField("machine")?.GetValue(currentValues) ?? "unknown");
-            return machineValue.ToLower().Contains("arm");
+            return machineValue.ToLower().Contains("arm") || machineValue.ToLower().Contains("aarch");
         }
 
         public static void Close()


### PR DESCRIPTION
Add detection for "aarch" prefix to support modern 64-bit ARM architectures.

The IsARMArchitecture() method only checked for "arm" in the machine value, which failed to detect aarch64 (ARM 64-bit) architectures. This caused NetMQ to attempt using x86/x64 RDTSC instruction on ARM systems, resulting in crashes.

After Ubuntu upgrade from 16.04 (armv7l) to 24.04 (aarch64) on Raspberry Pi, the detection failed and NetMQ crashed with IllegalInstructionException.

Fix checks for both "arm" and "aarch" prefixes, supporting:
- Legacy 32-bit ARM: armv6l, armv7l, armhf (still works)
- Modern 64-bit ARM: aarch64, aarch32 (now works)

Tested with 12 unit tests covering all ARM variants and non-ARM architectures.

Fixes #1116