### PR TITLE
Update System.Security.Cryptography.Xml patch version 10.0.6 => 10.0.10

### DIFF
--- a/src/NetMQ/NetMQ.csproj
+++ b/src/NetMQ/NetMQ.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
     <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">


### PR DESCRIPTION
Fixes #1166

### Problem
Current version of System.Security.Cryptography.Xml is vulnerable. MS have a patch that fixes this.

### Solution
Bump version of System.Security.Cryptography.Xml from 10.0.6 to 10.0.10

### Note
I noticed several pre-existing test failures exist in the current master branch unrelated to this change:

•	V2Encoder null assertion crash in Proactor thread causes NetMQConfig.Cleanup() to hang, blocking subsequent tests
•	SimpleReqRepWithRelaxedSucceeds hangs due to unread SendFrame
•	MonitorDisposeProperlyWhenDisposedAfterMonitoredTcpSocket demonstrates an unresolved monitor disposal bug

It is possible that these test failures are the result of our IT setup or possibly existing failures on master branch? I can't see how they would be related to this simple patch update.