### PR TITLE
Complete the nullable annotations

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NetMQ.Tests/CleanupAfterFixture.cs
+++ b/src/NetMQ.Tests/CleanupAfterFixture.cs
@@ -1,9 +1,7 @@
 using System;
-using JetBrains.Annotations;
 
 namespace NetMQ.Tests
 {
-    [UsedImplicitly]
     public sealed class CleanupAfterFixture : IDisposable
     {
         public void Dispose() => NetMQConfig.Cleanup();

--- a/src/NetMQ.Tests/NetMQ.Tests.csproj
+++ b/src/NetMQ.Tests/NetMQ.Tests.csproj
@@ -54,7 +54,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 

--- a/src/NetMQ/Annotations.cs
+++ b/src/NetMQ/Annotations.cs
@@ -88,3 +88,55 @@ namespace System.Diagnostics.CodeAnalysis
 }
 
 #endif
+
+#if !NET5_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">The field or property member that is promised to be not-null.</param>
+        public MemberNotNullAttribute(string member) => Members = [member];
+
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">The list of field and property members that are promised to be not-null.</param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter will not be null.</param>
+        /// <param name="member">The field or property member that is promised to be not-null.</param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = [member];
+        }
+
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter will not be null.</param>
+        /// <param name="members">The list of field and property members that are promised to be not-null.</param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+}
+
+#endif

--- a/src/NetMQ/Core/Ctx.cs
+++ b/src/NetMQ/Core/Ctx.cs
@@ -19,8 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -105,7 +103,7 @@ namespace NetMQ.Core
         /// <summary>
         /// The reaper thread.
         /// </summary>
-        private Reaper m_reaper;
+        private Reaper? m_reaper;
 
         /// <summary>
         /// List of I/O threads.
@@ -120,7 +118,7 @@ namespace NetMQ.Core
         /// <summary>
         /// Array of pointers to mailboxes for both application and I/O threads.
         /// </summary>
-        private IMailbox[] m_slots;
+        private IMailbox?[]? m_slots;
 
         /// <summary>
         /// Mailbox for zmq_term thread.
@@ -198,9 +196,9 @@ namespace NetMQ.Core
                             socket.Stop();
 
                         if (!block)
-                            m_reaper.ForceStop();
+                            m_reaper!.ForceStop();
                         else if (m_sockets.Count == 0)
-                            m_reaper.Stop();
+                            m_reaper!.Stop();
                     }
                     finally
                     {
@@ -338,7 +336,7 @@ namespace NetMQ.Core
                 SocketBase s = SocketBase.Create(type, this, slot, socketId);
 
                 m_sockets.Add(s);
-                m_slots[slot] = s.Mailbox;
+                m_slots![slot] = s.Mailbox;
 
                 //LOG.debug("NEW Slot [" + slot + "] " + s);
 
@@ -361,7 +359,7 @@ namespace NetMQ.Core
             {
                 int threadId = socket.ThreadId;
                 m_emptySlots.Push(threadId);
-                m_slots[threadId].Close();
+                m_slots![threadId]!.Close();
                 m_slots[threadId] = null;
 
                 // Remove the socket from the list of sockets.
@@ -370,7 +368,7 @@ namespace NetMQ.Core
                 // If zmq_term() was already called and there are no more socket
                 // we can ask reaper thread to terminate.
                 if (m_terminating && m_sockets.Count == 0)
-                    m_reaper.Stop();
+                    m_reaper!.Stop();
             }
 
             //LOG.debug("Released Slot [" + socket_ + "] ");
@@ -381,7 +379,7 @@ namespace NetMQ.Core
         /// </summary>
         public ZObject GetReaper()
         {
-            return m_reaper;
+            return m_reaper!;
         }
 
         /// <summary>
@@ -389,7 +387,7 @@ namespace NetMQ.Core
         /// </summary>
         public void SendCommand(int threadId, Command command)
         {
-            m_slots[threadId].Send(command);
+            m_slots![threadId]!.Send(command);
         }
 
         /// <summary>
@@ -397,14 +395,14 @@ namespace NetMQ.Core
         /// </summary>
         /// <paramref name="affinity">Which threads are eligible (0 = all).</paramref>
         /// <returns>The least busy thread, or <c>null</c> if none is available.</returns>
-        public IOThread ChooseIOThread(long affinity)
+        public IOThread? ChooseIOThread(long affinity)
         {
             if (m_ioThreads.Count == 0)
                 return null;
 
             // Find the I/O thread with minimum load.
             int minLoad = -1;
-            IOThread selectedIOThread = null;
+            IOThread? selectedIOThread = null;
 
             for (int i = 0; i != m_ioThreads.Count; i++)
             {
@@ -452,7 +450,7 @@ namespace NetMQ.Core
             lock (m_endpointsSync)
             {
 
-                if (!m_endpoints.TryGetValue(address, out Endpoint endpoint))
+                if (!m_endpoints.TryGetValue(address, out Endpoint? endpoint))
                     return false;
 
                 if (socket != endpoint.Socket)
@@ -490,8 +488,6 @@ namespace NetMQ.Core
         /// </remarks>
         public Endpoint FindEndpoint(string addr)
         {
-            Debug.Assert(addr != null);
-
             lock (m_endpointsSync)
             {
                 if (!m_endpoints.ContainsKey(addr))

--- a/src/NetMQ/Core/Ctx.cs
+++ b/src/NetMQ/Core/Ctx.cs
@@ -26,8 +26,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using JetBrains.Annotations;
-
 namespace NetMQ.Core
 {
     /// <summary>
@@ -54,7 +52,7 @@ namespace NetMQ.Core
             /// </summary>
             /// <param name="socket">the socket for this new Endpoint</param>
             /// <param name="options">the Options to assign to this new Endpoint</param>
-            public Endpoint([NotNull] SocketBase socket, [NotNull] Options options)
+            public Endpoint(SocketBase socket, Options options)
             {
                 Socket = socket;
                 Options = options;
@@ -63,13 +61,11 @@ namespace NetMQ.Core
             /// <summary>
             /// Get the socket associated with this Endpoint.
             /// </summary>
-            [NotNull]
             public SocketBase Socket { get; }
 
             /// <summary>
             /// Get the Options of this Endpoint.
             /// </summary>
-            [NotNull]
             public Options Options { get; }
         }
 
@@ -109,7 +105,7 @@ namespace NetMQ.Core
         /// <summary>
         /// The reaper thread.
         /// </summary>
-        [CanBeNull] private Reaper m_reaper;
+        private Reaper m_reaper;
 
         /// <summary>
         /// List of I/O threads.
@@ -124,7 +120,7 @@ namespace NetMQ.Core
         /// <summary>
         /// Array of pointers to mailboxes for both application and I/O threads.
         /// </summary>
-        [CanBeNull] private IMailbox[] m_slots;
+        private IMailbox[] m_slots;
 
         /// <summary>
         /// Mailbox for zmq_term thread.
@@ -265,7 +261,6 @@ namespace NetMQ.Core
         /// <exception cref="TerminatingException">Cannot create new socket while terminating.</exception>
         /// <exception cref="NetMQException">Maximum number of sockets reached.</exception>
         /// <exception cref="TerminatingException">The context (Ctx) must not be already terminating.</exception>
-        [NotNull]
         public SocketBase CreateSocket(ZmqSocketType type)
         {
             lock (m_slotSync)
@@ -359,7 +354,7 @@ namespace NetMQ.Core
         /// <remarks>
         /// If this was the last socket, then stop the reaper.
         /// </remarks>
-        public void DestroySocket([NotNull] SocketBase socket)
+        public void DestroySocket(SocketBase socket)
         {
             // Free the associated thread slot.
             lock (m_slotSync)
@@ -392,7 +387,7 @@ namespace NetMQ.Core
         /// <summary>
         /// Send a command to the given destination thread.
         /// </summary>
-        public void SendCommand(int threadId, [NotNull] Command command)
+        public void SendCommand(int threadId, Command command)
         {
             m_slots[threadId].Send(command);
         }
@@ -402,7 +397,6 @@ namespace NetMQ.Core
         /// </summary>
         /// <paramref name="affinity">Which threads are eligible (0 = all).</paramref>
         /// <returns>The least busy thread, or <c>null</c> if none is available.</returns>
-        [CanBeNull]
         public IOThread ChooseIOThread(long affinity)
         {
             if (m_ioThreads.Count == 0)
@@ -435,7 +429,7 @@ namespace NetMQ.Core
         /// <param name="address">the textual name to give this endpoint</param>
         /// <param name="endpoint">the Endpoint to remember</param>
         /// <returns>true if the given address was NOT already registered</returns>
-        public bool RegisterEndpoint([NotNull] string address, [NotNull] Endpoint endpoint)
+        public bool RegisterEndpoint(string address, Endpoint endpoint)
         {
             lock (m_endpointsSync)
             {
@@ -453,7 +447,7 @@ namespace NetMQ.Core
         /// <param name="address">the (string) address denoting the endpoint to unregister</param>
         /// <param name="socket">the socket associated with that endpoint</param>
         /// <returns>true if the endpoint having this address and socket is found, false otherwise</returns>
-        public bool UnregisterEndpoint([NotNull] string address, [NotNull] SocketBase socket)
+        public bool UnregisterEndpoint(string address, SocketBase socket)
         {
             lock (m_endpointsSync)
             {
@@ -473,7 +467,7 @@ namespace NetMQ.Core
         /// Remove from the list of endpoints, all endpoints that reference the given socket.
         /// </summary>
         /// <param name="socket">the socket to remove all references to</param>
-        public void UnregisterEndpoints([NotNull] SocketBase socket)
+        public void UnregisterEndpoints(SocketBase socket)
         {
             lock (m_endpointsSync)
             {
@@ -494,8 +488,7 @@ namespace NetMQ.Core
         /// By calling this method, the socket associated with that returned EndPoint has it's Seqnum incremented,
         /// in order to prevent it from being de-allocated before a command can be sent to it.
         /// </remarks>
-        [NotNull]
-        public Endpoint FindEndpoint([NotNull] string addr)
+        public Endpoint FindEndpoint(string addr)
         {
             Debug.Assert(addr != null);
 

--- a/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
@@ -24,8 +24,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using JetBrains.Annotations;
-
 namespace NetMQ.Core.Patterns.Utils
 {
     /// <summary>
@@ -40,7 +38,7 @@ namespace NetMQ.Core.Patterns.Utils
         private int m_liveNodes;
         private MultiTrie[] m_next;
 
-        public delegate void MultiTrieDelegate([CanBeNull] Pipe pipe, [CanBeNull] byte[] data, int size, [CanBeNull] object arg);
+        public delegate void MultiTrieDelegate(Pipe pipe, byte[] data, int size, object arg);
 
         public MultiTrie()
         {
@@ -56,12 +54,12 @@ namespace NetMQ.Core.Patterns.Utils
         /// Add key to the trie. Returns true if it's a new subscription
         /// rather than a duplicate.
         /// </summary>
-        public bool Add(Span<byte> prefix, [NotNull] Pipe pipe)
+        public bool Add(Span<byte> prefix, Pipe pipe)
         {
             return AddHelper(prefix, pipe);
         }
 
-        private bool AddHelper(Span<byte> prefix, [NotNull] Pipe pipe)
+        private bool AddHelper(Span<byte> prefix, Pipe pipe)
         {
             // We are at the node corresponding to the prefix. We are done.
             if (prefix.Length == 0)
@@ -147,12 +145,12 @@ namespace NetMQ.Core.Patterns.Utils
         /// <param name="func"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        public bool RemoveHelper([NotNull] Pipe pipe, [NotNull] MultiTrieDelegate func, [CanBeNull] object arg)
+        public bool RemoveHelper(Pipe pipe, MultiTrieDelegate func, object arg)
         {
             return RemoveHelper(pipe, [], 0, 0, func, arg);
         }
 
-        private bool RemoveHelper([NotNull] Pipe pipe, [NotNull] byte[] buffer, int bufferSize, int maxBufferSize, [NotNull] MultiTrieDelegate func, [CanBeNull] object arg)
+        private bool RemoveHelper(Pipe pipe, byte[] buffer, int bufferSize, int maxBufferSize, MultiTrieDelegate func, object arg)
         {
             // Remove the subscription from this node.
             if (m_pipes != null && m_pipes.Remove(pipe) && m_pipes.Count == 0)
@@ -284,12 +282,12 @@ namespace NetMQ.Core.Patterns.Utils
         /// <param name="prefix"></param>
         /// <param name="pipe"></param>
         /// <returns></returns>
-        public bool Remove(Span<byte> prefix, [NotNull] Pipe pipe)
+        public bool Remove(Span<byte> prefix, Pipe pipe)
         {
             return RemoveHelper(prefix, pipe);
         }
 
-        private bool RemoveHelper(Span<byte> prefix, [NotNull] Pipe pipe)
+        private bool RemoveHelper(Span<byte> prefix, Pipe pipe)
         {
             if (prefix.Length == 0)
             {
@@ -394,7 +392,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// <summary>
         /// Signal all the matching pipes.
         /// </summary>
-        public void Match(Span<byte> data, [NotNull] MultiTrieDelegate func, [CanBeNull] object arg)
+        public void Match(Span<byte> data, MultiTrieDelegate func, object arg)
         {
             MultiTrie current = this;
 

--- a/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/MultiTrie.cs
@@ -19,8 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -31,14 +29,14 @@ namespace NetMQ.Core.Patterns.Utils
     /// </summary>
     internal class MultiTrie
     {
-        private HashSet<Pipe> m_pipes;
+        private HashSet<Pipe>? m_pipes;
 
         private int m_minCharacter;
         private int m_count;
         private int m_liveNodes;
-        private MultiTrie[] m_next;
+        private MultiTrie?[]? m_next;
 
-        public delegate void MultiTrieDelegate(Pipe pipe, byte[] data, int size, object arg);
+        public delegate void MultiTrieDelegate(Pipe pipe, byte[]? data, int size, object? arg);
 
         public MultiTrie()
         {
@@ -73,8 +71,6 @@ namespace NetMQ.Core.Patterns.Utils
                 return result;
             }
 
-            Debug.Assert(prefix != null);
-
             byte currentCharacter = prefix[0];
 
             if (currentCharacter < m_minCharacter || currentCharacter >= m_minCharacter + m_count)
@@ -90,7 +86,7 @@ namespace NetMQ.Core.Patterns.Utils
                 else if (m_count == 1)
                 {
                     int oldc = m_minCharacter;
-                    MultiTrie oldp = m_next[0];
+                    MultiTrie? oldp = m_next![0];
                     m_count = (m_minCharacter < currentCharacter ? currentCharacter - m_minCharacter : m_minCharacter - currentCharacter) + 1;
                     m_next = new MultiTrie[m_count];
                     m_minCharacter = Math.Min(m_minCharacter, currentCharacter);
@@ -100,13 +96,13 @@ namespace NetMQ.Core.Patterns.Utils
                 {
                     // The new character is above the current character range.
                     m_count = currentCharacter - m_minCharacter + 1;
-                    m_next = m_next.Resize(m_count, true);
+                    m_next = m_next!.Resize(m_count, true);
                 }
                 else
                 {
                     // The new character is below the current character range.
                     m_count = (m_minCharacter + m_count) - currentCharacter;
-                    m_next = m_next.Resize(m_count, false);
+                    m_next = m_next!.Resize(m_count, false);
                     m_minCharacter = currentCharacter;
                 }
             }
@@ -121,17 +117,17 @@ namespace NetMQ.Core.Patterns.Utils
                     ++m_liveNodes;
                 }
 
-                return m_next[0].AddHelper(prefix.Slice(1), pipe);
+                return m_next[0]!.AddHelper(prefix.Slice(1), pipe);
             }
             else
             {
-                if (m_next[currentCharacter - m_minCharacter] == null)
+                if (m_next![currentCharacter - m_minCharacter] == null)
                 {
                     m_next[currentCharacter - m_minCharacter] = new MultiTrie();
                     ++m_liveNodes;
                 }
 
-                return m_next[currentCharacter - m_minCharacter].AddHelper(prefix.Slice(1), pipe);
+                return m_next[currentCharacter - m_minCharacter]!.AddHelper(prefix.Slice(1), pipe);
             }
         }
 
@@ -145,12 +141,12 @@ namespace NetMQ.Core.Patterns.Utils
         /// <param name="func"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        public bool RemoveHelper(Pipe pipe, MultiTrieDelegate func, object arg)
+        public bool RemoveHelper(Pipe pipe, MultiTrieDelegate func, object? arg)
         {
             return RemoveHelper(pipe, [], 0, 0, func, arg);
         }
 
-        private bool RemoveHelper(Pipe pipe, byte[] buffer, int bufferSize, int maxBufferSize, MultiTrieDelegate func, object arg)
+        private bool RemoveHelper(Pipe pipe, byte[] buffer, int bufferSize, int maxBufferSize, MultiTrieDelegate func, object? arg)
         {
             // Remove the subscription from this node.
             if (m_pipes != null && m_pipes.Remove(pipe) && m_pipes.Count == 0)
@@ -175,10 +171,10 @@ namespace NetMQ.Core.Patterns.Utils
             {
                 buffer[bufferSize] = (byte)m_minCharacter;
                 bufferSize++;
-                m_next[0].RemoveHelper(pipe, buffer, bufferSize, maxBufferSize, func, arg);
+                m_next![0]!.RemoveHelper(pipe, buffer, bufferSize, maxBufferSize, func, arg);
 
                 // Prune the node if it was made redundant by the removal
-                if (m_next[0].IsRedundant)
+                if (m_next[0]!.IsRedundant)
                 {
                     m_next = null;
                     m_count = 0;
@@ -199,13 +195,13 @@ namespace NetMQ.Core.Patterns.Utils
             for (int currentCharacter = 0; currentCharacter != m_count; currentCharacter++)
             {
                 buffer[bufferSize] = (byte)(m_minCharacter + currentCharacter);
-                if (m_next[currentCharacter] != null)
+                if (m_next![currentCharacter] != null)
                 {
-                    m_next[currentCharacter].RemoveHelper(pipe, buffer, bufferSize + 1,
+                    m_next[currentCharacter]!.RemoveHelper(pipe, buffer, bufferSize + 1,
                         maxBufferSize, func, arg);
 
                     // Prune redundant nodes from the mtrie
-                    if (m_next[currentCharacter].IsRedundant)
+                    if (m_next[currentCharacter]!.IsRedundant)
                     {
                         m_next[currentCharacter] = null;
 
@@ -247,12 +243,11 @@ namespace NetMQ.Core.Patterns.Utils
                 Debug.Assert(newMin == newMax);
                 Debug.Assert(newMin >= m_minCharacter && newMin < m_minCharacter + m_count);
 
-                MultiTrie node = m_next[newMin - m_minCharacter];
+                MultiTrie? node = m_next![newMin - m_minCharacter];
 
                 Debug.Assert(node != null);
 
-                m_next = null;
-                m_next = new[] { node };
+                m_next = [node];
                 m_count = 1;
                 m_minCharacter = newMin;
             }
@@ -260,7 +255,7 @@ namespace NetMQ.Core.Patterns.Utils
             {
                 Debug.Assert(newMax - newMin + 1 > 1);
 
-                MultiTrie[] oldTable = m_next;
+                MultiTrie?[] oldTable = m_next!;
                 Debug.Assert(newMin > m_minCharacter || newMax < m_minCharacter + m_count - 1);
                 Debug.Assert(newMin >= m_minCharacter);
                 Debug.Assert(newMax <= m_minCharacter + m_count - 1);
@@ -307,7 +302,7 @@ namespace NetMQ.Core.Patterns.Utils
             if (m_count == 0 || currentCharacter < m_minCharacter || currentCharacter >= m_minCharacter + m_count)
                 return false;
 
-            MultiTrie nextNode = m_count == 1 ? m_next[0] : m_next[currentCharacter - m_minCharacter];
+            MultiTrie? nextNode = m_count == 1 ? m_next![0] : m_next![currentCharacter - m_minCharacter];
 
             if (nextNode == null)
                 return false;
@@ -326,7 +321,7 @@ namespace NetMQ.Core.Patterns.Utils
                 }
                 else
                 {
-                    m_next[currentCharacter - m_minCharacter] = null;
+                    m_next![currentCharacter - m_minCharacter] = null;
                     Debug.Assert(m_liveNodes > 1);
                     --m_liveNodes;
 
@@ -348,8 +343,8 @@ namespace NetMQ.Core.Patterns.Utils
                         Debug.Assert(i < m_count);
                         m_minCharacter += i;
                         m_count = 1;
-                        MultiTrie old = m_next[i];
-                        m_next = new[] { old };
+                        MultiTrie? old = m_next[i];
+                        m_next = [old];
                     }
                     else if (currentCharacter == m_minCharacter)
                     {
@@ -392,7 +387,7 @@ namespace NetMQ.Core.Patterns.Utils
         /// <summary>
         /// Signal all the matching pipes.
         /// </summary>
-        public void Match(Span<byte> data, MultiTrieDelegate func, object arg)
+        public void Match(Span<byte> data, MultiTrieDelegate func, object? arg)
         {
             MultiTrie current = this;
 
@@ -422,7 +417,7 @@ namespace NetMQ.Core.Patterns.Utils
                 {
                     if (c != current.m_minCharacter)
                         break;
-                    current = current.m_next[0];
+                    current = current.m_next![0]!;
                     index++;
                     size--;
                     continue;
@@ -432,9 +427,9 @@ namespace NetMQ.Core.Patterns.Utils
                 if (c < current.m_minCharacter || c >=
                     current.m_minCharacter + current.m_count)
                     break;
-                if (current.m_next[c - current.m_minCharacter] == null)
+                if (current.m_next![c - current.m_minCharacter] == null)
                     break;
-                current = current.m_next[c - current.m_minCharacter];
+                current = current.m_next[c - current.m_minCharacter]!;
                 index++;
                 size--;
             }

--- a/src/NetMQ/Core/Patterns/Utils/Trie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/Trie.cs
@@ -24,8 +24,6 @@
 
 using System;
 using System.Diagnostics;
-using JetBrains.Annotations;
-
 namespace NetMQ.Core.Patterns.Utils
 {
     internal class Trie
@@ -36,7 +34,7 @@ namespace NetMQ.Core.Patterns.Utils
         private short m_count;
         private short m_liveNodes;
 
-        public delegate void TrieDelegate([NotNull] byte[] data, int size, [CanBeNull] object arg);
+        public delegate void TrieDelegate(byte[] data, int size, object arg);
 
         private Trie[] m_next;
 
@@ -272,12 +270,12 @@ namespace NetMQ.Core.Patterns.Utils
         }
 
         // Apply the function supplied to each subscription in the trie.
-        public void Apply([NotNull] TrieDelegate func, [CanBeNull] object arg)
+        public void Apply(TrieDelegate func, object arg)
         {
             ApplyHelper(null, 0, 0, func, arg);
         }
 
-        private void ApplyHelper([NotNull] byte[] buffer, int bufferSize, int maxBufferSize, [NotNull] TrieDelegate func, [CanBeNull] object arg)
+        private void ApplyHelper(byte[] buffer, int bufferSize, int maxBufferSize, TrieDelegate func, object arg)
         {
             // If this node is a subscription, apply the function.
             if (m_referenceCount > 0)

--- a/src/NetMQ/Core/Patterns/Utils/Trie.cs
+++ b/src/NetMQ/Core/Patterns/Utils/Trie.cs
@@ -20,8 +20,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 namespace NetMQ.Core.Patterns.Utils
@@ -34,9 +32,9 @@ namespace NetMQ.Core.Patterns.Utils
         private short m_count;
         private short m_liveNodes;
 
-        public delegate void TrieDelegate(byte[] data, int size, object arg);
+        public delegate void TrieDelegate(byte[]? data, int size, object? arg);
 
-        private Trie[] m_next;
+        private Trie?[]? m_next;
 
         /// <summary>
         /// Add key to the trie. Returns true if this is a new item in the trie
@@ -67,7 +65,7 @@ namespace NetMQ.Core.Patterns.Utils
                 else if (m_count == 1)
                 {
                     byte oldc = m_minCharacter;
-                    Trie oldp = m_next[0];
+                    Trie? oldp = m_next![0];
                     m_count = (short)((m_minCharacter < currentCharacter ? currentCharacter - m_minCharacter : m_minCharacter - currentCharacter) + 1);
                     m_next = new Trie[m_count];
                     m_minCharacter = Math.Min(m_minCharacter, currentCharacter);
@@ -77,13 +75,13 @@ namespace NetMQ.Core.Patterns.Utils
                 {
                     // The new character is above the current character range.
                     m_count = (short)(currentCharacter - m_minCharacter + 1);
-                    m_next = m_next.Resize(m_count, true);
+                    m_next = m_next!.Resize(m_count, true);
                 }
                 else
                 {
                     // The new character is below the current character range.
                     m_count = (short)((m_minCharacter + m_count) - currentCharacter);
-                    m_next = m_next.Resize(m_count, false);
+                    m_next = m_next!.Resize(m_count, false);
                     m_minCharacter = currentCharacter;
                 }
             }
@@ -98,17 +96,17 @@ namespace NetMQ.Core.Patterns.Utils
                     ++m_liveNodes;
                     //alloc_Debug.Assert(next.node);
                 }
-                return m_next[0].Add(prefix.Slice(1));
+                return m_next[0]!.Add(prefix.Slice(1));
             }
             else
             {
-                if (m_next[currentCharacter - m_minCharacter] == null)
+                if (m_next![currentCharacter - m_minCharacter] == null)
                 {
                     m_next[currentCharacter - m_minCharacter] = new Trie();
                     ++m_liveNodes;
                     //alloc_Debug.Assert(next.table [c - min]);
                 }
-                return m_next[currentCharacter - m_minCharacter].Add(prefix.Slice(1));
+                return m_next[currentCharacter - m_minCharacter]!.Add(prefix.Slice(1));
             }
         }
 
@@ -133,7 +131,7 @@ namespace NetMQ.Core.Patterns.Utils
             if (m_count == 0 || currentCharacter < m_minCharacter || currentCharacter >= m_minCharacter + m_count)
                 return false;
 
-            Trie nextNode = m_count == 1 ? m_next[0] : m_next[currentCharacter - m_minCharacter];
+            Trie? nextNode = m_count == 1 ? m_next![0] : m_next![currentCharacter - m_minCharacter];
 
             if (nextNode == null)
                 return false;
@@ -154,7 +152,7 @@ namespace NetMQ.Core.Patterns.Utils
                 }
                 else
                 {
-                    m_next[currentCharacter - m_minCharacter] = null;
+                    m_next![currentCharacter - m_minCharacter] = null;
                     Debug.Assert(m_liveNodes > 1);
                     --m_liveNodes;
 
@@ -164,7 +162,7 @@ namespace NetMQ.Core.Patterns.Utils
                         // If there's only one live node in the table we can
                         // switch to using the more compact single-node
                         // representation
-                        Trie node = null;
+                        Trie? node = null;
                         for (short i = 0; i < m_count; ++i)
                         {
                             if (m_next[i] != null)
@@ -177,8 +175,7 @@ namespace NetMQ.Core.Patterns.Utils
 
                         Debug.Assert(node != null);
 
-                        m_next = null;
-                        m_next = new[] { node };
+                        m_next = [node];
                         m_count = 1;
                     }
                     else if (currentCharacter == m_minCharacter)
@@ -256,13 +253,17 @@ namespace NetMQ.Core.Patterns.Utils
 
                 // Move to the next character.
                 if (current.m_count == 1)
-                    current = current.m_next[0];
+                {
+                    current = current.m_next![0]!;
+                }
                 else
                 {
-                    current = current.m_next[character - current.m_minCharacter];
+                    var next = current.m_next![character - current.m_minCharacter];
 
-                    if (current == null)
+                    if (next == null)
                         return false;
+
+                    current = next;
                 }
                 start++;
                 size--;
@@ -270,12 +271,12 @@ namespace NetMQ.Core.Patterns.Utils
         }
 
         // Apply the function supplied to each subscription in the trie.
-        public void Apply(TrieDelegate func, object arg)
+        public void Apply(TrieDelegate func, object? arg)
         {
             ApplyHelper(null, 0, 0, func, arg);
         }
 
-        private void ApplyHelper(byte[] buffer, int bufferSize, int maxBufferSize, TrieDelegate func, object arg)
+        private void ApplyHelper(byte[]? buffer, int bufferSize, int maxBufferSize, TrieDelegate func, object? arg)
         {
             // If this node is a subscription, apply the function.
             if (m_referenceCount > 0)
@@ -286,7 +287,6 @@ namespace NetMQ.Core.Patterns.Utils
             {
                 maxBufferSize = bufferSize + 256;
                 Array.Resize(ref buffer, maxBufferSize);
-                Debug.Assert(buffer != null);
             }
 
             // If there are no subnodes in the trie, return.
@@ -296,18 +296,18 @@ namespace NetMQ.Core.Patterns.Utils
             // If there's one subnode (optimisation).
             if (m_count == 1)
             {
-                buffer[bufferSize] = m_minCharacter;
+                buffer![bufferSize] = m_minCharacter;
                 bufferSize++;
-                m_next[0].ApplyHelper(buffer, bufferSize, maxBufferSize, func, arg);
+                m_next![0]!.ApplyHelper(buffer, bufferSize, maxBufferSize, func, arg);
                 return;
             }
 
             // If there are multiple subnodes.
             for (short c = 0; c != m_count; c++)
             {
-                buffer[bufferSize] = (byte)(m_minCharacter + c);
-                if (m_next[c] != null)
-                    m_next[c].ApplyHelper(buffer, bufferSize + 1, maxBufferSize, func, arg);
+                buffer![bufferSize] = (byte)(m_minCharacter + c);
+                if (m_next![c] != null)
+                    m_next[c]!.ApplyHelper(buffer, bufferSize + 1, maxBufferSize, func, arg);
             }
         }
 

--- a/src/NetMQ/Core/Patterns/XPub.cs
+++ b/src/NetMQ/Core/Patterns/XPub.cs
@@ -80,7 +80,7 @@ namespace NetMQ.Core.Patterns
         {
             s_markAsMatching = (pipe, data, size, arg) =>
             {
-                var self = (XPub)arg;
+                var self = (XPub)arg!;
                 // skip the sender of a broadcast message
                 if (!(self.m_broadcastEnabled && self.m_lastPipeIsBroadcast && self.m_lastPipe == pipe))
                 {
@@ -90,7 +90,7 @@ namespace NetMQ.Core.Patterns
 
             s_sendUnsubscription = (pipe, data, size, arg) =>
             {
-                var self = (XPub)arg;
+                var self = (XPub)arg!;
 
                 if (self.m_options.SocketType != ZmqSocketType.Pub)
                 {

--- a/src/NetMQ/Core/Patterns/XSub.cs
+++ b/src/NetMQ/Core/Patterns/XSub.cs
@@ -64,7 +64,7 @@ namespace NetMQ.Core.Patterns
         {
             s_sendSubscription = (data, size, arg) =>
             {
-                var pipe = (Pipe)arg;
+                var pipe = (Pipe)arg!;
 
                 // Create the subscription message.
                 var msg = new Msg();

--- a/src/NetMQ/Core/Transports/StreamEngine.cs
+++ b/src/NetMQ/Core/Transports/StreamEngine.cs
@@ -19,8 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -131,17 +129,16 @@ namespace NetMQ.Core.Transports
         // Position of the version field in the greeting.
         private const int VersionPos = 10;
 
-        //private IOObject io_object;
-        private AsyncSocket m_handle;
+        private AsyncSocket? m_handle;
 
-        private ByteArraySegment m_inpos;
+        private ByteArraySegment? m_inpos;
         private int m_insize;
-        private DecoderBase m_decoder;
+        private DecoderBase? m_decoder;
         private bool m_subscriptionRequired;
 
-        private ByteArraySegment m_outpos;
+        private ByteArraySegment? m_outpos;
         private int m_outsize;
-        private EncoderBase m_encoder;
+        private EncoderBase? m_encoder;
 
         // The receive buffer holding the greeting message
         // that we are receiving from the peer.
@@ -157,7 +154,7 @@ namespace NetMQ.Core.Transports
         private readonly ByteArraySegment m_greetingOutputBuffer = new byte[64];
 
         // The session this engine is attached to.
-        private SessionBase m_session;
+        private SessionBase? m_session;
 
         // Detached transient session.
         //private SessionBase leftover_session;
@@ -170,9 +167,9 @@ namespace NetMQ.Core.Transports
         private bool m_plugged;
 
         // Socket
-        private SocketBase m_socket;
+        private SocketBase? m_socket;
 
-        private IOObject m_ioObject;
+        private IOObject? m_ioObject;
 
         private SendState m_sendingState;
         private ReceiveState m_receivingState;
@@ -183,7 +180,7 @@ namespace NetMQ.Core.Transports
         private NextMsgDelegate m_nextMsg;
         private ProcessMsgDelegate m_processMsg;
         
-        private Mechanism m_mechanism;
+        private Mechanism? m_mechanism;
         private Msg m_pongMsg;
         
         // queue for actions that happen during the state machine
@@ -201,14 +198,9 @@ namespace NetMQ.Core.Transports
             m_sendingState = SendState.Idle;
             m_receivingState = ReceiveState.Idle;
             m_outsize = 0;
-            m_session = null;
             m_options = options;
             m_plugged = false;
             m_endpoint = endpoint;
-            m_socket = null;
-            m_encoder = null;
-            m_decoder = null;
-            m_mechanism = null;
             m_actionsQueue = new Queue<StateMachineAction>();
             m_subscriptionRequired = false;
             
@@ -229,11 +221,11 @@ namespace NetMQ.Core.Transports
             // Set the socket buffer limits for the underlying socket.
             if (m_options.SendBuffer != 0)
             {
-                m_handle.SendBufferSize = m_options.SendBuffer;
+                m_handle!.SendBufferSize = m_options.SendBuffer;
             }
             if (m_options.ReceiveBuffer != 0)
             {
-                m_handle.ReceiveBufferSize = m_options.ReceiveBuffer;
+                m_handle!.ReceiveBufferSize = m_options.ReceiveBuffer;
             }
         }
 
@@ -265,14 +257,14 @@ namespace NetMQ.Core.Transports
             Debug.Assert(m_session == null);
             Debug.Assert(session != null);
             m_session = session;
-            m_socket = m_session.Socket;
+            m_socket = m_session!.Socket;
 
             m_ioObject = new IOObject(null);
-            m_ioObject.SetHandler(this);
+            m_ioObject!.SetHandler(this);
 
             // Connect to I/O threads poller object.
-            m_ioObject.Plug(ioThread);
-            m_ioObject.AddSocket(m_handle);
+            m_ioObject!.Plug(ioThread);
+            m_ioObject!.AddSocket(m_handle!);
 
             FeedAction(Action.Start, SocketError.Success, 0);
         }
@@ -289,25 +281,25 @@ namespace NetMQ.Core.Transports
             m_plugged = false;
             
             if (m_hasTtlTimer) {
-                m_ioObject.CancelTimer(HeartbeatTtlTimerId);
+                m_ioObject!.CancelTimer(HeartbeatTtlTimerId);
                 m_hasTtlTimer = false;
             }
 
             if (m_hasTimeoutTimer) {
-                m_ioObject.CancelTimer(HeartbeatTimeoutTimerId);
+                m_ioObject!.CancelTimer(HeartbeatTimeoutTimerId);
                 m_hasTimeoutTimer = false;
             }
 
             if (m_hasHeartbeatTimer) {
-                m_ioObject.CancelTimer(HeartbeatIntervalTimerId);
+                m_ioObject!.CancelTimer(HeartbeatIntervalTimerId);
                 m_hasHeartbeatTimer = false;
             }
 
             // remove handle from proactor.
-            m_ioObject.RemoveSocket(m_handle);
+            m_ioObject!.RemoveSocket(m_handle!);
             
             // Disconnect from I/O threads poller object.
-            m_ioObject.Unplug();
+            m_ioObject!.Unplug();
 
             m_state = State.Closed;
 
@@ -319,9 +311,9 @@ namespace NetMQ.Core.Transports
         {
             Debug.Assert(m_session != null);
             m_state = State.Error;
-            m_socket.EventDisconnected(m_endpoint, m_handle);
-            m_session.Flush();
-            m_session.Detach(m_state != State.Handshaking && (m_mechanism is null || m_mechanism.Status != MechanismStatus.Handshaking) );
+            m_socket!.EventDisconnected(m_endpoint, m_handle!);
+            m_session!.Flush();
+            m_session!.Detach(m_state != State.Handshaking && (m_mechanism is null || m_mechanism!.Status != MechanismStatus.Handshaking) );
             Unplug();
             Destroy();
         }
@@ -356,8 +348,8 @@ namespace NetMQ.Core.Transports
                             {
                                 m_encoder = new RawEncoder(Config.OutBatchSize, m_options.Endian);
                                 m_decoder = new RawDecoder(Config.InBatchSize, m_options.MaxMessageSize, m_options.Endian);
-                                m_nextMsg = m_session.PullMsg;
-                                m_processMsg = m_session.PushMsg;
+                                m_nextMsg = m_session!.PullMsg;
+                                m_processMsg = m_session!.PushMsg;
                                     
                                 Activate();
                             }
@@ -387,11 +379,11 @@ namespace NetMQ.Core.Transports
                             // if we stuck let's continue, other than that nothing to do
                             if (m_receivingState == ReceiveState.Stuck)
                             {
-                                var pushResult = m_decoder.PushMsg(m_processMsg);
+                                var pushResult = m_decoder!.PushMsg(m_processMsg);
                                 if (pushResult == PushMsgResult.Ok)
                                 {
                                     m_receivingState = ReceiveState.Active;
-                                    m_session.Flush();
+                                    m_session!.Flush();
                                     ProcessInput();    
                                 }
                             }
@@ -408,7 +400,7 @@ namespace NetMQ.Core.Transports
                             }
                             else
                             {
-                                m_outpos.AdvanceOffset(bytesSent);
+                                m_outpos!.AdvanceOffset(bytesSent);
                                 m_outsize -= bytesSent;
 
                                 BeginSending();
@@ -435,18 +427,18 @@ namespace NetMQ.Core.Transports
             if (m_outsize == 0)
             {
                 m_outpos = null;
-                m_outsize = m_encoder.Encode(ref m_outpos, 0);
+                m_outsize = m_encoder!.Encode(ref m_outpos, 0);
                 
                 while (m_outsize < Config.OutBatchSize)
                 {
                     Msg msg = new Msg();
                     if (m_nextMsg(ref msg) != PullMsgResult.Ok)
                         break;
-                    m_encoder.LoadMsg(ref msg);
-                    ByteArraySegment buffer = null;
+                    m_encoder!.LoadMsg(ref msg);
+                    ByteArraySegment? buffer = null;
                     if (m_outpos != null)
                         buffer = m_outpos + m_outsize;
-                    var n = m_encoder.Encode(ref buffer, Config.OutBatchSize - m_outsize);
+                    var n = m_encoder!.Encode(ref buffer, Config.OutBatchSize - m_outsize);
                     if (m_outpos == null)
                         m_outpos = buffer;
                     m_outsize += n;
@@ -458,12 +450,12 @@ namespace NetMQ.Core.Transports
                 }
                 else
                 {
-                    BeginWrite(m_outpos, m_outsize);
+                    BeginWrite(m_outpos!, m_outsize);
                 }
             }
             else
             {
-                BeginWrite(m_outpos, m_outsize);
+                BeginWrite(m_outpos!, m_outsize);
             }
         }
 
@@ -490,7 +482,7 @@ namespace NetMQ.Core.Transports
 
                             m_handshakeState = HandshakeState.SendingGreeting;
 
-                            BeginWrite(m_outpos, m_outsize);
+                            BeginWrite(m_outpos!, m_outsize);
                             break;
                         default:
                             Debug.Assert(false);
@@ -509,12 +501,12 @@ namespace NetMQ.Core.Transports
                             }
                             else
                             {
-                                m_outpos.AdvanceOffset(bytesSent);
+                                m_outpos!.AdvanceOffset(bytesSent);
                                 m_outsize -= bytesSent;
 
                                 if (m_outsize > 0)
                                 {
-                                    BeginWrite(m_outpos, m_outsize);
+                                    BeginWrite(m_outpos!, m_outsize);
                                 }
                                 else
                                 {
@@ -565,7 +557,7 @@ namespace NetMQ.Core.Transports
                                     var tmp = new byte[10];
                                     var bufferp = new ByteArraySegment(tmp);
 
-                                    int bufferSize = m_encoder.Encode(ref bufferp, headerSize);
+                                    int bufferSize = m_encoder!.Encode(ref bufferp, headerSize);
                                     Debug.Assert(bufferSize == headerSize);
                                     
                                     // Make sure the decoder sees the data we have already received.
@@ -593,10 +585,10 @@ namespace NetMQ.Core.Transports
                                 {
                                     // The peer is using versioned protocol.
                                     // Send the rest of the greeting.
-                                    m_outpos[m_outsize++] = 3; // Protocol version
+                                    m_outpos![m_outsize++] = 3; // Protocol version
                                     m_handshakeState = HandshakeState.SendingMajorVersion;
                                     
-                                    BeginWrite(m_outpos, m_outsize);
+                                    BeginWrite(m_outpos!, m_outsize);
                                 }
                             }
                             break;
@@ -621,12 +613,12 @@ namespace NetMQ.Core.Transports
                             }
                             else
                             {
-                                m_outpos.AdvanceOffset(bytesSent);
+                                m_outpos!.AdvanceOffset(bytesSent);
                                 m_outsize -= bytesSent;
 
                                 if (m_outsize > 0)
                                 {
-                                    BeginWrite(m_outpos, m_outsize);
+                                    BeginWrite(m_outpos!, m_outsize);
                                 }
                                 else
                                 {
@@ -667,38 +659,38 @@ namespace NetMQ.Core.Transports
                                 }
                                 else if (m_greeting[VersionPos] == 0 || m_greeting[VersionPos] == 1)
                                 {
-                                    m_outpos[m_outsize++] = (byte)m_options.SocketType;
+                                    m_outpos![m_outsize++] = (byte)m_options.SocketType;
                                     m_handshakeState = HandshakeState.SendingSocketType;
                                     
-                                    BeginWrite(m_outpos, m_outsize);
+                                    BeginWrite(m_outpos!, m_outsize);
                                 }
                                 else
                                 {
-                                    m_outpos[m_outsize++] = 0; // Minor version
+                                    m_outpos![m_outsize++] = 0; // Minor version
                                             
                                     switch (m_options.Mechanism)
                                     {
                                         case MechanismType.Null:
-                                            m_outpos.PutBytes(NullMechanismBytes, m_outsize);
+                                            m_outpos!.PutBytes(NullMechanismBytes, m_outsize);
                                             m_outsize += 20;
                                             break;
                                         case MechanismType.Plain:
-                                            m_outpos.PutBytes(PlainMechanismBytes, m_outsize);
+                                            m_outpos!.PutBytes(PlainMechanismBytes, m_outsize);
                                             m_outsize += 20;
                                             break;
                                         case MechanismType.Curve:
-                                            m_outpos.PutBytes(CurveMechanismBytes, m_outsize);
+                                            m_outpos!.PutBytes(CurveMechanismBytes, m_outsize);
                                             m_outsize += 20;
                                             break;
                                         default:
                                             throw new ArgumentOutOfRangeException();
                                     }
                                     
-                                    m_outpos.Fill(0, m_outsize, 32);
+                                    m_outpos!.Fill(0, m_outsize, 32);
                                     m_outsize += 32;
                                             
                                     m_handshakeState = HandshakeState.SendingV3Greeting;
-                                    BeginWrite(m_outpos, m_outsize);
+                                    BeginWrite(m_outpos!, m_outsize);
                                 }
                             }
                             break;
@@ -723,12 +715,12 @@ namespace NetMQ.Core.Transports
                             }
                             else
                             {
-                                m_outpos.AdvanceOffset(bytesSent);
+                                m_outpos!.AdvanceOffset(bytesSent);
                                 m_outsize -= bytesSent;
 
                                 if (m_outsize > 0)
                                 {
-                                    BeginWrite(m_outpos, m_outsize);
+                                    BeginWrite(m_outpos!, m_outsize);
                                 }
                                 else
                                 {
@@ -836,12 +828,12 @@ namespace NetMQ.Core.Transports
                             }
                             else
                             {
-                                m_outpos.AdvanceOffset(bytesSent);
+                                m_outpos!.AdvanceOffset(bytesSent);
                                 m_outsize -= bytesSent;
 
                                 if (m_outsize > 0)
                                 {
-                                    BeginWrite(m_outpos, m_outsize);
+                                    BeginWrite(m_outpos!, m_outsize);
                                 }
                                 else
                                 {
@@ -886,7 +878,7 @@ namespace NetMQ.Core.Transports
                                     
                                     if (m_options.Mechanism == MechanismType.Null
                                         && ByteArrayUtility.AreEqual(m_greeting, 12, NullMechanismBytes, 0, 20))
-                                        m_mechanism = new NullMechanism(m_session, m_options);
+                                        m_mechanism = new NullMechanism(m_session!, m_options);
                                     else if (m_options.Mechanism == MechanismType.Plain
                                              && ByteArrayUtility.AreEqual(m_greeting, 12, PlainMechanismBytes, 0, 20))
                                     {
@@ -897,9 +889,9 @@ namespace NetMQ.Core.Transports
                                              && ByteArrayUtility.AreEqual(m_greeting, 12, CurveMechanismBytes, 0, 20))
                                     {
                                         if (m_options.AsServer)
-                                            m_mechanism = new CurveServerMechanism(m_session, m_options);
+                                            m_mechanism = new CurveServerMechanism(m_session!, m_options);
                                         else
-                                            m_mechanism = new CurveClientMechanism(m_session, m_options);
+                                            m_mechanism = new CurveClientMechanism(m_session!, m_options);
                                     }
                                     else {
                                         // Unsupported mechanism
@@ -944,8 +936,8 @@ namespace NetMQ.Core.Transports
 
             if (m_insize == 0)
             {
-                m_decoder.GetBuffer(out m_inpos, out m_insize);
-                BeginRead(m_inpos, m_insize);
+                m_decoder!.GetBuffer(out m_inpos, out m_insize);
+                BeginRead(m_inpos!, m_insize);
             }
             else
             {
@@ -964,8 +956,8 @@ namespace NetMQ.Core.Transports
             
             while (m_insize > 0)
             {
-                var result = m_decoder.Decode(m_inpos, m_insize, out var processed);
-                m_inpos.AdvanceOffset(processed);
+                var result = m_decoder!.Decode(m_inpos!, m_insize, out var processed);
+                m_inpos!.AdvanceOffset(processed);
                 m_insize -= processed;
 
                 if (result == DecodeResult.Error)
@@ -977,11 +969,11 @@ namespace NetMQ.Core.Transports
                 if (result == DecodeResult.Processing)
                     break;
 
-                var pushResult = m_decoder.PushMsg(m_processMsg);
+                var pushResult = m_decoder!.PushMsg(m_processMsg);
                 if (pushResult == PushMsgResult.Full)
                 {
                     m_receivingState = ReceiveState.Stuck;
-                    m_session.Flush();
+                    m_session!.Flush();
                     return;
                 }
                 else if (pushResult == PushMsgResult.Error)
@@ -991,9 +983,9 @@ namespace NetMQ.Core.Transports
                 }
             }
 
-            m_session.Flush();
-            m_decoder.GetBuffer(out m_inpos, out m_insize);
-            BeginRead(m_inpos, m_insize);
+            m_session!.Flush();
+            m_decoder!.GetBuffer(out m_inpos, out m_insize);
+            BeginRead(m_inpos!, m_insize);
         }
 
         /// <summary>
@@ -1058,7 +1050,7 @@ namespace NetMQ.Core.Transports
         {
             try
             {
-                m_handle.Send((byte[])data, data.Offset, size, SocketFlags.None);
+                m_handle!.Send((byte[])data, data.Offset, size, SocketFlags.None);
             }
             catch (SocketException ex)
             {
@@ -1098,7 +1090,7 @@ namespace NetMQ.Core.Transports
         {
             try
             {
-                m_handle.Receive((byte[])data, data.Offset, size, SocketFlags.None);
+                m_handle!.Receive((byte[])data, data.Offset, size, SocketFlags.None);
             }
             catch (SocketException ex)
             {
@@ -1116,7 +1108,7 @@ namespace NetMQ.Core.Transports
                 msg.Put(m_options.Identity, 0, m_options.IdentitySize);
             }
             
-            m_nextMsg = m_session.PullMsg;
+            m_nextMsg = m_session!.PullMsg;
             return PullMsgResult.Ok;
         }
 
@@ -1125,7 +1117,7 @@ namespace NetMQ.Core.Transports
             if (m_options.RecvIdentity) 
             {
                 msg.SetFlags(MsgFlags.Identity);
-                m_session.PushMsg(ref msg);
+                m_session!.PushMsg(ref msg);
             } 
             else 
             {
@@ -1139,27 +1131,27 @@ namespace NetMQ.Core.Transports
                 subscription.InitPool(1);
                 subscription.Put((byte)1);
                 
-                m_session.PushMsg(ref subscription);
+                m_session!.PushMsg(ref subscription);
             }
             
-            m_processMsg = m_session.PushMsg;
+            m_processMsg = m_session!.PushMsg;
             return PushMsgResult.Ok;
         }
 
         PullMsgResult NextHandshakeCommand (ref Msg msg)
         {
-            if (m_mechanism.Status == MechanismStatus.Ready) 
+            if (m_mechanism!.Status == MechanismStatus.Ready) 
             {
                 MechanismReady();
                 return PullAndEncode (ref msg);
             }
-            else if (m_mechanism.Status == MechanismStatus.Error) 
+            else if (m_mechanism!.Status == MechanismStatus.Error) 
             {
                 return PullMsgResult.Error;
             } 
             else 
             {
-                var result = m_mechanism.NextHandshakeCommand(ref msg);
+                var result = m_mechanism!.NextHandshakeCommand(ref msg);
 
                 if (result == PullMsgResult.Ok)
                     msg.SetFlags(MsgFlags.Command);
@@ -1170,12 +1162,12 @@ namespace NetMQ.Core.Transports
 
         PushMsgResult ProcessHandshakeCommand (ref Msg msg)
         {
-            var result = m_mechanism.ProcessHandshakeCommand(ref msg);
+            var result = m_mechanism!.ProcessHandshakeCommand(ref msg);
             if (result == PushMsgResult.Ok) 
             {
-                if (m_mechanism.Status == MechanismStatus.Ready)
+                if (m_mechanism!.Status == MechanismStatus.Ready)
                     MechanismReady();
-                else if (m_mechanism.Status == MechanismStatus.Error)
+                else if (m_mechanism!.Status == MechanismStatus.Error)
                     return PushMsgResult.Error;
                 
                 if (m_sendingState == SendState.Idle)
@@ -1193,13 +1185,13 @@ namespace NetMQ.Core.Transports
         {
             if (m_options.HeartbeatInterval > 0)
             {
-                m_ioObject.AddTimer(m_options.HeartbeatInterval, HeartbeatIntervalTimerId);
+                m_ioObject!.AddTimer(m_options.HeartbeatInterval, HeartbeatIntervalTimerId);
                 m_hasHeartbeatTimer = true;
             }
             
             if (m_options.RecvIdentity) {
                 Msg identity = new Msg();
-                byte[]? peerIdentity = m_mechanism.PeerIdentity;
+                byte[]? peerIdentity = m_mechanism!.PeerIdentity;
                 if (peerIdentity is null)
                     identity.InitEmpty();
                 else
@@ -1207,7 +1199,7 @@ namespace NetMQ.Core.Transports
                     identity.InitPool(peerIdentity.Length);
                     identity.Put(peerIdentity, 0, peerIdentity.Length);
                 }
-                var pushResult = m_session.PushMsg(ref identity);
+                var pushResult = m_session!.PushMsg(ref identity);
                 if (pushResult == PushMsgResult.Full) {
                     // If the write is failing at this stage with
                     // an EAGAIN the pipe must be being shut down,
@@ -1215,7 +1207,7 @@ namespace NetMQ.Core.Transports
                     return;
                 }
                 
-                m_session.Flush();
+                m_session!.Flush();
             }
 
             m_nextMsg = PullAndEncode;
@@ -1225,33 +1217,33 @@ namespace NetMQ.Core.Transports
         
         PullMsgResult PullAndEncode (ref Msg msg)
         {
-            var result = m_session.PullMsg(ref msg); 
+            var result = m_session!.PullMsg(ref msg); 
             if (result != PullMsgResult.Ok)
                 return result;
 
-            return m_mechanism.Encode(ref msg);
+            return m_mechanism!.Encode(ref msg);
         }
 
         PushMsgResult DecodeAndPush (ref Msg msg)
         {
-            var result = m_mechanism.Decode(ref msg);
+            var result = m_mechanism!.Decode(ref msg);
             if (result != PushMsgResult.Ok)
                 return result;
             
             if (m_hasTimeoutTimer) {
                 m_hasTimeoutTimer = false;
-                m_ioObject.CancelTimer(HeartbeatTimeoutTimerId);
+                m_ioObject!.CancelTimer(HeartbeatTimeoutTimerId);
             }
             
             if (m_hasTtlTimer) {
                 m_hasTtlTimer = false;
-                m_ioObject.CancelTimer(HeartbeatTtlTimerId);
+                m_ioObject!.CancelTimer(HeartbeatTtlTimerId);
             }
             
             if (msg.HasCommand)
                 ProcessCommandMessage(ref msg);
 
-            result = m_session.PushMsg(ref msg);
+            result = m_session!.PushMsg(ref msg);
             if (result == PushMsgResult.Full) 
                 m_processMsg = PushOneThenDecodeAndPush;
                 
@@ -1260,7 +1252,7 @@ namespace NetMQ.Core.Transports
         
         PushMsgResult PushOneThenDecodeAndPush (ref Msg msg)
         {
-            var result = m_session.PushMsg(ref msg);
+            var result = m_session!.PushMsg(ref msg);
             if (result == PushMsgResult.Ok)
                 m_processMsg = DecodeAndPush;
             return result;
@@ -1280,12 +1272,12 @@ namespace NetMQ.Core.Transports
             
             NetworkOrderBitsConverter.PutUInt16((ushort)m_options.HeartbeatTtl, msg, 1 + V3Protocol.PingCommand.Length);
 
-            var result = m_mechanism.Encode(ref msg);
+            var result = m_mechanism!.Encode(ref msg);
             m_nextMsg = PullAndEncode;
             
             if (!m_hasTimeoutTimer && m_heartbeatTimeout > 0) 
             {
-                m_ioObject.AddTimer(m_heartbeatTimeout, HeartbeatTimeoutTimerId);
+                m_ioObject!.AddTimer(m_heartbeatTimeout, HeartbeatTimeoutTimerId);
                 m_hasTimeoutTimer = true;
             }
             
@@ -1296,7 +1288,7 @@ namespace NetMQ.Core.Transports
         {
             msg.Move(ref m_pongMsg);
             m_nextMsg = PullAndEncode;
-            return m_mechanism.Encode(ref msg);
+            return m_mechanism!.Encode(ref msg);
         }
         
         void ProcessCommandMessage (ref Msg msg)
@@ -1328,7 +1320,7 @@ namespace NetMQ.Core.Transports
             remoteHeartbeatTtl *= 100;
 
             if (!m_hasTtlTimer && remoteHeartbeatTtl > 0) {
-                m_ioObject.AddTimer(remoteHeartbeatTtl, HeartbeatTtlTimerId);
+                m_ioObject!.AddTimer(remoteHeartbeatTtl, HeartbeatTtlTimerId);
                 m_hasTtlTimer = true;
             }
             
@@ -1371,7 +1363,7 @@ namespace NetMQ.Core.Transports
                     BeginSending();
                 }
                 
-                m_ioObject.AddTimer(m_options.HeartbeatInterval, HeartbeatIntervalTimerId);
+                m_ioObject!.AddTimer(m_options.HeartbeatInterval, HeartbeatIntervalTimerId);
             } 
             else if (id == HeartbeatTtlTimerId) 
             {

--- a/src/NetMQ/Core/Transports/StreamEngine.cs
+++ b/src/NetMQ/Core/Transports/StreamEngine.cs
@@ -27,7 +27,6 @@ using System.Diagnostics;
 using System.Net.Sockets;
 using System.Text;
 using AsyncIO;
-using JetBrains.Annotations;
 using NetMQ.Core.Mechanisms;
 using NetMQ.Core.Utils;
 
@@ -1055,7 +1054,7 @@ namespace NetMQ.Core.Transports
             throw NetMQException.Create(socketError);
         }
 
-        private void BeginWrite([NotNull] ByteArraySegment data, int size)
+        private void BeginWrite(ByteArraySegment data, int size)
         {
             try
             {
@@ -1095,7 +1094,7 @@ namespace NetMQ.Core.Transports
             throw NetMQException.Create(socketError);
         }
 
-        private void BeginRead([NotNull] ByteArraySegment data, int size)
+        private void BeginRead(ByteArraySegment data, int size)
         {
             try
             {

--- a/src/NetMQ/Core/Utils/YQueue.cs
+++ b/src/NetMQ/Core/Utils/YQueue.cs
@@ -19,8 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 namespace NetMQ.Core.Utils
@@ -49,7 +47,6 @@ namespace NetMQ.Core.Utils
             {
                 Values = new T[size];
                 GlobalOffset = globalIndex;
-                Debug.Assert(Values != null);
             }
 
             public T[] Values { get; }
@@ -58,10 +55,10 @@ namespace NetMQ.Core.Utils
             public int GlobalOffset { get; }
 
             /// <summary>Optional link to the previous <see cref="Chunk"/>.</summary>
-            public Chunk Previous { get; set; }
+            public Chunk? Previous { get; set; }
 
             /// <summary>Optional link to the next <see cref="Chunk"/>.</summary>
-            public Chunk Next { get; set; }
+            public Chunk? Next { get; set; }
         }
 
         #endregion
@@ -122,12 +119,12 @@ namespace NetMQ.Core.Utils
         public T Pop()
         {
             T value = m_beginChunk.Values[m_beginPositionInChunk];
-            m_beginChunk.Values[m_beginPositionInChunk] = default(T);
+            m_beginChunk.Values[m_beginPositionInChunk] = default!;
 
             m_beginPositionInChunk++;
             if (m_beginPositionInChunk == m_chunkSize)
             {
-                m_beginChunk = m_beginChunk.Next;
+                m_beginChunk = m_beginChunk.Next!;
                 m_beginChunk.Previous = null;
                 m_beginPositionInChunk = 0;
             }
@@ -149,7 +146,7 @@ namespace NetMQ.Core.Utils
             Chunk sc = m_spareChunk;
             if (sc != m_beginChunk)
             {
-                m_spareChunk = m_spareChunk.Next;
+                m_spareChunk = m_spareChunk.Next!;
                 m_endChunk.Next = sc;
                 sc.Previous = m_endChunk;
             }
@@ -159,7 +156,7 @@ namespace NetMQ.Core.Utils
                 m_nextGlobalIndex += m_chunkSize;
                 m_endChunk.Next.Previous = m_endChunk;
             }
-            m_endChunk = m_endChunk.Next;
+            m_endChunk = m_endChunk.Next!;
             m_endPosition = 0;
         }
 
@@ -178,7 +175,7 @@ namespace NetMQ.Core.Utils
             else
             {
                 m_backPositionInChunk = m_chunkSize - 1;
-                m_backChunk = m_backChunk.Previous;
+                m_backChunk = m_backChunk.Previous!;
             }
 
             // Now, move 'end' position backwards. Note that obsolete end chunk
@@ -192,13 +189,13 @@ namespace NetMQ.Core.Utils
             else
             {
                 m_endPosition = m_chunkSize - 1;
-                m_endChunk = m_endChunk.Previous;
+                m_endChunk = m_endChunk.Previous!;
                 m_endChunk.Next = null;
             }
 
             // Capturing and removing the unpushed value from chunk.
             T value = m_backChunk.Values[m_backPositionInChunk];
-            m_backChunk.Values[m_backPositionInChunk] = default(T);
+            m_backChunk.Values[m_backPositionInChunk] = default!;
 
             return value;
         }

--- a/src/NetMQ/Core/Utils/YQueue.cs
+++ b/src/NetMQ/Core/Utils/YQueue.cs
@@ -23,8 +23,6 @@
 
 using System;
 using System.Diagnostics;
-using JetBrains.Annotations;
-
 namespace NetMQ.Core.Utils
 {
     /// <summary>A FIFO queue.</summary>
@@ -54,18 +52,15 @@ namespace NetMQ.Core.Utils
                 Debug.Assert(Values != null);
             }
 
-            [NotNull]
             public T[] Values { get; }
 
             /// <summary>Contains global index positions of elements in the chunk.</summary>
             public int GlobalOffset { get; }
 
             /// <summary>Optional link to the previous <see cref="Chunk"/>.</summary>
-            [CanBeNull]
             public Chunk Previous { get; set; }
 
             /// <summary>Optional link to the next <see cref="Chunk"/>.</summary>
-            [CanBeNull]
             public Chunk Next { get; set; }
         }
 

--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -60,7 +60,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 </Project>

--- a/src/Performance/NetMQ.SimpleTests/NetMQ.SimpleTests.csproj
+++ b/src/Performance/NetMQ.SimpleTests/NetMQ.SimpleTests.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 

--- a/src/Performance/local_lat/local_lat.csproj
+++ b/src/Performance/local_lat/local_lat.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 

--- a/src/Performance/local_thr/local_thr.csproj
+++ b/src/Performance/local_thr/local_thr.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 

--- a/src/Performance/remote_lat/remote_lat.csproj
+++ b/src/Performance/remote_lat/remote_lat.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 

--- a/src/Performance/remote_thr/remote_thr.csproj
+++ b/src/Performance/remote_thr/remote_thr.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
 


### PR DESCRIPTION
This gets all the code null annotated. There are several places where the design makes it hard to avoid null forgiveness operators, so they have been added where needed. In future we may pay those off.

Motivated by the error reported in #1159 and fixed in #1160.