### PR TITLE
Handle SocketException while configuring an accepted socket in TcpListener

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,6 +12,7 @@ Contributors
 * Ilya Loginov &mdash; [@iloginov](https://github.com/iloginov)
 * James Hurst &mdash; [@JamesWhurst](https://github.com/JamesWhurst)
 * Jay Shelton &mdash; [@jayshelton](https://github.com/jayshelton)
+* Jonas Follesø &mdash; [@follesoe](https://github.com/follesoe)
 * Miguel Angel Jimenez &mdash; [@majimenezp](https://github.com/majimenezp)
 * Nicolas Dextraze &mdash; [@ndextraze-pbp](https://github.com/ndextraze-pbp)
 * Peter H. Merkel &mdash; [@mph911](https://github.com/mph911)

--- a/src/NetMQ.Tests/TcpListenerTests.cs
+++ b/src/NetMQ.Tests/TcpListenerTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using NetMQ.Sockets;
+using Xunit;
+
+namespace NetMQ.Tests
+{
+    public class TcpListenerTests : IClassFixture<CleanupAfterFixture>
+    {
+        public TcpListenerTests() => NetMQConfig.Cleanup();
+
+        [Fact]
+        public void AcceptedSocketFailingSetupDoesNotCrashProcessOrStopListener()
+        {
+            using (var pub = new PublisherSocket())
+            {
+                int port = pub.BindRandomPort("tcp://127.0.0.1");
+
+                // Hammer the listener with connections that are reset immediately:
+                // SO_LINGER=0 + Close sends RST, which can land between the proactor
+                // completing an accept and TcpListener applying socket options to the
+                // accepted socket. On macOS the option calls then throw
+                // SocketException (EINVAL). Unhandled, that exception killed the
+                // proactor thread and with it the process; swallowed carelessly, it
+                // skips the re-arming Accept() and the listener goes deaf instead.
+                for (int i = 0; i < 400; i++)
+                {
+                    using (var raw = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                    {
+                        raw.LingerState = new LingerOption(true, 0);
+                        try
+                        {
+                            raw.Connect(IPAddress.Loopback, port);
+                        }
+                        catch (SocketException)
+                        {
+                        }
+                    }
+                }
+
+                // The listener must still be alive and accepting: a subscriber that
+                // connects after the storm must complete the handshake and receive.
+                using (var sub = new SubscriberSocket())
+                {
+                    sub.Connect("tcp://127.0.0.1:" + port);
+                    sub.SubscribeToAnyTopic();
+
+                    var received = false;
+                    for (int i = 0; i < 100 && !received; i++)
+                    {
+                        pub.SendFrame("hello");
+                        received = sub.TryReceiveFrameString(TimeSpan.FromMilliseconds(100), out string? _);
+                    }
+
+                    Assert.True(received, "Listener stopped accepting connections after a flood of immediately-reset connects");
+                }
+            }
+        }
+    }
+}

--- a/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
+++ b/src/NetMQ/Core/Transports/Tcp/TcpListener.cs
@@ -199,11 +199,14 @@ namespace NetMQ.Core.Transports.Tcp
                     // TODO: check TcpFilters
                     var acceptedSocket = m_handle.GetAcceptedSocket();
 
+                    StreamEngine engine;
+                    try
+                    {
                         acceptedSocket.NoDelay = true;
 
-                    if (m_options.TcpKeepalive != -1)
-                    {
-                        acceptedSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, m_options.TcpKeepalive);
+                        if (m_options.TcpKeepalive != -1)
+                        {
+                            acceptedSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, m_options.TcpKeepalive);
 #if NET
                             if (m_options.TcpKeepaliveIdle != -1)
                                 acceptedSocket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, m_options.TcpKeepaliveIdle / 1000);
@@ -213,24 +216,54 @@ namespace NetMQ.Core.Transports.Tcp
                                 acceptedSocket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, m_options.TcpKeepaliveCnt);
 #else
 
-                        if (m_options.TcpKeepaliveIdle != -1 && m_options.TcpKeepaliveIntvl != -1)
-                        {
-                            var bytes = new ByteArraySegment(new byte[12]);
+                            if (m_options.TcpKeepaliveIdle != -1 && m_options.TcpKeepaliveIntvl != -1)
+                            {
+                                var bytes = new ByteArraySegment(new byte[12]);
 
-                            Endianness endian = BitConverter.IsLittleEndian ? Endianness.Little : Endianness.Big;
+                                Endianness endian = BitConverter.IsLittleEndian ? Endianness.Little : Endianness.Big;
 
-                            bytes.PutInteger(endian, m_options.TcpKeepalive, 0);
-                            bytes.PutInteger(endian, m_options.TcpKeepaliveIdle, 4);
-                            bytes.PutInteger(endian, m_options.TcpKeepaliveIntvl, 8);
+                                bytes.PutInteger(endian, m_options.TcpKeepalive, 0);
+                                bytes.PutInteger(endian, m_options.TcpKeepaliveIdle, 4);
+                                bytes.PutInteger(endian, m_options.TcpKeepaliveIntvl, 8);
 
 
-                            acceptedSocket.IOControl(IOControlCode.KeepAliveValues, (byte[])bytes, null);
-                        }
+                                acceptedSocket.IOControl(IOControlCode.KeepAliveValues, (byte[])bytes, null);
+                            }
 #endif
-                    }
+                        }
 
-                    // Create the engine object for this connection.
-                    var engine = new StreamEngine(acceptedSocket, m_options, m_endpoint);
+                        // Create the engine object for this connection. The engine
+                        // constructor also touches the socket (send/receive buffer
+                        // sizes), so it shares the failure window below.
+                        engine = new StreamEngine(acceptedSocket, m_options, m_endpoint);
+                    }
+                    catch (SocketException ex)
+                    {
+                        // The peer can reset the connection between the accept
+                        // completing and the socket options above being applied; the
+                        // accepted socket is then already dead and the option calls
+                        // throw (EINVAL/InvalidArgument on macOS and Linux). Without
+                        // this catch the exception escapes on the proactor thread and
+                        // terminates the process. Treat it as a failed accept, as
+                        // libzmq does: drop the socket and keep listening. The raw
+                        // SocketError is deliberately not passed through ToErrorCode,
+                        // which Debug.Asserts on unmapped values; ConnectionReset is
+                        // the effective outcome whatever the exact reported code.
+                        Debug.WriteLine($"TcpListener dropping accepted socket that failed setup: {ex.SocketErrorCode}");
+
+                        try
+                        {
+                            acceptedSocket.Dispose();
+                        }
+                        catch (SocketException)
+                        {
+                        }
+
+                        m_socket.EventAcceptFailed(m_endpoint, ErrorCode.ConnectionReset);
+
+                        Accept();
+                        break;
+                    }
 
                     // Choose I/O thread to run connector in. Given that we are already
                     // running in an I/O thread, there must be at least one available.


### PR DESCRIPTION
## Problem

A TCP peer that connects and immediately resets the connection can kill the whole process. When the RST lands between the proactor completing an accept and `TcpListener.InCompleted` applying socket options to the accepted socket, the option calls throw — on macOS as `SocketException (22): Invalid argument` from `acceptedSocket.NoDelay = true`:

```
Unhandled exception. System.Net.Sockets.SocketException (22): Invalid argument
   at AsyncIO.AsyncSocket.set_NoDelay(Boolean value)
   at NetMQ.Core.Transports.Tcp.TcpListener.InCompleted(SocketError socketError, Int32 bytesTransferred)
   at NetMQ.Core.IOObject.InCompleted(SocketError socketError, Int32 bytesTransferred)
   at NetMQ.Core.Utils.Proactor.Loop()
```

`InCompleted` runs on the proactor thread, where nothing catches the exception, so it terminates the process. Any bound socket is exposed to this through a flapping or rapidly reconnecting client — a test suite that hammers connect/disconnect against a bound PUB socket crashed its test host roughly 1 run in 10 on macOS arm64.

This is the accept-side sibling of #1161, which handled the same macOS `EINVAL` behaviour for outbound sockets in `TcpConnector`.

## Solution

Treat a failure to set up the accepted socket as a failed accept, the way libzmq's `tcp_listener` treats `tune_socket` failure: dispose the accepted socket, raise `EventAcceptFailed`, and keep accepting. The guarded region also covers the `StreamEngine` construction, whose constructor touches the socket too (send/receive buffer sizes) and shares the same failure window.

Two deliberate choices, called out for review:

- The catch is `SocketException` broadly, not #1161's `when (SocketErrorCode == InvalidArgument)` filter. On the connector path the socket is kept afterwards, so that filter must be narrow; here the socket is being dropped on any setup failure, and a peer-reset socket does not necessarily fail with `EINVAL` on every OS. Dropping is also safe for a hypothetically healthy socket — the peer's reconnect logic recovers — whereas an escaped exception is fatal.
- `EventAcceptFailed` reports `ErrorCode.ConnectionReset` instead of mapping the caught `SocketErrorCode` through `ToErrorCode()`, because `ToErrorCode` hits `Debug.Assert(false)` on unmapped values — an assertion failure inside crash recovery would defeat the purpose. Connection reset is the effective outcome regardless of the exact errno.

## Proof

The new regression test floods a bound `PublisherSocket` with 400 raw TCP connects that reset immediately (`SO_LINGER=0` + close), then asserts the listener still accepts and serves a real subscriber. On macOS arm64 (.NET 10):

- Without the fix: **12/12 runs crash the test host** with the exact exception above.
- With the fix: **12/12 runs pass** in ~170 ms.

The liveness assertion keeps the test meaningful on platforms that never throw here, and would also catch the alternative failure mode where the exception is swallowed without re-arming `Accept()`, which leaves the listener permanently deaf.

The full NetMQ.Tests suite passes locally on net10.0 (267 passed, 4 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
